### PR TITLE
Radiolib sync upstream

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,14 +9,14 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-;default_envs = tbeam
+default_envs = tbeam
 ;default_envs = tbeam0.7
 ;default_envs = heltec-v2.0
 ;default_envs = tlora-v1
 ;default_envs = tlora_v1_3
 ;default_envs = tlora-v2
 ;default_envs = lora-relay-v1 # nrf board
-default_envs = t-echo
+;default_envs = t-echo
 ;default_envs = nrf52840dk-geeksville
 ;default_envs = native # lora-relay-v1 # nrf52840dk-geeksville # linux # or if you'd like to change the default to something like lora-relay-v1 put that here
 ;default_envs = rak4631
@@ -72,7 +72,7 @@ lib_deps =
   1202 ; CRC32, explicitly needed because dependency is missing in the ble ota update lib
   https://github.com/meshtastic/arduino-fsm.git
   https://github.com/meshtastic/SparkFun_Ublox_Arduino_Library.git#31015a55e630a2df77d9d714669c621a5bf355ad
-  https://github.com/meshtastic/RadioLib.git#d82e9e6cf5d014a600981885fff98f56896659e9
+  https://github.com/meshtastic/RadioLib.git#5582ac30578ff3f53f20630a00b2a8a4b8f92c74
   https://github.com/meshtastic/TinyGPSPlus.git#f0f47067ef2f67c856475933188251c1ef615e79
   https://github.com/meshtastic/AXP202X_Library.git#8404abb6d4b486748636bc6ad72d2a47baaf5460
   Wire ; explicitly needed here because the AXP202 library forgets to add it

--- a/platformio.ini
+++ b/platformio.ini
@@ -72,7 +72,7 @@ lib_deps =
   1202 ; CRC32, explicitly needed because dependency is missing in the ble ota update lib
   https://github.com/meshtastic/arduino-fsm.git
   https://github.com/meshtastic/SparkFun_Ublox_Arduino_Library.git#31015a55e630a2df77d9d714669c621a5bf355ad
-  https://github.com/meshtastic/RadioLib.git#80ed10d689a0568782c5bd152906b0f97d2bce93
+  https://github.com/meshtastic/RadioLib.git#d82e9e6cf5d014a600981885fff98f56896659e9
   https://github.com/meshtastic/TinyGPSPlus.git#f0f47067ef2f67c856475933188251c1ef615e79
   https://github.com/meshtastic/AXP202X_Library.git#8404abb6d4b486748636bc6ad72d2a47baaf5460
   Wire ; explicitly needed here because the AXP202 library forgets to add it

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -70,6 +70,12 @@ bool RF95Interface::init()
     int res = lora->begin(freq, bw, sf, cr, syncWord, power, currentLimit, preambleLength);
     DEBUG_MSG("RF95 init result %d\n", res);
 
+    // current limit was removed from module' ctor
+    // override default value (60 mA)
+    res = lora->setCurrentLimit(currentLimit);
+    DEBUG_MSG("Current limit set to %f\n", currentLimit);
+    DEBUG_MSG("Current limit set result %d\n", res);
+
     if (res == ERR_NONE)
         res = lora->setCRC(SX126X_LORA_CRC_ON);
 

--- a/src/mesh/RadioLibRF95.cpp
+++ b/src/mesh/RadioLibRF95.cpp
@@ -19,6 +19,12 @@ int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_
         state = SX127x::begin(RF95_ALT_VERSION, syncWord, preambleLength);
     RADIOLIB_ASSERT(state);
 
+    // current limit was removed from module' ctor
+    // override default value (60 mA)
+    state = setCurrentLimit(currentLimit);
+    DEBUG_MSG("Current limit set to %f\n", currentLimit);
+    DEBUG_MSG("Current limit set result %d\n", state);
+
     // configure settings not accessible by API
     state = config();
     RADIOLIB_ASSERT(state);

--- a/src/mesh/RadioLibRF95.cpp
+++ b/src/mesh/RadioLibRF95.cpp
@@ -10,7 +10,7 @@
 
 RadioLibRF95::RadioLibRF95(Module *mod) : SX1278(mod) {}
 
