### PR TITLE
Screen width correction for sh1106 display controller 

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -35,11 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define FONT_HEIGHT 14 // actually 13 for "ariel 10" but want a little extra space
 #define FONT_HEIGHT_16 (ArialMT_Plain_16[1] + 1)
-#ifdef USE_SH1106
-#define SCREEN_WIDTH 132
-#else
+// This means the *visible* area (sh1106 can address 132, but shows 128 for example)
 #define SCREEN_WIDTH 128
-#endif
 #define SCREEN_HEIGHT 64
 #define TRANSITION_FRAMERATE 30 // fps
 #define IDLE_FRAMERATE 10       // in fps

--- a/src/screen.h
+++ b/src/screen.h
@@ -119,7 +119,7 @@ class Screen : public PeriodicTask
 
     // Implementation to Adjust Brightness
     void adjustBrightness();
-    int brightness = 150;
+    uint8_t brightness = 150;
 
     /// Starts showing the Bluetooth PIN screen.
     //


### PR DESCRIPTION
While working on the brightness issue for the sh1106 based display  I noticed that the additional screen width of the sh1106 controller is not actually visible. The visible screen width is the same as with the ssd1306 controller.

The offset calculations are treated in the library, so in the "application level" the coordinates can be treated the same (i.e. column 0 gets translated to 2 etc.)

So, for sh1106 the screen width is actually the same, this pr reflects that. We probably should rename the constant at some point when we actually get displays supported that do have other resolutions, but for now this will be sufficient.

The other correction is just a type declaration fix.

PS
The brightness issue for the sh1106 is not resolved yet.