### PR TITLE
Changes to Environmental Measurement App

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -937,7 +937,7 @@ void Screen::setFrames()
         normalFrames[numframes++] = drawPluginFrame;
     }
     
-    DEBUG_MSG("Added plugins.  numframes: %d", numframes);
+    DEBUG_MSG("Added plugins.  numframes: %d\n", numframes);
 
     // If we have a critical fault, show it first
     if (myNodeInfo.error_code)

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -164,9 +164,9 @@ static void drawPluginFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int
     else {
         // otherwise, just display the plugin frame that's aligned with the current frame
         plugin_frame = state->currentFrame;
-        DEBUG_MSG("Screen is not in transition.  Frame: %d\n\n", plugin_frame);
+        //DEBUG_MSG("Screen is not in transition.  Frame: %d\n\n", plugin_frame);
     }
-    DEBUG_MSG("Drawing Plugin Frame %d\n\n", plugin_frame);
+    //DEBUG_MSG("Drawing Plugin Frame %d\n\n", plugin_frame);
     MeshPlugin &pi = *pluginFrames.at(plugin_frame);
     pi.drawFrame(display,state,x,y);
     

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -150,8 +150,24 @@ static void drawSleepScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int
 
 static void drawPluginFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
-    DEBUG_MSG("Drawing Plugin Frame %d\n\n", state->currentFrame);
-    MeshPlugin &pi = *pluginFrames.at(state->currentFrame);
+    uint8_t plugin_frame;
+    // there's a little but in the UI transition code
+    // where it invokes the function at the correct offset 
+    // in the array of "drawScreen" functions; however,
+    // the passed-state doesn't quite reflect the "current" 
+    // screen, so we have to detect it.
+    if (state->frameState == IN_TRANSITION && state->transitionFrameRelationship == INCOMING) {
+        // if we're transitioning from the end of the frame list back around to the first 
+        // frame, then we want this to be `0`
+        plugin_frame = state->transitionFrameTarget;
+    }
+    else {
+        // otherwise, just display the plugin frame that's aligned with the current frame
+        plugin_frame = state->currentFrame;
+        DEBUG_MSG("Screen is not in transition.  Frame: %d\n\n", plugin_frame);
+    }
+    DEBUG_MSG("Drawing Plugin Frame %d\n\n", plugin_frame);
+    MeshPlugin &pi = *pluginFrames.at(plugin_frame);
     pi.drawFrame(display,state,x,y);
     
 }

--- a/src/mesh/MeshPlugin.cpp
+++ b/src/mesh/MeshPlugin.cpp
@@ -76,3 +76,17 @@ void setReplyTo(MeshPacket *p, const MeshPacket &to) {
     p->to = to.from;
     p->want_ack = to.want_ack;
 }
+
+std::vector<MeshPlugin *> MeshPlugin::GetMeshPluginsWithUIFrames() {
+
+    std::vector<MeshPlugin *> pluginsWithUIFrames;    
+    for (auto i = plugins->begin(); i != plugins->end(); ++i) {
+        auto &pi = **i;
+        if ( pi.wantUIFrame()) {
+            DEBUG_MSG("Plugin wants a UI Frame\n");
+            pluginsWithUIFrames.push_back(&pi);
+        }
+    }
+    return pluginsWithUIFrames;
+    
+}

--- a/src/mesh/MeshPlugin.h
+++ b/src/mesh/MeshPlugin.h
@@ -2,6 +2,8 @@
 
 #include "mesh/MeshTypes.h"
 #include <vector>
+#include <OLEDDisplay.h>
+#include <OLEDDisplayUi.h>
 /** A baseclass for any mesh "plugin".
  *
  * A plugin allows you to add new features to meshtastic device code, without needing to know messaging details.
@@ -14,7 +16,7 @@
  */
 class MeshPlugin
 {
-    static std::vector<MeshPlugin *> *plugins;
+  static std::vector<MeshPlugin *> *plugins;
 
   public:
     /** Constructor
@@ -27,6 +29,10 @@ class MeshPlugin
     /** For use only by MeshService
      */
     static void callPlugins(const MeshPacket &mp);
+
+    static std::vector<MeshPlugin *> GetMeshPluginsWithUIFrames();
+
+    virtual void drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y) { return; }
 
   protected:
     const char *name;
