### PR TITLE
Display status of the BT radio on screen

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -32,6 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "main.h"
 #include "mesh-pb-constants.h"
 #include "utils.h"
+#include "nimble/BluetoothUtil.h"
 
 using namespace meshtastic; /** @todo remove */
 
@@ -883,6 +884,63 @@ void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *stat
     // TODO: Use this line for WiFi information.
     // display->drawString(x + (SCREEN_WIDTH - (display->getStringWidth("WiFi: 192.168.0.100"))) / 2, y + FONT_HEIGHT * 2, "WiFi: 192.168.0.100");
 
+    //TODO change stirng BT to image bluetooth
+    if (stateBT == ON or stateBT == DISCONNECT)
+    {
+        if (seconds % 2)
+	{
+	    display->drawString(x + SCREEN_WIDTH - display->getStringWidth("BT"), y, "BT");
+        } else
+        {
+            display->drawString(x + SCREEN_WIDTH - display->getStringWidth("  "), y, "  ");
+        }
+    } else if (stateBT == OFF)
+    {
+         display->drawString(x + SCREEN_WIDTH - display->getStringWidth("  "), y, "  ");
+    } else
+    {
+         display->drawString(x + SCREEN_WIDTH - display->getStringWidth("BT"), y, "BT");
+    }
+
+    switch (stateBT) {
+    case CONNECT:
+        display->drawString(x, y + FONT_HEIGHT * 2,"BT: CONNECT");
+	break;
+    case DISCONNECT:
+        display->drawString(x, y + FONT_HEIGHT * 2,"BT: DISCONNECT");
+	break;
+    case CONN_UPDATE:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: CONN_UPDATE");
+	break;
+    case ADV_COMPLETE:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: ADV_COMPLETE");
+	break;
+    case ENC_CHANGE:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: ENC_CHANGE");
+	break;
+    case SUBSCRIBE:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: SUBSCRIBE");
+	break;
+    case MTU:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: MTU");
+	break;
+    case REPEAT_PAIRING:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: REPEAT_PAIRING");
+	break;
+    case PASSKEY_ACTION:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: PASSKEY_ACTION");
+	break;
+    case ON:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: ON");
+	break;
+    case OFF:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: OFF");
+	break;
+    default:
+	display->drawString(x, y + FONT_HEIGHT * 2,"BT: ");
+    }
+
+  //  }
     // Line 4
     drawGPScoordinates(display, x, y + FONT_HEIGHT * 3, gpsStatus);
 

--- a/src/nimble/BluetoothUtil.cpp
+++ b/src/nimble/BluetoothUtil.cpp
@@ -119,6 +119,9 @@ static void advertise();
  *                                  of the return code is specific to the
  *                                  particular GAP event being signalled.
  */