-int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint8_t currentLimit,
+int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power,
                             uint16_t preambleLength, uint8_t gain)
 {
     // execute common part

--- a/src/mesh/RadioLibRF95.cpp
+++ b/src/mesh/RadioLibRF95.cpp
@@ -14,9 +14,9 @@ int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_
                             uint16_t preambleLength, uint8_t gain)
 {
     // execute common part
-    int16_t state = SX127x::begin(RF95_CHIP_VERSION, syncWord, currentLimit, preambleLength);
+    int16_t state = SX127x::begin(RF95_CHIP_VERSION, syncWord, preambleLength);
     if (state != ERR_NONE)
-        state = SX127x::begin(RF95_ALT_VERSION, syncWord, currentLimit, preambleLength);
+        state = SX127x::begin(RF95_ALT_VERSION, syncWord, preambleLength);
     RADIOLIB_ASSERT(state);
 
     // configure settings not accessible by API

--- a/src/mesh/RadioLibRF95.h
+++ b/src/mesh/RadioLibRF95.h
@@ -62,6 +62,11 @@ class RadioLibRF95: public SX1278 {
     /// For debugging
     uint8_t readReg(uint8_t addr); 
 
+  protected:
+    // since default current limit for SX126x/127x in updated RadioLib is 60mA
+    // use the previous value
+    float currentLimit = 100;
+
 #ifndef RADIOLIB_GODMODE
   private:
 #endif

--- a/src/mesh/RadioLibRF95.h
+++ b/src/mesh/RadioLibRF95.h
@@ -35,9 +35,6 @@ class RadioLibRF95: public SX1278 {
 
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
 
-      \param currentLimit Trim value for OCP (over current protection) in mA. Can be set to multiplies of 5 in range 45 to 120 mA and to multiples of 10 in range 120 to 240 mA.
-      Set to 0 to disable OCP (not recommended).
-
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.
       Allowed values range from 6 to 65535.
 
@@ -46,7 +43,7 @@ class RadioLibRF95: public SX1278 {
 
       \returns \ref status_codes
     */
-    int16_t begin(float freq = 915.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = SX127X_SYNC_WORD, int8_t power = 17, uint8_t currentLimit = 100, uint16_t preambleLength = 8, uint8_t gain = 0);
+    int16_t begin(float freq = 915.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = SX127X_SYNC_WORD, int8_t power = 17, uint16_t preambleLength = 8, uint8_t gain = 0);
 
     // configuration methods
 

--- a/src/mesh/SX1262Interface.cpp
+++ b/src/mesh/SX1262Interface.cpp
@@ -50,7 +50,7 @@ bool SX1262Interface::init()
 
     limitPower();
 
-    int res = lora.begin(freq, bw, sf, cr, syncWord, power, currentLimit, preambleLength, tcxoVoltage, useRegulatorLDO);
+    int res = lora.begin(freq, bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage, useRegulatorLDO);
     DEBUG_MSG("SX1262 init result %d\n", res);
 
 #ifdef SX1262_TXEN

--- a/src/mesh/SX1262Interface.cpp
+++ b/src/mesh/SX1262Interface.cpp
@@ -53,6 +53,12 @@ bool SX1262Interface::init()
     int res = lora.begin(freq, bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage, useRegulatorLDO);
     DEBUG_MSG("SX1262 init result %d\n", res);
 
+    // current limit was removed from module' ctor
+    // override default value (60 mA)
+    res = lora.setCurrentLimit(currentLimit);
+    DEBUG_MSG("Current limit set to %f\n", currentLimit);
+    DEBUG_MSG("Current limit set result %d\n", res);
+
 #ifdef SX1262_TXEN
     // lora.begin sets Dio2 as RF switch control, which is not true if we are manually controlling RX and TX
     if (res == ERR_NONE)


### PR DESCRIPTION
To reflect changes in the updated RadioLib (#849) we need slightly modify these two adapters:

- RadioLibRF95
- SX1262Interface

as the argument `currentLimit` was removed from the `begin` method:
jgromes/RadioLib@e1141ca#diff-507c32190e4a29ffe411c8eab06c75b594c5d2a5fd92e5cb703b787e5f019589L568