### PR TITLE
Shall upgrade RTC currentQuality if higher q available (fix #604)

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -36,6 +36,7 @@ bool perhapsSetRTC(RTCQuality q, const struct timeval *tv)
 
     bool shouldSet;
     if (q > currentQuality) {
+        currentQuality = q;
         shouldSet = true;
         DEBUG_MSG("Upgrading time to RTC %ld secs (quality %d)\n", tv->tv_sec, q);
     } else if(q == RTCQualityGPS && (now - lastSetMsec) > (12 * 60 * 60 * 1000L)) {


### PR DESCRIPTION
Related to issue #604.

currentQuality never gets upgraded in the code. Shall upgrade currentQuality if a higher q is available.
