### PR TITLE
No SuperDeepSleep for RAK4631 and T-Echo

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -82,10 +82,13 @@ class AnalogBatteryLevel : public HasBatteryLevel
         if (v < noBatVolt)
             return -1; // If voltage is super low assume no battery installed
 
+#ifndef NRF52_SERIES
+        // This does not work on a RAK4631 with battery connected
         if (v > chargingVolt)
             return 0; // While charging we can't report % full on the battery
+#endif
 
-        return 100 * (v - emptyVolt) / (fullVolt - emptyVolt);
+        return clamp((int)(100 * (v - emptyVolt) / (fullVolt - emptyVolt)), 0, 100);
     }
 
     /**

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -299,6 +299,8 @@ void PowerFSM_setup()
     // On most boards we use light-sleep to be our main state, but on NRF52 we just stay in DARK
     State *lowPowerState = &stateLS;
 
+    auto meshSds = 0;
+
 #ifndef NRF52_SERIES
     // We never enter light-sleep or NB states on NRF52 (because the CPU uses so little power normally)
 
@@ -307,11 +309,12 @@ void PowerFSM_setup()
 
     powerFSM.add_timed_transition(&stateNB, &stateLS, getPref_min_wake_secs() * 1000, NULL, "Min wake timeout");
     powerFSM.add_timed_transition(&stateDARK, &stateLS, getPref_wait_bluetooth_secs() * 1000, NULL, "Bluetooth timeout");
+    meshSds = getPref_mesh_sds_timeout_secs();
 #else
     lowPowerState = &stateDARK;
+    meshSds = UINT32_MAX; //Workaround for now: Don't go into deep sleep on the RAK4631
 #endif
 
-    auto meshSds = getPref_mesh_sds_timeout_secs();
     if (meshSds != UINT32_MAX)
         powerFSM.add_timed_transition(lowPowerState, &stateSDS, meshSds * 1000, NULL, "mesh timeout");
     // removing for now, because some users don't even have phones

--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -299,7 +299,7 @@ void PowerFSM_setup()
     // On most boards we use light-sleep to be our main state, but on NRF52 we just stay in DARK
     State *lowPowerState = &stateLS;
 
-    auto meshSds = 0;
+    uint32_t meshSds = 0;
 
 #ifndef NRF52_SERIES
     // We never enter light-sleep or NB states on NRF52 (because the CPU uses so little power normally)

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -251,6 +251,26 @@ External serial flash WP25R1635FZUIL0
 // To debug via the segger JLINK console rather than the CDC-ACM serial device
 // #define USE_SEGGER
 
+// Battery
+// The battery sense is hooked to pin A0 (4)
+// it is defined in the anlaolgue pin section of this file
+// and has 12 bit resolution
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define BATTERY_SENSE_RESOLUTION 4096.0
+// Definition of milliVolt per LSB => 3.0V ADC range and 12-bit ADC resolution = 3000mV/4096
+#define VBAT_MV_PER_LSB (0.73242188F)
+// Voltage divider value => 100K + 100K voltage divider on VBAT = (100K / (100K + 100K))
+#define VBAT_DIVIDER (0.5F)
+// Compensation factor for the VBAT divider
+#define VBAT_DIVIDER_COMP (2.0)
+// Fixed calculation of milliVolt from compensation value
+#define REAL_VBAT_MV_PER_LSB (VBAT_DIVIDER_COMP * VBAT_MV_PER_LSB)
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+#define ADC_MULTIPLIER VBAT_DIVIDER_COMP 
+#define VBAT_RAW_TO_SCALED(x) (REAL_VBAT_MV_PER_LSB * x)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Removed the SDS (SuperDeepSleep) for NRF52 boards
Added battery sense for T-Echo
I don't have a T-Echo so that part is not tested.
This PR fixes bug #827 
