### PR TITLE
Fixed GPS pin Definitions for Heltec Lora V2

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -168,6 +168,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // This string must exactly match the case used in release file names or the android updater won't work
 #define HW_VENDOR "heltec"
 
+// the default ESP32 Pin of 15 is the Oled SCL, set to 36 and 37 and works fine.
+//Tested on Neo6m module. 
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+#define GPS_RX_PIN 36
+#define GPS_TX_PIN 37
+
 #ifndef USE_JTAG  // gpio15 is TDO for JTAG, so no I2C on this board while doing jtag
 #define I2C_SDA 4 // I2C pins for this board
 #define I2C_SCL 15


### PR DESCRIPTION
Original pins for esp32 pinout was 15 and 12.

Pin 15 on the heltec lorav2 is the OLED_SCL pin, so the screen doesn't work
changing the pins to 36 and 37 works fine and allows a cheap Neo-6m to be plugged in and work automatically!
```
#undef GPS_RX_PIN
#undef GPS_TX_PIN
#define GPS_RX_PIN 36
#define GPS_TX_PIN 37
```
![goodgps](https://user-images.githubusercontent.com/13477955/84689557-635a2600-aefe-11ea-9aa0-254f67446325.jpg)

