### PR TITLE
Fix for non-working tx pin

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -343,7 +343,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #undef GPS_RX_PIN
 #undef GPS_TX_PIN
 #define GPS_RX_PIN 36
-#define GPS_TX_PIN 39
+#define GPS_TX_PIN 13
 
 #define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 


### PR DESCRIPTION
Fix for non-working tx pin for tlora-v2-1-1.6
* GPS_TX_PIN 39 was found to not transmit, resulting in GPS not entering Ublox mode
* I suspect this is the same error that @eugene fixed for tlora-v1-3
