### PR TITLE
Fix GPS turned on then off immediately every 2 minutes

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -239,6 +239,7 @@ int32_t GPS::runOnce()
         }
 
         // We've been awake too long - force sleep
+        now = millis();
         auto wakeTime = getWakeTime();
         bool tooLong = wakeTime != UINT32_MAX && (now - lastWakeStartMsec) > wakeTime;
 


### PR DESCRIPTION
## Thank you for sending in a pull request, here's some tips to get started!

Issue reported in group https://meshtastic.discourse.group/t/how-gps-works-on-meshtastic/1972/4

The problem is  lastWakeStartMsec which is assigned a more recent time (https://github.com/meshtastic/Meshtastic-device/blob/master/src/gps/GPS.cpp#L217) than the unsigned uint32 value of now, causing (now - lastWakeStartMsec) overflow in line of https://github.com/meshtastic/Meshtastic-device/blob/master/src/gps/GPS.cpp#L243.

Fixed by re-assigning now with most recent time.

