### PR TITLE
make notifications frame indicators bounce on text message

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -68,7 +68,7 @@ debug_tool = jlink
 ;  monitor adapter_khz 10000
 
 lib_deps =
-  https://github.com/meshtastic/esp8266-oled-ssd1306.git#35d796226b853b0c0ff818b2f1aa3d35e7296a96 ; ESP8266_SSD1306 
+  https://github.com/meshtastic/esp8266-oled-ssd1306.git#4e724c42f22effdcaa7cdc707a6dceaf9fc10383 ; ESP8266_SSD1306 
   https://github.com/geeksville/OneButton.git ; OneButton library for non-blocking button debounce
   1202 ; CRC32, explicitly needed because dependency is missing in the ble ota update lib
   https://github.com/meshtastic/arduino-fsm.git#2f106146071fc7bc620e1e8d4b88dc4e0266ce39

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,7 +68,7 @@ debug_tool = jlink
 ;  monitor adapter_khz 10000
 
 lib_deps =
-  https://github.com/meshtastic/esp8266-oled-ssd1306.git#4e724c42f22effdcaa7cdc707a6dceaf9fc10383 ; ESP8266_SSD1306 
+  https://github.com/meshtastic/esp8266-oled-ssd1306.git#22c7eef2025431ba5e1f5f8bd1720cfdcc49cadc ; ESP8266_SSD1306 
   https://github.com/geeksville/OneButton.git ; OneButton library for non-blocking button debounce
   1202 ; CRC32, explicitly needed because dependency is missing in the ble ota update lib
   https://github.com/meshtastic/arduino-fsm.git#2f106146071fc7bc620e1e8d4b88dc4e0266ce39

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1366,9 +1366,16 @@ int Screen::handleTextMessage(const MeshPacket *arg)
     
     return 0;
 }
+bool Screen::goToNextNotification() {
+    uint32_t frame = ui.getFirstNotifyingFrame();
+    if (frame == -1) {
+        return false;
+    }
+    ui.switchToFrame(frame);
+}
 
-void Screen::goToNextNotificaiton() {
-    ui.switchToFrame(ui.getFirstNotifyingFrame());
+void Screen::goToFirstUIFrame() {
+    ui.switchToFrame(0);
 }
 
 } // namespace graphics

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1352,8 +1352,7 @@ int Screen::handleTextMessage(const MeshPacket *arg)
     // let's use an instance variable to track which UI frame is for text messages.
     // TODO: Move the text messages display UI to a plugin 
     // so we can get it out of Screen.cpp
-    std::vector<uint32_t> textFrames = {textMessageFrame};
-    ui.setFrameNotifications(textFrames);
+    ui.addFrameToNotifications(textMessageFrame);
     
     return 0;
 }

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -56,6 +56,7 @@ namespace graphics
 
 // A text message frame + debug frame + all the node infos
 static FrameCallback normalFrames[MAX_NUM_NODES + NUM_EXTRA_FRAMES];
+static FrameNotificationCallback notificationCallback;
 static uint32_t targetFramerate = IDLE_FRAMERATE;
 static char btPIN[16] = "888888";
 
@@ -134,6 +135,12 @@ static void drawIconScreen(const char *upperMsg, OLEDDisplay *display, OLEDDispl
     screen->forceDisplay();
 
     // FIXME - draw serial # somewhere?
+}
+
+static void handleFrameNotificationCallback(uint32_t FrameNumber, void* UI) {
+    //DEBUG_MSG("SCREEN: Received notification that frame %d is active", FrameNumber);
+    OLEDDisplayUi* ui = reinterpret_cast<OLEDDisplayUi *>(UI);
+    ui->removeFrameFromNotifications(FrameNumber);
 }
 
 static void drawBootScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
@@ -969,6 +976,9 @@ void Screen::setFrames()
     DEBUG_MSG("Finished building frames. numframes: %d\n", numframes);
 
     ui.setFrames(normalFrames, numframes);
+
+    notificationCallback = handleFrameNotificationCallback;
+    ui.setFrameNotificationCallback(&notificationCallback);
     ui.enableAllIndicators();
 
     prevFrame = -1; // Force drawNodeInfo to pick a new node (because our list

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -196,7 +196,8 @@ class Screen : public concurrency::OSThread
 
     int handleStatusUpdate(const meshtastic::Status *arg);
     int handleTextMessage(const MeshPacket *arg);
-    void goToNextNotificaiton();
+    bool goToNextNotification();
+    void goToFirstUIFrame();
 
     /// Used to force (super slow) eink displays to draw critical frames
     void forceDisplay();

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -196,6 +196,7 @@ class Screen : public concurrency::OSThread
 
     int handleStatusUpdate(const meshtastic::Status *arg);
     int handleTextMessage(const MeshPacket *arg);
+    void goToNextNotificaiton();
 
     /// Used to force (super slow) eink displays to draw critical frames
     void forceDisplay();
@@ -246,6 +247,8 @@ class Screen : public concurrency::OSThread
     static void drawDebugInfoSettingsTrampoline(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
 
     static void drawDebugInfoWiFiTrampoline(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
+
+    uint32_t textMessageFrame;
 
     /// Queue of commands to execute in doTask.
     TypedQueue<ScreenCmd> cmdQueue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -252,6 +252,7 @@ class ButtonThread : public OSThread
     {
 #ifndef NO_ESP32
         disablePin();
+        screen->goToNextNotificaiton();
 #endif
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -252,7 +252,9 @@ class ButtonThread : public OSThread
     {
 #ifndef NO_ESP32
         disablePin();
-        screen->goToNextNotificaiton();
+        if (!screen->goToNextNotification()) {
+            screen->goToFirstUIFrame();
+        }
 #endif
     }
 


### PR DESCRIPTION


Update the UI frame symbols on the bottom of the OLED to "bounce" if that frame has a notification (currently only works with the text messages).

Double-pressing the user button takes you to the first screen with active notifications.

Opening a screen with an active notification "acknowledges" the notification, and causes bouncing to stop.

https://user-images.githubusercontent.com/11679900/109587749-9a488a00-7ad5-11eb-9bdb-f03f134f0eaa.mp4



Double-pressing the user button when there are no active notifications takes you to the first screen

Depends on: https://github.com/meshtastic/esp8266-oled-ssd1306/pull/3