@@ -60,6 +66,13 @@ class MeshPlugin
     /** Messages can be received that have the want_response bit set.  If set, this callback will be invoked
      * so that subclasses can (optionally) send a response back to the original sender.  */
     virtual MeshPacket *allocReply() { return NULL; }
+
+    /***
+     * @return true if you want to be alloced a UI screen frame
+     */
+    virtual bool wantUIFrame() { return false; }
+
+
 
   private:
 

--- a/src/mesh/generated/deviceonly.pb.h
+++ b/src/mesh/generated/deviceonly.pb.h
@@ -80,7 +80,7 @@ extern const pb_msgdesc_t DeviceState_msg;
 #define DeviceState_fields &DeviceState_msg
 
 /* Maximum encoded size of messages (where known) */
-#define DeviceState_size                         6290
+#define DeviceState_size                         6293
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/deviceonly.pb.h
+++ b/src/mesh/generated/deviceonly.pb.h
@@ -80,7 +80,7 @@ extern const pb_msgdesc_t DeviceState_msg;
 #define DeviceState_fields &DeviceState_msg
 
 /* Maximum encoded size of messages (where known) */
-#define DeviceState_size                         6266
+#define DeviceState_size                         6290
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/mesh.pb.h
+++ b/src/mesh/generated/mesh.pb.h
@@ -208,6 +208,10 @@ typedef struct _RadioConfig_UserPreferences {
     bool range_test_plugin_save;
     bool store_forward_plugin_enabled;
     uint32_t store_forward_plugin_records;
+    bool environmental_measurement_plugin_enabled;
+    uint32_t environmental_measurement_plugin_read_error_count_threshold;
+    uint32_t environmental_measurement_plugin_update_interval;
+    uint32_t environmental_measurement_plugin_recovery_interval;
 } RadioConfig_UserPreferences;
 
 typedef struct _RouteDiscovery {
@@ -360,7 +364,7 @@ extern "C" {
 #define MeshPacket_init_default                  {0, 0, 0, {SubPacket_init_default}, 0, 0, 0, 0, 0, 0, _MeshPacket_Priority_MIN}
 #define ChannelSettings_init_default             {0, _ChannelSettings_ModemConfig_MIN, {0, {0}}, "", 0, 0, 0, 0, 0, 0, 0}
 #define RadioConfig_init_default                 {false, RadioConfig_UserPreferences_init_default, false, ChannelSettings_init_default}
-#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define NodeInfo_init_default                    {0, false, User_init_default, false, Position_init_default, 0, 0}
 #define MyNodeInfo_init_default                  {0, 0, 0, "", "", "", _CriticalErrorCode_MIN, 0, 0, 0, 0, 0, 0, 0}
 #define LogRecord_init_default                   {"", 0, "", _LogRecord_Level_MIN}
@@ -374,7 +378,7 @@ extern "C" {
 #define MeshPacket_init_zero                     {0, 0, 0, {SubPacket_init_zero}, 0, 0, 0, 0, 0, 0, _MeshPacket_Priority_MIN}
 #define ChannelSettings_init_zero                {0, _ChannelSettings_ModemConfig_MIN, {0, {0}}, "", 0, 0, 0, 0, 0, 0, 0}
 #define RadioConfig_init_zero                    {false, RadioConfig_UserPreferences_init_zero, false, ChannelSettings_init_zero}
-#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define NodeInfo_init_zero                       {0, false, User_init_zero, false, Position_init_zero, 0, 0}
 #define MyNodeInfo_init_zero                     {0, 0, 0, "", "", "", _CriticalErrorCode_MIN, 0, 0, 0, 0, 0, 0, 0}
 #define LogRecord_init_zero                      {"", 0, "", _LogRecord_Level_MIN}
@@ -460,6 +464,10 @@ extern "C" {
 #define RadioConfig_UserPreferences_range_test_plugin_save_tag 134
 #define RadioConfig_UserPreferences_store_forward_plugin_enabled_tag 136
 #define RadioConfig_UserPreferences_store_forward_plugin_records_tag 137
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_enabled_tag 140
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_read_error_count_threshold_tag 141
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_update_interval_tag 142
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_recovery_interval_tag 143
 #define RouteDiscovery_route_tag                 2
 #define User_id_tag                              1
 #define User_long_name_tag                       2
@@ -641,7 +649,11 @@ X(a, STATIC,   SINGULAR, BOOL,     range_test_plugin_enabled, 132) \
 X(a, STATIC,   SINGULAR, UINT32,   range_test_plugin_sender, 133) \
 X(a, STATIC,   SINGULAR, BOOL,     range_test_plugin_save, 134) \
 X(a, STATIC,   SINGULAR, BOOL,     store_forward_plugin_enabled, 136) \
-X(a, STATIC,   SINGULAR, UINT32,   store_forward_plugin_records, 137)
+X(a, STATIC,   SINGULAR, UINT32,   store_forward_plugin_records, 137) \
+X(a, STATIC,   SINGULAR, BOOL,     environmental_measurement_plugin_enabled, 140) \
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_read_error_count_threshold, 141) \
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_update_interval, 142) \
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_recovery_interval, 143)
 #define RadioConfig_UserPreferences_CALLBACK NULL
 #define RadioConfig_UserPreferences_DEFAULT NULL
 
@@ -753,13 +765,13 @@ extern const pb_msgdesc_t ToRadio_msg;
 #define SubPacket_size                           275
 #define MeshPacket_size                          322
 #define ChannelSettings_size                     95
-#define RadioConfig_size                         405
-#define RadioConfig_UserPreferences_size         305
+#define RadioConfig_size                         429
+#define RadioConfig_UserPreferences_size         329
 #define NodeInfo_size                            132
 #define MyNodeInfo_size                          106
 #define LogRecord_size                           81
-#define FromRadio_size                           414
-#define ToRadio_size                             409
+#define FromRadio_size                           438
+#define ToRadio_size                             433
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/mesh.pb.h
+++ b/src/mesh/generated/mesh.pb.h
@@ -208,7 +208,8 @@ typedef struct _RadioConfig_UserPreferences {
     bool range_test_plugin_save;
     bool store_forward_plugin_enabled;
     uint32_t store_forward_plugin_records;
-    bool environmental_measurement_plugin_enabled;
+    bool environmental_measurement_plugin_measurement_enabled;
+    bool environmental_measurement_plugin_screen_enabled;
     uint32_t environmental_measurement_plugin_read_error_count_threshold;
     uint32_t environmental_measurement_plugin_update_interval;
     uint32_t environmental_measurement_plugin_recovery_interval;
@@ -364,7 +365,7 @@ extern "C" {
 #define MeshPacket_init_default                  {0, 0, 0, {SubPacket_init_default}, 0, 0, 0, 0, 0, 0, _MeshPacket_Priority_MIN}
 #define ChannelSettings_init_default             {0, _ChannelSettings_ModemConfig_MIN, {0, {0}}, "", 0, 0, 0, 0, 0, 0, 0}
 #define RadioConfig_init_default                 {false, RadioConfig_UserPreferences_init_default, false, ChannelSettings_init_default}
-#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define NodeInfo_init_default                    {0, false, User_init_default, false, Position_init_default, 0, 0}
 #define MyNodeInfo_init_default                  {0, 0, 0, "", "", "", _CriticalErrorCode_MIN, 0, 0, 0, 0, 0, 0, 0}
 #define LogRecord_init_default                   {"", 0, "", _LogRecord_Level_MIN}
@@ -378,7 +379,7 @@ extern "C" {
 #define MeshPacket_init_zero                     {0, 0, 0, {SubPacket_init_zero}, 0, 0, 0, 0, 0, 0, _MeshPacket_Priority_MIN}
 #define ChannelSettings_init_zero                {0, _ChannelSettings_ModemConfig_MIN, {0, {0}}, "", 0, 0, 0, 0, 0, 0, 0}
 #define RadioConfig_init_zero                    {false, RadioConfig_UserPreferences_init_zero, false, ChannelSettings_init_zero}
-#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define NodeInfo_init_zero                       {0, false, User_init_zero, false, Position_init_zero, 0, 0}
 #define MyNodeInfo_init_zero                     {0, 0, 0, "", "", "", _CriticalErrorCode_MIN, 0, 0, 0, 0, 0, 0, 0}
 #define LogRecord_init_zero                      {"", 0, "", _LogRecord_Level_MIN}
@@ -464,10 +465,11 @@ extern "C" {
 #define RadioConfig_UserPreferences_range_test_plugin_save_tag 134
 #define RadioConfig_UserPreferences_store_forward_plugin_enabled_tag 136
 #define RadioConfig_UserPreferences_store_forward_plugin_records_tag 137
-#define RadioConfig_UserPreferences_environmental_measurement_plugin_enabled_tag 140
-#define RadioConfig_UserPreferences_environmental_measurement_plugin_read_error_count_threshold_tag 141
-#define RadioConfig_UserPreferences_environmental_measurement_plugin_update_interval_tag 142
-#define RadioConfig_UserPreferences_environmental_measurement_plugin_recovery_interval_tag 143
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_measurement_enabled_tag 140
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_screen_enabled_tag 141
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_read_error_count_threshold_tag 142
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_update_interval_tag 143
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_recovery_interval_tag 144
 #define RouteDiscovery_route_tag                 2
 #define User_id_tag                              1
 #define User_long_name_tag                       2
@@ -650,10 +652,11 @@ X(a, STATIC,   SINGULAR, UINT32,   range_test_plugin_sender, 133) \
 X(a, STATIC,   SINGULAR, BOOL,     range_test_plugin_save, 134) \
 X(a, STATIC,   SINGULAR, BOOL,     store_forward_plugin_enabled, 136) \
 X(a, STATIC,   SINGULAR, UINT32,   store_forward_plugin_records, 137) \
-X(a, STATIC,   SINGULAR, BOOL,     environmental_measurement_plugin_enabled, 140) \
-X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_read_error_count_threshold, 141) \
-X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_update_interval, 142) \
-X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_recovery_interval, 143)
+X(a, STATIC,   SINGULAR, BOOL,     environmental_measurement_plugin_measurement_enabled, 140) \
+X(a, STATIC,   SINGULAR, BOOL,     environmental_measurement_plugin_screen_enabled, 141) \
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_read_error_count_threshold, 142) \
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_update_interval, 143) \
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_recovery_interval, 144)
 #define RadioConfig_UserPreferences_CALLBACK NULL
 #define RadioConfig_UserPreferences_DEFAULT NULL
 
