### PR TITLE
Add support for SH1106 controller

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -104,6 +104,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define SSD1306_ADDRESS 0x3C
 
+// The SH1106 controller is almost, but not quite, the same as SSD1306
+// Define this if you know you have that controller or your "SSD1306" misbehaves.
+//#define USE_SH1106
+
 // Flip the screen upside down by default as it makes more sense on T-BEAM
 // devices. Comment this out to not rotate screen 180 degrees.
 #define FLIP_SCREEN_VERTICALLY

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -34,7 +34,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define FONT_HEIGHT 14 // actually 13 for "ariel 10" but want a little extra space
 #define FONT_HEIGHT_16 (ArialMT_Plain_16[1] + 1)
+#ifdef USE_SH1106
+#define SCREEN_WIDTH 132
+#else
 #define SCREEN_WIDTH 128
+#endif
 #define SCREEN_HEIGHT 64
 #define TRANSITION_FRAMERATE 30 // fps
 #define IDLE_FRAMERATE 10       // in fps

--- a/src/screen.h
+++ b/src/screen.h
@@ -3,7 +3,12 @@
 #include <cstring>
 
 #include <OLEDDisplayUi.h>
+
+#ifdef USE_SH1106
+#include <SH1106Wire.h>
+#else
 #include <SSD1306Wire.h>
+#endif
 
 #include "PeriodicTask.h"
 #include "TypedQueue.h"
@@ -211,7 +216,11 @@ class Screen : public PeriodicTask
     /// Holds state for debug information
     DebugInfo debugInfo;
     /// Display device
+#ifdef USE_SH1106
+    SH1106Wire dispdev;
+#else
     SSD1306Wire dispdev;
+#endif
     /// UI helper for rendering to frames and switching between them
     OLEDDisplayUi ui;
 };


### PR DESCRIPTION
The SH1106 is almost indistinguisable from a SSD1306.

- the nr of columns in the sh1106 is 132 vs 128
- use the proper includes/library functions when in use

This needs https://github.com/meshtastic/esp8266-oled-ssd1306/pull/1

Related to issue #178 