### PR TITLE
disable gps powercycle for small gps_update_interval

### DIFF
--- a/src/gps/UBloxGPS.cpp
+++ b/src/gps/UBloxGPS.cpp
@@ -5,7 +5,7 @@
 #include "sleep.h"
 #include <assert.h>
 
-/ if gps_update_interval below this value, do not powercycle the GPS
+// if gps_update_interval below this value, do not powercycle the GPS
 #define UBLOX_POWEROFF_THRESHOLD 90
 
 extern RadioConfig radioConfig;


### PR DESCRIPTION
Implements the change described in issue #844 , by disabling the external power cycling of UBlox GPS modules when `gps_update_interval` is too short to allow a meaningful power saving