+
+StateBT stateBT;
+
 static int gap_event(struct ble_gap_event *event, void *arg)
 {
     struct ble_gap_conn_desc desc;
@@ -126,6 +129,7 @@ static int gap_event(struct ble_gap_event *event, void *arg)
 
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
+	stateBT = CONNECT;
         /* A new connection was established or a connection attempt failed. */
         DEBUG_MSG("connection %s; status=%d ", event->connect.status == 0 ? "established" : "failed", event->connect.status);
         if (event->connect.status == 0) {
@@ -143,6 +147,7 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_DISCONNECT:
+	stateBT = DISCONNECT;
         DEBUG_MSG("disconnect; reason=%d ", event->disconnect.reason);
         print_conn_desc(&event->disconnect.conn);
         DEBUG_MSG("\n");
@@ -154,6 +159,7 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_CONN_UPDATE:
+	stateBT = CONN_UPDATE;
         /* The central has updated the connection parameters. */
         DEBUG_MSG("connection updated; status=%d ", event->conn_update.status);
         rc = ble_gap_conn_find(event->conn_update.conn_handle, &desc);
@@ -163,11 +169,13 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
+	stateBT = ADV_COMPLETE;
         DEBUG_MSG("advertise complete; reason=%d", event->adv_complete.reason);
         advertise();
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
+	stateBT = ENC_CHANGE;
         /* Encryption has been enabled or disabled for this connection. */
         DEBUG_MSG("encryption change event; status=%d ", event->enc_change.status);
         rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
@@ -180,6 +188,7 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
+	stateBT = SUBSCRIBE;
         DEBUG_MSG("subscribe event; conn_handle=%d attr_handle=%d "
                   "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                   event->subscribe.conn_handle, event->subscribe.attr_handle, event->subscribe.reason,
@@ -188,11 +197,13 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
+	stateBT = MTU;
         DEBUG_MSG("mtu update event; conn_handle=%d cid=%d mtu=%d\n", event->mtu.conn_handle, event->mtu.channel_id,
                   event->mtu.value);
         return 0;
 
     case BLE_GAP_EVENT_REPEAT_PAIRING:
+	stateBT = REPEAT_PAIRING;
         DEBUG_MSG("repeat pairing event; conn_handle=%d "
                   "cur_key_sz=%d cur_auth=%d cur_sc=%d "
                   "new_key_sz=%d new_auth=%d new_sc=%d "
@@ -216,6 +227,7 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         return BLE_GAP_REPEAT_PAIRING_RETRY;
 
     case BLE_GAP_EVENT_PASSKEY_ACTION:
+	stateBT = PASSKEY_ACTION;
         DEBUG_MSG("PASSKEY_ACTION_EVENT started \n");
         struct ble_sm_io pkey = {0};
 
@@ -542,9 +554,11 @@ void setBluetoothEnable(bool on)
             Serial.printf("Pre BT: %u heap size\n", ESP.getFreeHeap());
             // ESP_ERROR_CHECK( heap_trace_start(HEAP_TRACE_LEAKS) );
             reinitBluetooth();
+	    stateBT = ON;
             initWifi();
         } else {
             // We have to totally teardown our bluetooth objects to prevent leaks
+	    stateBT = OFF;
             deinitBLE();
             WiFi.mode(WIFI_MODE_NULL); // shutdown wifi
             Serial.printf("Shutdown BT: %u heap size\n", ESP.getFreeHeap());
@@ -599,3 +613,4 @@ BLEServer *serve = initBLE(, , getDeviceName(), HW_VENDOR, optstr(APP_VERSION),
                            optstr(HW_VERSION)); // FIXME, use a real name based on the macaddr
 
 #endif
+

--- a/src/nimble/BluetoothUtil.h
+++ b/src/nimble/BluetoothUtil.h
@@ -28,3 +28,20 @@ int chr_readwrite32le(uint32_t *v, struct ble_gatt_access_ctxt *ctxt);
  * A helper for readwrite access to an array of bytes (with no endian conversion)
  */
 int chr_readwrite8(uint8_t *v, size_t vlen, struct ble_gatt_access_ctxt *ctxt);
+
+enum StateBT 
+{
+	CONNECT,
+	DISCONNECT,
+	CONN_UPDATE,
+	ADV_COMPLETE,
+	ENC_CHANGE,
+	SUBSCRIBE,
+	MTU,
+	REPEAT_PAIRING,
+	PASSKEY_ACTION,
+	ON,
+	OFF
+};
+
+extern StateBT stateBT;


### PR DESCRIPTION
Fix for: #352 - Added status of the BT radio on screen

The bluetooth status display concept:

- when bluetooth is turned on and waiting for a connection, the BT symbol flashes 1 per second

- when a bluetooth connection is set up, the BT symbol is showing in the top right corner

- when bluetooth is off there is nothing in the top right corner.

Additionally, in the 3rd line the exact bluetooth status is displayed (for information purposes - until Wi-Fi connectivity is implemented) .

If everything is ok, then BT can be replaced with the appropriate symbol.

