### PR TITLE
Added battery charge percentage support, Issue#196

### DIFF
--- a/src/esp32/main-esp32.cpp
+++ b/src/esp32/main-esp32.cpp
@@ -6,7 +6,6 @@
 #include "power.h"
 #include "sleep.h"
 #include "target_specific.h"
-#include <algorithm>
 
 bool bluetoothOn;
 

--- a/src/power.h
+++ b/src/power.h
@@ -1,5 +1,18 @@
 #pragma once
 
+/**
+ * Per @spattinson
+ * MIN_BAT_MILLIVOLTS seems high. Typical 18650 are different chemistry to LiPo, even for LiPos that chart seems a bit off, other
+ * charts put 3690mV at about 30% for a lipo, for 18650 i think 10% remaining iis in the region of 3.2-3.3V. Reference 1st graph
+ * in [this test report](https://lygte-info.dk/review/batteries2012/Samsung%20INR18650-30Q%203000mAh%20%28Pink%29%20UK.html)
+ * looking at the red line - discharge at 0.2A - he gets a capacity of 2900mah, 90% of 2900 = 2610, that point in the graph looks
+ * to be a shade above 3.2V
+ */
+#define MIN_BAT_MILLIVOLTS 3250 // millivolts. 10% per https://blog.ampow.com/lipo-voltage-chart/
+
+#define BAT_MILLIVOLTS_FULL 4100
+#define BAT_MILLIVOLTS_EMPTY 3500
+
 namespace meshtastic
 {
 
@@ -9,6 +22,8 @@ struct PowerStatus {
     bool haveBattery;
     /// Battery voltage in mV, valid if haveBattery is true
     int batteryVoltageMv;
+    /// Battery charge percentage, either read directly or estimated
+    int batteryChargePercent;
     /// Whether USB is connected
     bool usb;
     /// Whether we are charging the battery

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -658,9 +658,11 @@ void DebugInfo::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
         snprintf(channelStr, sizeof(channelStr), "%s", channelName.c_str());
         if (powerStatus.haveBattery) {
             // TODO: draw a battery icon instead of letter "B".
-            int batV = powerStatus.batteryVoltageMv / 1000;
-            int batCv = (powerStatus.batteryVoltageMv % 1000) / 10;
-            snprintf(batStr, sizeof(batStr), "B %01d.%02dV%c%c", batV, batCv, powerStatus.charging ? '+' : ' ',
+            //int batV = powerStatus.batteryVoltageMv / 1000;
+            //int batCv = (powerStatus.batteryVoltageMv % 1000) / 10;
+            //snprintf(batStr, sizeof(batStr), "B %01d.%02dV%c%c", batV, batCv, powerStatus.charging ? '+' : ' ',
+            //         powerStatus.usb ? 'U' : ' ');
+            snprintf(batStr, sizeof(batStr), "B %d%%%c%c", powerStatus.batteryChargePercent, powerStatus.charging ? '+' : ' ',
                      powerStatus.usb ? 'U' : ' ');
         } else {
             snprintf(batStr, sizeof(batStr), "%s", powerStatus.usb ? "USB" : "");


### PR DESCRIPTION
If the board eventually supports percent readings directly from the AXP192, it'll use that.  Otherwise it estimates the percentage based on full/empty definitions in power.h