### PR TITLE
Improvements to Environmental Measurement Plugin

### DIFF
--- a/src/mesh/generated/admin.pb.h
+++ b/src/mesh/generated/admin.pb.h
@@ -67,7 +67,7 @@ extern const pb_msgdesc_t AdminMessage_msg;
 #define AdminMessage_fields &AdminMessage_msg
 
 /* Maximum encoded size of messages (where known) */
-#define AdminMessage_size                        338
+#define AdminMessage_size                        351
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/deviceonly.pb.h
+++ b/src/mesh/generated/deviceonly.pb.h
@@ -82,7 +82,7 @@ extern const pb_msgdesc_t DeviceState_msg;
 #define DeviceState_fields &DeviceState_msg
 
 /* Maximum encoded size of messages (where known) */
-#define DeviceState_size                         6156
+#define DeviceState_size                         6169
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/portnums.pb.h
+++ b/src/mesh/generated/portnums.pb.h
@@ -20,10 +20,10 @@ typedef enum _PortNum {
     PortNum_ADMIN_APP = 6,
     PortNum_REPLY_APP = 32,
     PortNum_IP_TUNNEL_APP = 33,
-    PortNum_ENVIRONMENTAL_MEASUREMENT_APP = 34,
     PortNum_SERIAL_APP = 64,
     PortNum_STORE_FORWARD_APP = 65,
     PortNum_RANGE_TEST_APP = 66,
+    PortNum_ENVIRONMENTAL_MEASUREMENT_APP = 67,
     PortNum_PRIVATE_APP = 256,
     PortNum_ATAK_FORWARDER = 257,
     PortNum_MAX = 511

--- a/src/mesh/generated/radioconfig.pb.c
+++ b/src/mesh/generated/radioconfig.pb.c
@@ -17,3 +17,4 @@ PB_BIND(RadioConfig_UserPreferences, RadioConfig_UserPreferences, 2)
 
 
 
+

--- a/src/mesh/generated/radioconfig.pb.h
+++ b/src/mesh/generated/radioconfig.pb.h
@@ -56,6 +56,10 @@ typedef enum _LocationSharing {
     LocationSharing_LocDisabled = 2
 } LocationSharing;
 
+typedef enum _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType {
+    RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11 = 0
+} RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType;
+
 /* Struct definitions */
 typedef struct _RadioConfig_UserPreferences {
     uint32_t position_broadcast_secs;
@@ -106,6 +110,9 @@ typedef struct _RadioConfig_UserPreferences {
     uint32_t environmental_measurement_plugin_read_error_count_threshold;
     uint32_t environmental_measurement_plugin_update_interval;
     uint32_t environmental_measurement_plugin_recovery_interval;
+    bool environmental_measurement_plugin_display_farenheit;
+    RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType environmental_measurement_plugin_sensor_type;
+    uint32_t environmental_measurement_plugin_sensor_pin;
 } RadioConfig_UserPreferences;
 
 typedef struct _RadioConfig {
@@ -131,6 +138,10 @@ typedef struct _RadioConfig {
 #define _LocationSharing_MAX LocationSharing_LocDisabled
 #define _LocationSharing_ARRAYSIZE ((LocationSharing)(LocationSharing_LocDisabled+1))
 
+#define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11
+#define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MAX RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11
+#define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_ARRAYSIZE ((RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType)(RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11+1))
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -138,9 +149,9 @@ extern "C" {
 
 /* Initializer values for message structs */
 #define RadioConfig_init_default                 {false, RadioConfig_UserPreferences_init_default}
-#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0}
 #define RadioConfig_init_zero                    {false, RadioConfig_UserPreferences_init_zero}
-#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define RadioConfig_UserPreferences_position_broadcast_secs_tag 1
@@ -190,6 +201,9 @@ extern "C" {
 #define RadioConfig_UserPreferences_environmental_measurement_plugin_read_error_count_threshold_tag 142
 #define RadioConfig_UserPreferences_environmental_measurement_plugin_update_interval_tag 143
 #define RadioConfig_UserPreferences_environmental_measurement_plugin_recovery_interval_tag 144
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_display_farenheit_tag 145
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_sensor_type_tag 146
+#define RadioConfig_UserPreferences_environmental_measurement_plugin_sensor_pin_tag 147
 #define RadioConfig_preferences_tag              1
 
 /* Struct field encoding specification for nanopb */
@@ -246,7 +260,10 @@ X(a, STATIC,   SINGULAR, BOOL,     environmental_measurement_plugin_measurement_
 X(a, STATIC,   SINGULAR, BOOL,     environmental_measurement_plugin_screen_enabled, 141) \
 X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_read_error_count_threshold, 142) \
 X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_update_interval, 143) \
-X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_recovery_interval, 144)
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_recovery_interval, 144) \
+X(a, STATIC,   SINGULAR, BOOL,     environmental_measurement_plugin_display_farenheit, 145) \
+X(a, STATIC,   SINGULAR, UENUM,    environmental_measurement_plugin_sensor_type, 146) \
+X(a, STATIC,   SINGULAR, UINT32,   environmental_measurement_plugin_sensor_pin, 147)
 #define RadioConfig_UserPreferences_CALLBACK NULL
 #define RadioConfig_UserPreferences_DEFAULT NULL
 
@@ -258,8 +275,8 @@ extern const pb_msgdesc_t RadioConfig_UserPreferences_msg;
 #define RadioConfig_UserPreferences_fields &RadioConfig_UserPreferences_msg
 
 /* Maximum encoded size of messages (where known) */
-#define RadioConfig_size                         335
-#define RadioConfig_UserPreferences_size         332
+#define RadioConfig_size                         348
+#define RadioConfig_UserPreferences_size         345
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -10,19 +10,9 @@
 #include <OLEDDisplay.h>
 #include <OLEDDisplayUi.h>
 
-EnvironmentalMeasurementPlugin *environmentalMeasurementPlugin;
-EnvironmentalMeasurementPluginRadio *environmentalMeasurementPluginRadio;
-
-EnvironmentalMeasurementPlugin::EnvironmentalMeasurementPlugin() : concurrency::OSThread("EnvironmentalMeasurementPlugin") {}
-
-uint32_t sensor_read_error_count = 0;
-
-#define DHT_11_GPIO_PIN 13
 #define DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS 1000 // Some sensors (the DHT11) have a minimum required duration between read attempts
 #define FAILED_STATE_SENSOR_READ_MULTIPLIER 10
 #define DISPLAY_RECEIVEID_MEASUREMENTS_ON_SCREEN true
-
-DHT dht(DHT_11_GPIO_PIN,DHT11);
 
 
 #ifdef HAS_EINK
@@ -49,12 +39,15 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
         Uncomment the preferences below if you want to use the plugin
         without having to configure it from the PythonAPI or WebUI.
     */
+   
     /*radioConfig.preferences.environmental_measurement_plugin_measurement_enabled = 1;
     radioConfig.preferences.environmental_measurement_plugin_screen_enabled = 1;
     radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold = 5;
     radioConfig.preferences.environmental_measurement_plugin_update_interval = 30;
     radioConfig.preferences.environmental_measurement_plugin_recovery_interval = 60;
-    radioConfig.preferences.environmental_measurement_plugin_display_farenheit = true;*/
+    radioConfig.preferences.environmental_measurement_plugin_display_farenheit = true;
+    radioConfig.preferences.environmental_measurement_plugin_sensor_pin = 13;
+    radioConfig.preferences.environmental_measurement_plugin_sensor_type = RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType::RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11;*/
 
     if (! (radioConfig.preferences.environmental_measurement_plugin_measurement_enabled || radioConfig.preferences.environmental_measurement_plugin_screen_enabled)){
         // If this plugin is not enabled, and the user doesn't want the display screen don't waste any OSThread time on it
@@ -63,20 +56,32 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
 
     if (firstTime) {
         // This is the first time the OSThread library has called this function, so do some setup
-        DEBUG_MSG("EnvironmentalMeasurement: Initializing\n");
-        environmentalMeasurementPluginRadio = new EnvironmentalMeasurementPluginRadio();
+       
         firstTime = 0;
-        // begin reading measurements from the sensor
-        // DHT have a max read-rate of 1HZ, so we should wait at least 1 second
-        // after initializing the sensor before we try to read from it.
-        // returning the interval here means that the next time OSThread
-        // calls our plugin, we'll run the other branch of this if statement
-        // and actually do a "sendOurEnvironmentalMeasurement()"
+       
         if (radioConfig.preferences.environmental_measurement_plugin_measurement_enabled)
         {
+            DEBUG_MSG("EnvironmentalMeasurement: Initializing\n");
             // it's possible to have this plugin enabled, only for displaying values on the screen.
             // therefore, we should only enable the sensor loop if measurement is also enabled
-            dht.begin();
+            switch(radioConfig.preferences.environmental_measurement_plugin_sensor_type) {
+                case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11:
+                    dht = new DHT(radioConfig.preferences.environmental_measurement_plugin_sensor_pin,DHT11);
+                    this->dht->begin();
+                    this->dht->read();
+                    DEBUG_MSG("EnvironmentalMeasurement: Opened DHT11 on pin: %d\n",radioConfig.preferences.environmental_measurement_plugin_sensor_pin);
+                break;
+                default:
+                    DEBUG_MSG("EnvironmentalMeasurement: Invalid sensor type selected; Disabling plugin");
+                    return (INT32_MAX);
+                    break;
+            }
+            // begin reading measurements from the sensor
+            // DHT have a max read-rate of 1HZ, so we should wait at least 1 second
+            // after initializing the sensor before we try to read from it.
+            // returning the interval here means that the next time OSThread
+            // calls our plugin, we'll run the other branch of this if statement
+            // and actually do a "sendOurEnvironmentalMeasurement()"
             return(DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);   
         }
         return (INT32_MAX);
@@ -112,7 +117,7 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
                 sensor_read_error_count, 
                 radioConfig.preferences.environmental_measurement_plugin_read_error_count_threshold-sensor_read_error_count);
         }
-        if (! environmentalMeasurementPluginRadio->sendOurEnvironmentalMeasurement() ){
+        if (!sendOurEnvironmentalMeasurement() ){
             // if we failed to read the sensor, then try again 
             // as soon as we can according to the maximum polling frequency
             return(DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
@@ -125,7 +130,7 @@ int32_t EnvironmentalMeasurementPlugin::runOnce() {
 #endif
 }
 
-bool EnvironmentalMeasurementPluginRadio::wantUIFrame() {
+bool EnvironmentalMeasurementPlugin::wantUIFrame() {
     return radioConfig.preferences.environmental_measurement_plugin_screen_enabled;
 }
 
@@ -154,12 +159,12 @@ uint32_t GetTimeSinceMeshPacket(const MeshPacket *mp) {
 }
 
 
-float CelsiusToFarenheit(float c) {
+float EnvironmentalMeasurementPlugin::CelsiusToFarenheit(float c) {
     return (c*9)/5 + 32;
 }
 
 
-void EnvironmentalMeasurementPluginRadio::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
+void EnvironmentalMeasurementPlugin::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
     display->setTextAlignment(TEXT_ALIGN_LEFT);
     display->setFont(FONT_MEDIUM);
@@ -167,7 +172,7 @@ void EnvironmentalMeasurementPluginRadio::drawFrame(OLEDDisplay *display, OLEDDi
     if (lastMeasurementPacket == nullptr) {
         display->setFont(FONT_SMALL);
         display->drawString(x, y += fontHeight(FONT_MEDIUM), "No measurement");
-        DEBUG_MSG("EnvironmentalMeasurement: No previous measurement; not drawing frame");
+        //DEBUG_MSG("EnvironmentalMeasurement: No previous measurement; not drawing frame\n");
         return;
     }
 
@@ -177,7 +182,7 @@ void EnvironmentalMeasurementPluginRadio::drawFrame(OLEDDisplay *display, OLEDDi
     uint32_t agoSecs = GetTimeSinceMeshPacket(lastMeasurementPacket);
     String lastSender = GetSenderName(*lastMeasurementPacket);
 
-    auto &p = lastMeasurementPacket->decoded.data;
+    auto &p = lastMeasurementPacket->decoded;
     if (!pb_decode_from_bytes(p.payload.bytes, 
             p.payload.size,
             EnvironmentalMeasurement_fields, 
@@ -198,37 +203,25 @@ void EnvironmentalMeasurementPluginRadio::drawFrame(OLEDDisplay *display, OLEDDi
 
 }
 
-bool EnvironmentalMeasurementPluginRadio::handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement &p)
+bool EnvironmentalMeasurementPlugin::handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement *p)
 {
-    const EnvironmentalMeasurement &p = *pptr;
-    
     if (!(radioConfig.preferences.environmental_measurement_plugin_measurement_enabled || radioConfig.preferences.environmental_measurement_plugin_screen_enabled)){
         // If this plugin is not enabled in any capacity, don't handle the packet, and allow other plugins to consume 
          return false;
     }
-    bool wasBroadcast = mp.to == NODENUM_BROADCAST;
 
     String sender = GetSenderName(mp);
-    
-    // Show new nodes on LCD screen
-    if (DISPLAY_RECEIVEID_MEASUREMENTS_ON_SCREEN && wasBroadcast) {
-        String lcd = String("Env Measured: ") +sender + "\n" +
-            "T: " + p.temperature + "\n" +
-            "H: " + p.relative_humidity + "\n";
-        screen->print(lcd.c_str());
-    }
-    DEBUG_MSG("-----------------------------------------\n");
 
     DEBUG_MSG("EnvironmentalMeasurement: Received data from %s\n", sender);
-    DEBUG_MSG("EnvironmentalMeasurement->relative_humidity: %f\n", p.relative_humidity);
-    DEBUG_MSG("EnvironmentalMeasurement->temperature: %f\n", p.temperature);
+    DEBUG_MSG("EnvironmentalMeasurement->relative_humidity: %f\n", p->relative_humidity);
+    DEBUG_MSG("EnvironmentalMeasurement->temperature: %f\n", p->temperature);
 
     lastMeasurementPacket = packetPool.allocCopy(mp);
 
     return false; // Let others look at this message also if they want
 }
 
-bool EnvironmentalMeasurementPluginRadio::sendOurEnvironmentalMeasurement(NodeNum dest, bool wantReplies)
+bool EnvironmentalMeasurementPlugin::sendOurEnvironmentalMeasurement(NodeNum dest, bool wantReplies)
 {
     EnvironmentalMeasurement m;
 
@@ -236,13 +229,13 @@ bool EnvironmentalMeasurementPluginRadio::sendOurEnvironmentalMeasurement(NodeNu
     DEBUG_MSG("-----------------------------------------\n");
 
     DEBUG_MSG("EnvironmentalMeasurement: Read data\n");
-    if (!dht.read(true)){
+    if (!this->dht->read(true)){
         sensor_read_error_count++;
         DEBUG_MSG("EnvironmentalMeasurement: FAILED TO READ DATA\n");
         return false;
     }
-    m.relative_humidity = dht.readHumidity();
-    m.temperature = dht.readTemperature();
+    m.relative_humidity = this->dht->readHumidity();
+    m.temperature = this->dht->readTemperature();
 
     DEBUG_MSG("EnvironmentalMeasurement->relative_humidity: %f\n", m.relative_humidity);
     DEBUG_MSG("EnvironmentalMeasurement->temperature: %f\n", m.temperature);

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
@@ -3,56 +3,32 @@
 #include "../mesh/generated/environmental_measurement.pb.h"
 #include <OLEDDisplay.h>
 #include <OLEDDisplayUi.h>
+#include <DHT.h>
 
-
-class EnvironmentalMeasurementPlugin : private concurrency::OSThread
-{
-    bool firstTime = 1;
-
-  public:
-    EnvironmentalMeasurementPlugin();
-
-  protected:
-    virtual int32_t runOnce();
-};
-
-extern EnvironmentalMeasurementPlugin *environmentalMeasurementPlugin;
-
-/**
- * EnvironmentalMeasurementPluginRadio plugin for sending/receiving environmental measurements to/from the mesh
- */
-class EnvironmentalMeasurementPluginRadio : public ProtobufPlugin<EnvironmentalMeasurement>
+class EnvironmentalMeasurementPlugin : private concurrency::OSThread, public ProtobufPlugin<EnvironmentalMeasurement>
 {
   public:
-    /** Constructor
-     * name is for debugging output
-     */
-    EnvironmentalMeasurementPluginRadio() : ProtobufPlugin("EnvironmentalMeasurement", PortNum_ENVIRONMENTAL_MEASUREMENT_APP, &EnvironmentalMeasurement_msg) { 
+    EnvironmentalMeasurementPlugin(): concurrency::OSThread("EnvironmentalMeasurementPlugin"), ProtobufPlugin("EnvironmentalMeasurement", PortNum_ENVIRONMENTAL_MEASUREMENT_APP, &EnvironmentalMeasurement_msg) { 
       lastMeasurementPacket = nullptr;
     }
+    virtual bool wantUIFrame();
+    virtual void drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
 
+  protected:
+    /** Called to handle a particular incoming message
+    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    */
+    virtual bool handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement *p);
+    virtual int32_t runOnce();
     /**
      * Send our EnvironmentalMeasurement into the mesh
      */
     bool sendOurEnvironmentalMeasurement(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false);
     
-    virtual void drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y);
-
-  protected:
-    
-    /** Called to handle a particular incoming message
-
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
-    */
-    virtual bool handleReceivedProtobuf(const MeshPacket &mp, const EnvironmentalMeasurement *p);
-
-    virtual bool wantUIFrame();
-
-
   private:
-  
+    float CelsiusToFarenheit(float c);
+    bool firstTime = 1;
+    DHT* dht;
     const MeshPacket *lastMeasurementPacket;
-
+    uint32_t sensor_read_error_count = 0;
 };
-
-extern EnvironmentalMeasurementPluginRadio *environmentalMeasurementPluginRadio;

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.h
@@ -27,11 +27,8 @@ class EnvironmentalMeasurementPluginRadio : public ProtobufPlugin<EnvironmentalM
     /** Constructor
      * name is for debugging output
      */
-    EnvironmentalMeasurementPluginRadio() : ProtobufPlugin("EnvironmentalMeasurement", PortNum_ENVIRONMENTAL_MEASUREMENT_APP, &EnvironmentalMeasurement_msg) {
-      lastMeasurement.barometric_pressure = nanf("");
-      lastMeasurement.relative_humidity =  nanf("");
-      lastMeasurement.temperature =  nanf("");
-      lastSender = "N/A";
+    EnvironmentalMeasurementPluginRadio() : ProtobufPlugin("EnvironmentalMeasurement", PortNum_ENVIRONMENTAL_MEASUREMENT_APP, &EnvironmentalMeasurement_msg) { 
+      lastMeasurementPacket = nullptr;
     }
 
     /**
@@ -54,9 +51,7 @@ class EnvironmentalMeasurementPluginRadio : public ProtobufPlugin<EnvironmentalM
 
   private:
   
-    EnvironmentalMeasurement lastMeasurement;
-
-    String lastSender;
+    const MeshPacket *lastMeasurementPacket;
 
 };
 


### PR DESCRIPTION
Refactor the Environmental Measurement plugin

Add new protobufs for UserPreferences to set the sensor GPIO pin and Sensor type and display units.

Refactor the plugin to be a single class with multiple inheritance

Address comments by @mc-hamster from slack

Depends on https://github.com/meshtastic/Meshtastic-protobufs/pull/16