### PR TITLE
Add option to set python interpreter used for device-install.sh scripts

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -1,21 +1,24 @@
 #!/bin/sh
 
+PYTHON=${PYTHON:-python}
+
 set -e
 
 # Usage info
 show_help() {
 cat << EOF
-Usage: ${0##*/} [-h] [-p ESPTOOL_PORT] [-f FILENAME]
+Usage: ${0##*/} [-h] [-p ESPTOOL_PORT] [-P PYTHON] [-f FILENAME]
 Flash image file to device, but first erasing and writing system information"
 
     -h               Display this help and exit
     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerrous).
-    -f FILENAME         The .bin file to flash.  Custom to your device type and region.
+    -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: "$PYTHON")
+    -f FILENAME      The .bin file to flash.  Custom to your device type and region.
 EOF
 }
 
 
-while getopts ":h:p:f:" opt; do
+while getopts ":hp:P:f:" opt; do
     case "${opt}" in
         h)
             show_help
@@ -23,6 +26,8 @@ while getopts ":h:p:f:" opt; do
             ;;
         p)  export ESPTOOL_PORT=${OPTARG}
 	    ;;
+        P)  PYTHON=${OPTARG}
+            ;;
         f)  FILENAME=${OPTARG}
             ;;
         *)
@@ -36,10 +41,10 @@ shift "$((OPTIND-1))"
 
 if [ -f "${FILENAME}" ]; then
 	echo "Trying to flash ${FILENAME}, but first erasing and writing system information"
-	esptool.py --baud 921600 erase_flash
-	esptool.py --baud 921600 write_flash 0x1000 system-info.bin
-    esptool.py --baud 921600 write_flash 0x00390000 spiffs-*.bin
-	esptool.py --baud 921600 write_flash 0x10000 ${FILENAME}
+	$PYTHON -m esptool --baud 921600 erase_flash
+	$PYTHON -m esptool --baud 921600 write_flash 0x1000 system-info.bin
+	$PYTHON -m esptool --baud 921600 write_flash 0x00390000 spiffs-*.bin
+	$PYTHON -m esptool --baud 921600 write_flash 0x10000 ${FILENAME}
 else
 	echo "Invalid file: ${FILENAME}"
 	show_help

--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -1,19 +1,22 @@
 #!/bin/sh
 
+PYTHON=${PYTHON:-python}
+
 # Usage info
 show_help() {
 cat << EOF
-Usage: ${0##*/} [-h] [-p ESPTOOL_PORT] -f FILENAME
+Usage: ${0##*/} [-h] [-p ESPTOOL_PORT] [-P PYTHON] -f FILENAME
 Flash image file to device, leave existing system intact."
 
     -h               Display this help and exit
     -p ESPTOOL_PORT  Set the environment variable for ESPTOOL_PORT.  If not set, ESPTOOL iterates all ports (Dangerrous).
-    -f FILENAME         The .bin file to flash.  Custom to your device type and region.
+    -P PYTHON        Specify alternate python interpreter to use to invoke esptool. (Default: "$PYTHON")
+    -f FILENAME      The .bin file to flash.  Custom to your device type and region.
 EOF
 }
 
 
-while getopts ":h:p:f:" opt; do
+while getopts ":hp:P:f:" opt; do
     case "${opt}" in
         h)
             show_help
@@ -21,6 +24,8 @@ while getopts ":h:p:f:" opt; do
             ;;
         p)  export ESPTOOL_PORT=${OPTARG}
 	    ;;
+        P)  PYTHON=${OPTARG}
+            ;;
         f)  FILENAME=${OPTARG}
             ;;
         *)
@@ -34,9 +39,9 @@ shift "$((OPTIND-1))"
 
 if [ -f "${FILENAME}" ]; then
 	echo "Trying to flash update ${FILENAME}."
-	esptool.py --baud 921600 write_flash 0x10000 ${FILENAME}
+	$PYTHON -m esptool --baud 921600 write_flash 0x10000 ${FILENAME}
 	echo "Erasing the otadata partition, which will turn off flash flippy-flop and force the first image to be used"
-	esptool.py --baud 921600 erase_region 0xe000 0x2000
+	$PYTHON -m esptool --baud 921600 erase_region 0xe000 0x2000
 else
 	echo "Invalid file: ${FILENAME}"
 	show_help


### PR DESCRIPTION
If find these modifications are helpful if you have multiple pythons installed, or are using git bash from a windows system with multiple pythons.