### PR TITLE
GPS Coordinate Formats

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -548,16 +548,16 @@ static void drawGPScoordinates(OLEDDisplay *display, int16_t x, int16_t y, const
     } else {
         char coordinateLine[22];
 
-        if (gpsFormat == GpsCoordinateFormat_GpsFormatDMS) {
+        if (gpsFormat == GpsCoordinateFormat_GpsFormatDMS) { // Degrees Minutes Seconds
             DMS dms = latLongToDMS(gps->getLatitude() * 1e-7, gps->getLongitude() * 1e-7);
-            sprintf(coordinateLine, "%2i°%2i'%2.0f\"%1c %3i°%2i'%2.0f\"", dms.latDeg, dms.latMin, dms.latSec, dms.latCP, 
-                    dms.lonDeg, dms.lonMin, dms.lonSec);
-        } else if (gpsFormat == GpsCoordinateFormat_GpsFormatUTM) {
+            sprintf(coordinateLine, "%2i°%2i'%2.0f\"%1c%3i°%2i'%2.0f\"%1c", dms.latDeg, dms.latMin, dms.latSec, dms.latCP, 
+                    dms.lonDeg, dms.lonMin, dms.lonSec, dms.lonCP);
+        } else if (gpsFormat == GpsCoordinateFormat_GpsFormatUTM) { // Universal Transverse Mercator
             UTM utm = latLongToUTM(gps->getLatitude() * 1e-7, gps->getLongitude() * 1e-7);
-            sprintf(coordinateLine, "%2i%1c %6.0f %7.0f", utm.zone, utm.band, utm.easting, utm.northing);
-        } else if (gpsFormat == GpsCoordinateFormat_GpsFormatMGRS) {
+            sprintf(coordinateLine, "%2i%1c %06.0f %07.0f", utm.zone, utm.band, utm.easting, utm.northing);
+        } else if (gpsFormat == GpsCoordinateFormat_GpsFormatMGRS) { // Military Grid Reference System
             MGRS mgrs = latLongToMGRS(gps->getLatitude() * 1e-7, gps->getLongitude() * 1e-7);
-            sprintf(coordinateLine, "%2i%1c %1c%1c %5i %5i", mgrs.zone, mgrs.band, mgrs.east100k, mgrs.north100k, 
+            sprintf(coordinateLine, "%2i%1c %1c%1c %05i %05i", mgrs.zone, mgrs.band, mgrs.east100k, mgrs.north100k, 
                     mgrs.easting, mgrs.northing);
         } else // Defaults to decimal degrees
             sprintf(coordinateLine, "%f %f", gps->getLatitude() * 1e-7, gps->getLongitude() * 1e-7);

--- a/src/mesh/generated/radioconfig.pb.h
+++ b/src/mesh/generated/radioconfig.pb.h
@@ -51,6 +51,13 @@ typedef enum _GpsOperation {
     GpsOperation_GpsOpDisabled = 4
 } GpsOperation;
 
+typedef enum _GpsCoordinateFormat {
+    GpsCoordinateFormat_GpsFormatDec = 0,
+    GpsCoordinateFormat_GpsFormatDMS = 1,
+    GpsCoordinateFormat_GpsFormatUTM = 2,
+    GpsCoordinateFormat_GpsFormatMGRS = 3,
+} GpsCoordinateFormat;
+
 typedef enum _LocationSharing {
     LocationSharing_LocUnset = 0,
     LocationSharing_LocEnabled = 1,
@@ -89,6 +96,7 @@ typedef struct _RadioConfig_UserPreferences {
     float frequency_offset;
     char mqtt_server[32];
     bool mqtt_disabled;
+    GpsCoordinateFormat gps_format;
     bool factory_reset;
     bool debug_log_enabled;
     pb_size_t ignore_incoming_count;
@@ -139,6 +147,10 @@ typedef struct _RadioConfig {
 #define _GpsOperation_MAX GpsOperation_GpsOpDisabled
 #define _GpsOperation_ARRAYSIZE ((GpsOperation)(GpsOperation_GpsOpDisabled+1))
 
+#define _GpsCoordinateFormat_MIN GpsCoordinateFormat_GpsFormatDec
+#define _GpsCoordinateFormat_MAX GpsCoordinateFormat_GpsFormatMGRS
+#define _GpsCoordinateFormat_ARRAYSIZE ((GpsCoordinateFormat)(GpsCoordinateFormat_GpsFormatMGRS+1))
+
 #define _LocationSharing_MIN LocationSharing_LocUnset
 #define _LocationSharing_MAX LocationSharing_LocDisabled
 #define _LocationSharing_ARRAYSIZE ((LocationSharing)(LocationSharing_LocDisabled+1))
@@ -154,9 +166,9 @@ extern "C" {
 
 /* Initializer values for message structs */
 #define RadioConfig_init_default                 {false, RadioConfig_UserPreferences_init_default}
-#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0}
+#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0}
 #define RadioConfig_init_zero                    {false, RadioConfig_UserPreferences_init_zero}
-#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0}
+#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define RadioConfig_UserPreferences_position_broadcast_secs_tag 1
@@ -185,6 +197,7 @@ extern "C" {
 #define RadioConfig_UserPreferences_frequency_offset_tag 41
 #define RadioConfig_UserPreferences_mqtt_server_tag 42
 #define RadioConfig_UserPreferences_mqtt_disabled_tag 43
+#define RadioConfig_UserPreferences_gps_format_tag 44
 #define RadioConfig_UserPreferences_factory_reset_tag 100
 #define RadioConfig_UserPreferences_debug_log_enabled_tag 101
 #define RadioConfig_UserPreferences_ignore_incoming_tag 103
@@ -249,6 +262,7 @@ X(a, STATIC,   SINGULAR, BOOL,     serial_disabled,  40) \
 X(a, STATIC,   SINGULAR, FLOAT,    frequency_offset,  41) \
 X(a, STATIC,   SINGULAR, STRING,   mqtt_server,      42) \
 X(a, STATIC,   SINGULAR, BOOL,     mqtt_disabled,    43) \
+X(a, STATIC,   SINGULAR, UENUM,     gps_format,      44) \
 X(a, STATIC,   SINGULAR, BOOL,     factory_reset,   100) \
 X(a, STATIC,   SINGULAR, BOOL,     debug_log_enabled, 101) \
 X(a, STATIC,   REPEATED, UINT32,   ignore_incoming, 103) \


### PR DESCRIPTION
Added different coordinate formats (Issue #437) to display the current GPS position on the OLED. Included with this request are the DMS, UTM and MGRS formats. The radioconfig section of the protobufs were used to track the type of format to be used, a PR will be done for those changes as well.


**DMS Issues**
The DMS does have some loss of fidelity due to the current 22 character limit of the OLED display, so for the seconds only the integer value is used and no decimal places. We can possibly adjust the code for other displays that have more space so that they can get better accuracy. Maybe we could implement some kind of scrolling feature for longer text one day?

**UTM Issues**
There are two different ways of displaying UTM grids, this method uses the same bands as used by MGRS but sometimes UTM is given with a band of either N or S to represent the latitudinal hemisphere.  See  
 https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system   in the section titled: "Locating a position using UTM coordinates". 

**Python CLI Addition**
Currently there is no way for a user to configure which coordinate format to use, so some argument should be added to the Python CLI. The code is written to default to the decimal degrees format that we've been using.

**Testing**
I tested all of these with a set of about 15 coordinates from different locations around the world, it's possible there are some locations where there will be issues, so more testing will be beneficial. Conversions were tested using this site: https://www.earthpoint.us/Convert.aspx .