### PR TITLE
Take configured SCREEN_WIDTH into account for brightness bar

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -740,8 +740,8 @@ void Screen::adjustBrightness(){
     } else {
         brightness++;    
     }
-    int width = brightness / 1.984375;
-    dispdev.drawRect( 0, 30, 128, 4);
+    int width = (brightness / 254) * SCREEN_WIDTH;
+    dispdev.drawRect( 0, 30, SCREEN_WIDTH, 4);
     dispdev.fillRect(0, 30, width, 4);
     dispdev.display();
     dispdev.setBrightness(brightness);


### PR DESCRIPTION
width of sh1106 display is 132  and supported.

Note: the actual redisplay does not work for instantly on my device, but I'm not sure if that is a sh1106 issue.