### PR TITLE
Fix compilation without a BUTTON_PIN definition

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -284,8 +284,10 @@ esp_sleep_wakeup_cause_t doLightSleep(uint64_t sleepMsec) // FIXME, use a more r
     assert(esp_light_sleep_start() == ESP_OK);
 
     esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+#ifdef BUTTON_PIN
     if (cause == ESP_SLEEP_WAKEUP_GPIO)
         DEBUG_MSG("Exit light sleep gpio: btn=%d\n", !digitalRead(BUTTON_PIN));
+#endif
 
     return cause;
 }


### PR DESCRIPTION
If you undefine `BUTTON_PIN` currently the build will fail. Applying this PR (and undefining `BUTTON_PIN` on your platform) allows the firmware to build. I've tested this on `tlora-v2` in trying to track down #341, and the device sleeps properly and wakes up when connected to with the app.

This shouldn't affect any existing platforms, as they have a definition for `BUTTON_PIN`.