### PR TITLE
Fixed #154 - Cleaned up UTF-8 conversion, tweaked screen.cpp to replace a hardcoded constant

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -717,7 +717,7 @@ void DebugInfo::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
     }
 
     const char *fields[] = {channelStr, nullptr};
-    uint32_t yo = drawRows(display, x, y + 12, fields);
+    uint32_t yo = drawRows(display, x, y + FONT_HEIGHT, fields);
 
     display->drawLogBuffer(x, yo);
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -499,6 +499,9 @@ void Screen::setup()
     // Store a pointer to Screen so we can get to it from static functions.
     ui.getUiState()->userData = this;
 
+    // Set the utf8 conversion function
+    dispdev.setFontTableLookupFunction(customFontTableLookup);
+
     // Add frames.
     static FrameCallback bootFrames[] = {drawBootScreen};
     static const int bootFrameCount = sizeof(bootFrames) / sizeof(bootFrames[0]);

--- a/src/screen.h
+++ b/src/screen.h
@@ -149,6 +149,29 @@ class Screen : public PeriodicTask
         }
     }
 
+    /// Overrides the default utf8 character conversion, to replace empty space with question marks
+    static char customFontTableLookup(const uint8_t ch) {
+        // UTF-8 to font table index converter
+        // Code form http://playground.arduino.cc/Main/Utf8ascii
+        static uint8_t LASTCHAR;
+
+        if (ch < 128) { // Standard ASCII-set 0..0x7F handling
+            LASTCHAR = 0;
+            return ch;
+        }
+
+        uint8_t last = LASTCHAR;   // get last char
+        LASTCHAR = ch;
+
+        switch (last) {    // conversion depnding on first UTF8-character
+            case 0xC2: return (uint8_t) ch;
+            case 0xC3: return (uint8_t) (ch | 0xC0);
+            case 0x82: if (ch == 0xAC) return (uint8_t) 0x80;    // special case Euro-symbol
+        }
+
+        return (uint8_t) '?'; // otherwise: return ?, if character can't be converted
+    }
+
     /// Returns a handle to the DebugInfo screen.
     //
     // Use this handle to set things like battery status, user count, GPS status, etc.

--- a/src/screen.h
+++ b/src/screen.h
@@ -168,13 +168,16 @@ class Screen : public PeriodicTask
         switch (last) {    // conversion depnding on first UTF8-character
             case 0xC2: { SKIPREST = false; return (uint8_t) ch; }
             case 0xC3: { SKIPREST = false; return (uint8_t) (ch | 0xC0); }
-            case 0x82: { SKIPREST = false; if (ch == 0xAC) return (uint8_t) 0x80; }   // special case Euro-symbol
         }
+
+        // We want to strip out prefix chars for two-byte char formats
+        if (ch == 0xC2 || ch == 0xC3 || ch == 0x82) return (uint8_t) 0;
+
         // If we already returned an unconvertable-character symbol for this unconvertable-character sequence, return NULs for the rest of it
         if (SKIPREST) return (uint8_t) 0;
         SKIPREST = true;
 
-        return (uint8_t) 0xA8; // otherwise: return ¿ if character can't be converted
+        return (uint8_t) 191; // otherwise: return ¿ if character can't be converted (note that the font map we're using doesn't stick to standard EASCII codes)
     }
 
     /// Returns a handle to the DebugInfo screen.

--- a/src/screen.h
+++ b/src/screen.h
@@ -154,9 +154,11 @@ class Screen : public PeriodicTask
         // UTF-8 to font table index converter
         // Code form http://playground.arduino.cc/Main/Utf8ascii
         static uint8_t LASTCHAR;
+        static bool SKIPREST;   // Only display a single unconvertable-character symbol per sequence of unconvertable characters
 
         if (ch < 128) { // Standard ASCII-set 0..0x7F handling
             LASTCHAR = 0;
+            SKIPREST = false;
             return ch;
         }
 
@@ -164,12 +166,15 @@ class Screen : public PeriodicTask
         LASTCHAR = ch;
 
         switch (last) {    // conversion depnding on first UTF8-character
-            case 0xC2: return (uint8_t) ch;
-            case 0xC3: return (uint8_t) (ch | 0xC0);
-            case 0x82: if (ch == 0xAC) return (uint8_t) 0x80;    // special case Euro-symbol
+            case 0xC2: { SKIPREST = false; return (uint8_t) ch; }
+            case 0xC3: { SKIPREST = false; return (uint8_t) (ch | 0xC0); }
+            case 0x82: { SKIPREST = false; if (ch == 0xAC) return (uint8_t) 0x80; }   // special case Euro-symbol
         }
+        // If we already returned an unconvertable-character symbol for this unconvertable-character sequence, return NULs for the rest of it
+        if (SKIPREST) return (uint8_t) 0;
+        SKIPREST = true;
 
-        return (uint8_t) '?'; // otherwise: return ?, if character can't be converted
+        return (uint8_t) 0xA8; // otherwise: return ¿ if character can't be converted
     }
 
     /// Returns a handle to the DebugInfo screen.


### PR DESCRIPTION
Unconvertable UTF-8 character sequences are now replaced with a single ¿ symbol.  I also removed mapping support for the euro symbol, since it doesn't appear to be part of our font table at this time.
I also replaced the hardcoded pixel offset for the channel string in display.cpp to reference the FONT_HEIGHT def instead.