@@ -765,13 +768,13 @@ extern const pb_msgdesc_t ToRadio_msg;
 #define SubPacket_size                           275
 #define MeshPacket_size                          322
 #define ChannelSettings_size                     95
-#define RadioConfig_size                         429
-#define RadioConfig_UserPreferences_size         329
+#define RadioConfig_size                         432
+#define RadioConfig_UserPreferences_size         332
 #define NodeInfo_size                            132
 #define MyNodeInfo_size                          106
 #define LogRecord_size                           81
-#define FromRadio_size                           438
-#define ToRadio_size                             433
+#define FromRadio_size                           441
+#define ToRadio_size                             436
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/portnums.pb.h
+++ b/src/mesh/generated/portnums.pb.h
@@ -18,10 +18,10 @@ typedef enum _PortNum {
     PortNum_NODEINFO_APP = 4,
     PortNum_REPLY_APP = 32,
     PortNum_IP_TUNNEL_APP = 33,
-    PortNum_ENVIRONMENTAL_MEASUREMENT_APP = 67,
     PortNum_SERIAL_APP = 64,
     PortNum_STORE_FORWARD_APP = 65,
     PortNum_RANGE_TEST_APP = 66,
+    PortNum_ENVIRONMENTAL_MEASUREMENT_APP = 67,
     PortNum_PRIVATE_APP = 256,
     PortNum_ATAK_FORWARDER = 257
 } PortNum;

