### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We currently support three models of radios.
 
 - US/JP/AU/NZ - 915MHz
 - CN - 470MHz
-- EU - 870MHz
+- EU - 868MHz, 433MHz
 
 Getting a version that includes a screen is optional, but highly recommended.
 


### PR DESCRIPTION
https://www.everythingrf.com/community/lora-frequency-in-europe

The LoRa Alliance has defined two frequency bands for the usage of LoRa technology in Europe. These bands are EU433 from 433.05 to 434.79 MHz and EU863 from 863 to 870 MHz.

EU433 (433.05 to 434.79 MHz)

The end devices in EU433 band operate from 433.05 to 434.79 MHz and use a channel data structure to support at least 16 channels.

and so on...
https://lora-alliance.org/sites/default/files/2018-04/lorawantm_regional_parameters_v1.1rb_-_final.pdf