### PR TITLE
Add Canada to list of countries that use 915 MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We currently support three models of radios.
 
 **Make sure to get the frequency for your country**
 
-- US/JP/AU/NZ - 915MHz
+- US/JP/AU/NZ/CA - 915MHz
 - CN - 470MHz
 - EU - 868MHz, 433MHz
 


### PR DESCRIPTION
Meshtastic prompted me to get a couple boards to try, and I had to figure out what frequency. Canada uses the same US902-928 as the US, add it to the list for simplicity.

Not sure where to find an "official" reference, but there's a reference here: https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html