### PR TITLE
Use spare TBeam GPIO for an alternate middle button - Issue#162

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ debug_tool = jlink
 lib_deps =
   https://github.com/meshtastic/esp8266-oled-ssd1306.git ; ESP8266_SSD1306 
   SPI
-  ; 1260 ; OneButton - not used yet
+  1260 ; OneButton library for non-blocking button debounce
   1202 ; CRC32, explicitly needed because dependency is missing in the ble ota update lib
   Wire ; explicitly needed here because the AXP202 library forgets to add it
   https://github.com/meshtastic/arduino-fsm.git 
@@ -96,6 +96,7 @@ board = ttgo-t-beam
 lib_deps =
   ${env.lib_deps}
   https://github.com/meshtastic/AXP202X_Library.git
+
 build_flags = 
   ${esp32_base.build_flags} -D TBEAM_V10
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -144,7 +144,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define I2C_SDA 21
 #define I2C_SCL 22
 
-#define BUTTON_PIN 38
+#define BUTTON_PIN 38       // The middle button GPIO on the T-Beam
+#define BUTTON_PIN_ALT 13   // Alternate GPIO for an external button if needed
 
 #ifndef USE_JTAG
 #define RESET_GPIO 14

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "screen.h"
 #include "sleep.h"
 #include <Wire.h>
+#include <OneButton.h>
 // #include <driver/rtc_io.h>
 
 #ifndef NO_ESP32
@@ -124,7 +125,16 @@ static uint32_t ledBlinker()
 
 Periodic ledPeriodic(ledBlinker);
 
-
+// Prepare for button presses
+#ifdef BUTTON_PIN
+    OneButton userButton;
+#endif
+#ifdef BUTTON_PIN_ALT
+    OneButton userButtonAlt;
+#endif
+void userButtonPressed() {
+    powerFSM.trigger(EVENT_PRESS);
+}
 
 void setup()
 {
@@ -161,8 +171,12 @@ void setup()
 
     // Buttons & LED
 #ifdef BUTTON_PIN
-    pinMode(BUTTON_PIN, INPUT_PULLUP);
-    digitalWrite(BUTTON_PIN, 1);
+    userButton = OneButton(BUTTON_PIN, true, true);
+    userButton.attachClick(userButtonPressed);
+#endif
+#ifdef BUTTON_PIN_ALT
+    userButtonAlt = OneButton(BUTTON_PIN_ALT, true, true);
+    userButtonAlt.attachClick(userButtonPressed);
 #endif
 #ifdef LED_PIN
     pinMode(LED_PIN, OUTPUT);
@@ -295,24 +309,10 @@ void loop()
 #endif
 
 #ifdef BUTTON_PIN
-    // if user presses button for more than 3 secs, discard our network prefs and reboot (FIXME, use a debounce lib instead of
-    // this boilerplate)
-    static bool wasPressed = false;
-
-    if (!digitalRead(BUTTON_PIN)) {
-        if (!wasPressed) { // just started a new press
-            DEBUG_MSG("pressing\n");
-
-            // doLightSleep();
-            // esp_pm_dump_locks(stdout); // FIXME, do this someplace better
-            wasPressed = true;
-
-            powerFSM.trigger(EVENT_PRESS);
-        }
-    } else if (wasPressed) {
-        // we just did a release
-        wasPressed = false;
-    }
+    userButton.tick();
+#endif
+#ifdef BUTTON_PIN_ALT
+    userButtonAlt.tick();
 #endif
 
     // Show boot screen for first 3 seconds, then switch to normal operation.


### PR DESCRIPTION
Switched the middle button handling to use OneButton, and added support for an external button on pin 13 that does the same thing