### PR TITLE
Issue#242 - at least partially fixed the setFrames issue with nodeDB updates

### DIFF
--- a/src/NodeStatus.h
+++ b/src/NodeStatus.h
@@ -15,13 +15,17 @@ namespace meshtastic {
         uint8_t numOnline = 0;
         uint8_t numTotal = 0;
 
+        uint8_t lastNumTotal = 0;
+
        public:
+        bool forceUpdate = false;
 
         NodeStatus() {
             statusType = STATUS_TYPE_NODE;
         }
-        NodeStatus( uint8_t numOnline, uint8_t numTotal ) : Status()
+        NodeStatus( uint8_t numOnline, uint8_t numTotal, bool forceUpdate = false ) : Status()
         {
+            this->forceUpdate = forceUpdate;
             this->numOnline = numOnline;
             this->numTotal = numTotal;
         }
@@ -43,6 +47,11 @@ namespace meshtastic {
             return numTotal; 
         }
 
+        uint8_t getLastNumTotal() const
+        {
+            return lastNumTotal;
+        }
+
         bool matches(const NodeStatus *newStatus) const
         {
             return (
@@ -52,6 +61,7 @@ namespace meshtastic {
         }
         int updateStatus(const NodeStatus *newStatus) {
             // Only update the status if values have actually changed
+            lastNumTotal = numTotal;
             bool isDirty;
             {
                 isDirty = matches(newStatus);
@@ -59,7 +69,7 @@ namespace meshtastic {
                 numOnline = newStatus->getNumOnline();
                 numTotal = newStatus->getNumTotal();
             }
-            if(isDirty) {
+            if(isDirty || newStatus->forceUpdate) {
                 DEBUG_MSG("Node status update: %d online, %d total\n", numOnline, numTotal);            
                 onNewStatus.notifyObservers(this);
             }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -339,10 +339,7 @@ void NodeDB::updateFrom(const MeshPacket &mp)
         const SubPacket &p = mp.decoded;
         DEBUG_MSG("Update DB node 0x%x, rx_time=%u\n", mp.from, mp.rx_time);
 
-        int oldNumNodes = *numNodes;
         NodeInfo *info = getOrCreateNode(mp.from);
-
-        notifyObservers();
 
         if (mp.rx_time) {              // if the packet has a valid timestamp use it to update our last_seen
             info->has_position = true; // at least the time is valid
@@ -359,6 +356,7 @@ void NodeDB::updateFrom(const MeshPacket &mp)
             info->position.time = oldtime;
             info->has_position = true;
             updateGUIforNode = info;
+            notifyObservers(true);  //Force an update whether or not our node counts have changed
             break;
         }
 
@@ -373,6 +371,7 @@ void NodeDB::updateFrom(const MeshPacket &mp)
                     devicestate.has_rx_text_message = true;
                     updateTextMessage = true;
                     powerFSM.trigger(EVENT_RECEIVED_TEXT_MSG);
+                    notifyObservers(true);  //Force an update whether or not our node counts have changed
                 }
             }
             break;
@@ -391,12 +390,17 @@ void NodeDB::updateFrom(const MeshPacket &mp)
             if (changed) {
                 updateGUIforNode = info;
                 powerFSM.trigger(EVENT_NODEDB_UPDATED);
+                notifyObservers(true);  //Force an update whether or not our node counts have changed
 
                 // Not really needed - we will save anyways when we go to sleep
                 // We just changed something important about the user, store our DB
                 // saveToDisk();
             }
             break;
+        }
+
+        default: {
+            notifyObservers();  //If the node counts have changed, notify observers
         }
         }
     }

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -95,9 +95,9 @@ class NodeDB
     NodeInfo *getOrCreateNode(NodeNum n);
 
     /// Notify observers of changes to the DB
-    void notifyObservers() {
+    void notifyObservers(bool forceUpdate = false) {
         // Notify observers of the current node state
-        const meshtastic::NodeStatus status = meshtastic::NodeStatus(getNumOnlineNodes(), getNumNodes());
+        const meshtastic::NodeStatus status = meshtastic::NodeStatus(getNumOnlineNodes(), getNumNodes(), forceUpdate);
         newStatus.notifyObservers(&status);
     }
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -92,7 +92,7 @@ class Screen : public PeriodicTask
 
     // Implementation to Adjust Brightness
     void adjustBrightness();
-    int brightness = 150;
+    uint8_t brightness = 150;
 
     /// Starts showing the Bluetooth PIN screen.
     //


### PR DESCRIPTION
I added the ability for NodeDB to notify observers of events that should force propagate even if the number of online / total nodes did not change.  I integrated that into screen.cpp to fix the issue with incoming messages not being displayed, and some problems with being able to switch between frames with the user button (partially fixes #242).  I also tweaked the compass display to better handle an edge case