### PR TITLE
Fix for reading battery level on RAK-4631

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -43,6 +43,7 @@ Power *power;
 
 using namespace meshtastic;
 
+#ifndef AREF_VOLTAGE
 #if defined(NRF52_SERIES)
 /*
  * Internal Reference is +/-0.6V, with an adjustable gain of 1/6, 1/5, 1/4,
@@ -56,6 +57,7 @@ using namespace meshtastic;
 #define AREF_VOLTAGE 3.6
 #else
 #define AREF_VOLTAGE 3.3
+#endif
 #endif
 
 /**
@@ -102,8 +104,12 @@ class AnalogBatteryLevel : public HasBatteryLevel
         if (millis() - last_read_time_ms > min_read_interval) {
             last_read_time_ms = millis();
             uint32_t raw = analogRead(BATTERY_PIN);
-            float scaled = 1000.0 * ADC_MULTIPLIER * (AREF_VOLTAGE / 1024.0) * raw;
-            
+            float scaled;
+            #ifndef VBAT_RAW_TO_SCALED
+            scaled = 1000.0 * ADC_MULTIPLIER * (AREF_VOLTAGE / 1024.0) * raw;
+            #else
+            scaled = VBAT_RAW_TO_SCALED(raw); //defined in variant.h
+            #endif
             // DEBUG_MSG("battery gpio %d raw val=%u scaled=%u\n", BATTERY_PIN, raw, (uint32_t)(scaled));
             last_read_value = scaled;
             return scaled;
@@ -136,7 +142,9 @@ class AnalogBatteryLevel : public HasBatteryLevel
     const float fullVolt = 4200, emptyVolt = 3270, chargingVolt = 4210, noBatVolt = 2230;
     float last_read_value = 0.0;
     uint32_t last_read_time_ms = 0;
-} analogLevel;
+};
+
+AnalogBatteryLevel analogLevel;
 
 Power::Power() : OSThread("Power") {}
 
@@ -153,11 +161,19 @@ bool Power::analogInit()
     adcAttachPin(BATTERY_PIN);
 #endif
 #ifdef NRF52_SERIES
+#ifdef VBAT_AR_INTERNAL
+     analogReference(VBAT_AR_INTERNAL);
+#else
     analogReference(AR_INTERNAL); // 3.6V
 #endif
+#endif
 
+#ifndef BATTERY_SENSE_RESOLUTION_BITS
+#define BATTERY_SENSE_RESOLUTION_BITS 10
+#endif
+    
     // adcStart(BATTERY_PIN);
-    analogReadResolution(10); // Default of 12 is not very linear. Recommended to use 10 or 11 depending on needed resolution.
+    analogReadResolution(BATTERY_SENSE_RESOLUTION_BITS); // Default of 12 is not very linear. Recommended to use 10 or 11 depending on needed resolution.
     batteryLevel = &analogLevel;
     return true;
 #else

--- a/variants/WisCore_RAK4631_Board/variant.h
+++ b/variants/WisCore_RAK4631_Board/variant.h
@@ -171,8 +171,25 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define GPS_RX_PIN PIN_SERIAL1_RX
 #define GPS_TX_PIN PIN_SERIAL1_TX
 
-// The battery sense is hooked to pin A0
+// Battery
+// The battery sense is hooked to pin A0 (5)
 #define BATTERY_PIN PIN_A0
+// and has 12 bit resolution
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define BATTERY_SENSE_RESOLUTION 4096.0
+// Definition of milliVolt per LSB => 3.0V ADC range and 12-bit ADC resolution = 3000mV/4096
+#define VBAT_MV_PER_LSB (0.73242188F)
+// Voltage divider value => 1.5M + 1M voltage divider on VBAT = (1.5M / (1M + 1.5M))
+#define VBAT_DIVIDER (0.4F)
+// Compensation factor for the VBAT divider
+#define VBAT_DIVIDER_COMP (1.73)
+// Fixed calculation of milliVolt from compensation value
+#define REAL_VBAT_MV_PER_LSB (VBAT_DIVIDER_COMP * VBAT_MV_PER_LSB)
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+#define ADC_MULTIPLIER VBAT_DIVIDER_COMP //REAL_VBAT_MV_PER_LSB
+#define VBAT_RAW_TO_SCALED(x) (REAL_VBAT_MV_PER_LSB * x)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes bug #815
Build tested on RAK4631 with battery and their solar panel box.
This is from the serial log:
17:40:30 102 [Power] Battery: usbPower=0, isCharging=0, batMv=4164, batPct=96
Note that mV reading and Pct is ok.
It does not detect being connected to USB and charging.

Also tested on TBEAM where it seems to be ok.

There still seems to be a problem with the FW for this board that it goes to
sleep for ever after running for a few hours.