--- a/src/mesh/generated/portnums.pb.h
+++ b/src/mesh/generated/portnums.pb.h
@@ -18,7 +18,7 @@ typedef enum _PortNum {
     PortNum_NODEINFO_APP = 4,
     PortNum_REPLY_APP = 32,
     PortNum_IP_TUNNEL_APP = 33,
-    PortNum_ENVIRONMENTAL_MEASUREMENT_APP = 34,
+    PortNum_ENVIRONMENTAL_MEASUREMENT_APP = 67,
     PortNum_SERIAL_APP = 64,
     PortNum_STORE_FORWARD_APP = 65,
     PortNum_RANGE_TEST_APP = 66,

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -49,10 +49,10 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
         Uncomment the preferences below if you want to use the plugin
         without having to configure it from the PythonAPI or WebUI.
     */
-    /*radioConfig.preferences.environmental_measurement_plugin_enabled = 1;
+    radioConfig.preferences.environmental_measurement_plugin_enabled = 1;
     radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold = 5;
     radioConfig.preferences.environmental_measurement_plugin_update_interval = 30;
-    radioConfig.preferences.environmental_measurement_plugin_recovery_interval = 600;*/
+    radioConfig.preferences.environmental_measurement_plugin_recovery_interval = 600;
 
     if (!radioConfig.preferences.environmental_measurement_plugin_enabled){
         // If this plugin is not enabled, don't waste any OSThread time on it

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -28,7 +28,7 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
 #ifndef NO_ESP32
     if (firstTime) {
         // This is the first time the OSThread library has called this function, so do some setup
-        DEBUG_MSG("Initializing Environmental Measurement Plugin -- Sender\n");
+        DEBUG_MSG("EnvironmentalMeasurement: Initializing as sender\n");
         environmentalMeasurementPluginRadio = new EnvironmentalMeasurementPluginRadio();
         firstTime = 0;
         // begin reading measurements from the sensor
@@ -45,11 +45,11 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
         // so just do what we intend to do on the interval
         if(sensor_read_error_count > SENSOR_READ_ERROR_COUNT_THRESHOLD)
         {
-            DEBUG_MSG("Environmental Measurement Plugin: DISABLED; The SENSOR_READ_ERROR_COUNT_THRESHOLD has been exceed: %d\n",SENSOR_READ_ERROR_COUNT_THRESHOLD);
-            return(DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);  
+            DEBUG_MSG("EEnvironmentalMeasurement: DISABLED; The SENSOR_READ_ERROR_COUNT_THRESHOLD has been exceed: %d\n",SENSOR_READ_ERROR_COUNT_THRESHOLD);
+            return(FAILED_STATE_SENSOR_READ_MULTIPLIER * DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);  
         }
         else if (sensor_read_error_count > 0){
-            DEBUG_MSG("Environmental Measurement Plugin: There have been %d sensor read failures.\n",sensor_read_error_count);
+            DEBUG_MSG("EnvironmentalMeasurement: There have been %d sensor read failures.\n",sensor_read_error_count);
         }
         if (! environmentalMeasurementPluginRadio->sendOurEnvironmentalMeasurement() ){
             // if we failed to read the sensor, then try again 
@@ -80,13 +80,13 @@ bool EnvironmentalMeasurementPluginRadio::sendOurEnvironmentalMeasurement(NodeNu
 
     DEBUG_MSG("-----------------------------------------\n");
 
-    DEBUG_MSG("Environmental Measurement Plugin: Read data\n");
+    DEBUG_MSG("EnvironmentalMeasurement: Read data\n");
     DEBUG_MSG("EnvironmentalMeasurement->relative_humidity: %f\n", m.relative_humidity);
     DEBUG_MSG("EnvironmentalMeasurement->temperature: %f\n", m.temperature);
 
     if (isnan(m.relative_humidity) || isnan(m.temperature) ){
         sensor_read_error_count++;
-        DEBUG_MSG("Environmental Measurement Plugin: FAILED TO READ DATA\n");
+        DEBUG_MSG("EnvironmentalMeasurement: FAILED TO READ DATA\n");
         return false;
     }
 

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -49,10 +49,10 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
         Uncomment the preferences below if you want to use the plugin
         without having to configure it from the PythonAPI or WebUI.
     */
-    radioConfig.preferences.environmental_measurement_plugin_enabled = 1;
+    /*radioConfig.preferences.environmental_measurement_plugin_enabled = 1;
     radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold = 5;
     radioConfig.preferences.environmental_measurement_plugin_update_interval = 30;
-    radioConfig.preferences.environmental_measurement_plugin_recovery_interval = 600;
+    radioConfig.preferences.environmental_measurement_plugin_recovery_interval = 600;*/
 
     if (!radioConfig.preferences.environmental_measurement_plugin_enabled){
         // If this plugin is not enabled, don't waste any OSThread time on it

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -18,11 +18,7 @@ EnvironmentalMeasurementPlugin::EnvironmentalMeasurementPlugin() : concurrency::
 uint32_t sensor_read_error_count = 0;
 
 #define DHT_11_GPIO_PIN 13
-//TODO: Make a related radioconfig preference to allow less-frequent reads
-#define ENVIRONMENTAL_MEASUREMENT_APP_ENABLED true // DISABLED by default; set this to true if you want to use the plugin
-#define DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS 1000
-#define SENSOR_READ_ERROR_COUNT_THRESHOLD 5
-#define SENSOR_READ_MULTIPLIER 3
+#define DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS 1000 // Some sensors (the DHT11) have a minimum required duration between read attempts
 #define FAILED_STATE_SENSOR_READ_MULTIPLIER 10
 #define DISPLAY_RECEIVEID_MEASUREMENTS_ON_SCREEN true
 
@@ -47,11 +43,22 @@ DHT dht(DHT_11_GPIO_PIN,DHT11);
 
 
 int32_t EnvironmentalMeasurementPlugin::runOnce() {
-#ifndef NO_ESP32
-    if (!ENVIRONMENTAL_MEASUREMENT_APP_ENABLED){
+#ifndef NO_ESP32 // this only works on ESP32 devices
+
+    /*
+        Uncomment the preferences below if you want to use the plugin
+        without having to configure it from the PythonAPI or WebUI.
+    */
+    /*radioConfig.preferences.environmental_measurement_plugin_enabled = 1;
+    radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold = 5;
+    radioConfig.preferences.environmental_measurement_plugin_update_interval = 30;
+    radioConfig.preferences.environmental_measurement_plugin_recovery_interval = 600;*/
+
+    if (!radioConfig.preferences.environmental_measurement_plugin_enabled){
         // If this plugin is not enabled, don't waste any OSThread time on it
         return (INT32_MAX);
     }
+
     if (firstTime) {
         // This is the first time the OSThread library has called this function, so do some setup
         DEBUG_MSG("EnvironmentalMeasurement: Initializing as sender\n");
@@ -69,13 +76,26 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
     else {
         // this is not the first time OSThread library has called this function
         // so just do what we intend to do on the interval
-        if(sensor_read_error_count > SENSOR_READ_ERROR_COUNT_THRESHOLD)
+        if(sensor_read_error_count > radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold)
         {
-            DEBUG_MSG("EnvironmentalMeasurement: DISABLED; The SENSOR_READ_ERROR_COUNT_THRESHOLD has been exceed: %d\n",SENSOR_READ_ERROR_COUNT_THRESHOLD);
-            return(FAILED_STATE_SENSOR_READ_MULTIPLIER * DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);  
+            if (radioConfig.preferences.environmental_measurement_plugin_recovery_interval > 0 ) {
+                DEBUG_MSG(
+                    "EnvironmentalMeasurement: TEMPORARILY DISABLED; The environmental_measurement_plugin_read_error_count_threshold has been exceed: %d. Will retry reads in %d seconds\n",
+                    radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold,
+                    radioConfig.preferences.environmental_measurement_plugin_recovery_interval);
+                return(radioConfig.preferences.environmental_measurement_plugin_recovery_interval*1000);  
+            }
+             DEBUG_MSG(
+                    "EnvironmentalMeasurement: DISABLED; The environmental_measurement_plugin_read_error_count_threshold has been exceed: %d. Reads will not be retried until after device reset\n",
+                    radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold);
+                return(INT32_MAX);
+
+            
         }
         else if (sensor_read_error_count > 0){
-            DEBUG_MSG("EnvironmentalMeasurement: There have been %d sensor read failures.\n",sensor_read_error_count);
+            DEBUG_MSG("EnvironmentalMeasurement: There have been %d sensor read failures. Will retry %d more times\n", 
+                sensor_read_error_count, 
+                radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold-sensor_read_error_count);
         }
         if (! environmentalMeasurementPluginRadio->sendOurEnvironmentalMeasurement() ){
             // if we failed to read the sensor, then try again 
@@ -85,8 +105,8 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
     }
     // The return of runOnce is an int32 representing the desired number of 
     // miliseconds until the function should be called again by the 
-    // OSThread library.
-    return(SENSOR_READ_MULTIPLIER * DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);   
+    // OSThread library.  Multiply the preference value by 1000 to convert seconds to miliseconds
+    return(radioConfig.preferences.environmental_measurement_plugin_update_interval * 1000);   
 #endif
 }
 
@@ -114,7 +134,7 @@ String GetSenderName(const MeshPacket &mp) {
 
 bool EnvironmentalMeasurementPluginRadio::handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement &p)
 {
-    if (!ENVIRONMENTAL_MEASUREMENT_APP_ENABLED){
+    if (!radioConfig.preferences.environmental_measurement_plugin_enabled){
         // If this plugin is not enabled, don't handle the packet, and allow other plugins to consume 
          return false;
     }

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -17,6 +17,7 @@ uint32_t sensor_read_error_count = 0;
 
 #define DHT_11_GPIO_PIN 13
 //TODO: Make a related radioconfig preference to allow less-frequent reads
+#define ENVIRONMENTAL_MEASUREMENT_APP_ENABLED false // DISABLED by default; set this to true if you want to use the plugin
 #define DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS 1000
 #define SENSOR_READ_ERROR_COUNT_THRESHOLD 5
 #define SENSOR_READ_MULTIPLIER 3
@@ -27,6 +28,10 @@ DHT dht(DHT_11_GPIO_PIN,DHT11);
 
 int32_t EnvironmentalMeasurementPlugin::runOnce() {
 #ifndef NO_ESP32
+    if (!ENVIRONMENTAL_MEASUREMENT_APP_ENABLED){
+        // If this plugin is not enabled, don't waste any OSThread time on it
+        return (INT32_MAX);
+    }
     if (firstTime) {
         // This is the first time the OSThread library has called this function, so do some setup
         DEBUG_MSG("EnvironmentalMeasurement: Initializing as sender\n");
@@ -67,6 +72,10 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
 
 bool EnvironmentalMeasurementPluginRadio::handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement &p)
 {
+    if (!ENVIRONMENTAL_MEASUREMENT_APP_ENABLED){
+        // If this plugin is not enabled, don't handle the packet, and allow other plugins to consume 
+         return false;
+    }
     bool wasBroadcast = mp.to == NODENUM_BROADCAST;
     String sender;
     

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -71,7 +71,7 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
         // so just do what we intend to do on the interval
         if(sensor_read_error_count > SENSOR_READ_ERROR_COUNT_THRESHOLD)
         {
-            DEBUG_MSG("EEnvironmentalMeasurement: DISABLED; The SENSOR_READ_ERROR_COUNT_THRESHOLD has been exceed: %d\n",SENSOR_READ_ERROR_COUNT_THRESHOLD);
+            DEBUG_MSG("EnvironmentalMeasurement: DISABLED; The SENSOR_READ_ERROR_COUNT_THRESHOLD has been exceed: %d\n",SENSOR_READ_ERROR_COUNT_THRESHOLD);
             return(FAILED_STATE_SENSOR_READ_MULTIPLIER * DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);  
         }
         else if (sensor_read_error_count > 0){

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
@@ -44,9 +44,7 @@ class EnvironmentalMeasurementPluginRadio : public ProtobufPlugin<EnvironmentalM
     */
     virtual bool handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement &p);
 
-    virtual bool wantUIFrame() {
-      return true;
-    }
+    virtual bool wantUIFrame();
 
 
   private:

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "ProtobufPlugin.h"
 #include "../mesh/generated/environmental_measurement.pb.h"
+#include <OLEDDisplay.h>
+#include <OLEDDisplayUi.h>
 
 
 class EnvironmentalMeasurementPlugin : private concurrency::OSThread
@@ -31,6 +33,8 @@ class EnvironmentalMeasurementPluginRadio : public ProtobufPlugin<EnvironmentalM
      * Send our EnvironmentalMeasurement into the mesh
      */
     bool sendOurEnvironmentalMeasurement(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false);
+    
+    virtual void drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
 
   protected:
     
@@ -39,6 +43,17 @@ class EnvironmentalMeasurementPluginRadio : public ProtobufPlugin<EnvironmentalM
     @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
     virtual bool handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement &p);
+
+    virtual bool wantUIFrame() {
+      return true;
+    }
+
+
+  private:
+  
+    EnvironmentalMeasurement lastMeasurement;
+
+    String lastSender;
 
 };
 

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
@@ -27,7 +27,12 @@ class EnvironmentalMeasurementPluginRadio : public ProtobufPlugin<EnvironmentalM
     /** Constructor
      * name is for debugging output
      */
-    EnvironmentalMeasurementPluginRadio() : ProtobufPlugin("EnvironmentalMeasurement", PortNum_ENVIRONMENTAL_MEASUREMENT_APP, &EnvironmentalMeasurement_msg) {}
+    EnvironmentalMeasurementPluginRadio() : ProtobufPlugin("EnvironmentalMeasurement", PortNum_ENVIRONMENTAL_MEASUREMENT_APP, &EnvironmentalMeasurement_msg) {
+      lastMeasurement.barometric_pressure = nanf("");
+      lastMeasurement.relative_humidity =  nanf("");
+      lastMeasurement.temperature =  nanf("");
+      lastSender = "N/A";
+    }
 
     /**
      * Send our EnvironmentalMeasurement into the mesh


### PR DESCRIPTION
Adds a custom UI Frame to display environment details.

![image](https://user-images.githubusercontent.com/11679900/108640021-6e8a2c00-7465-11eb-9c64-d3151e889c38.png)


https://user-images.githubusercontent.com/11679900/108791075-3a3d6b00-754c-11eb-99ae-75954dc4d6b8.mp4


Plugins may be allocated their own frame by overriding in their header:
```
 virtual bool wantUIFrame() { return true; }
 ```

When this is defined, the UI will call the plugin's `drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);` method


Known bugs:
Receiving a text message will drop you to the 0th UI Frame; which used to be the text message frame, but is now the environment frame