### PR TITLE
allow GPS modules to redefine GPS::hasLock()

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -80,6 +80,8 @@ GPS::~GPS()
     notifyDeepSleepObserver.unobserve();
 }
 
+bool GPS::hasLock() { return hasValidLocation; }
+
 // Allow defining the polarity of the WAKE output.  default is active high
 #ifndef GPS_WAKE_ACTIVE
 #define GPS_WAKE_ACTIVE 1

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -57,8 +57,8 @@ class GPS : private concurrency::OSThread
      */
     virtual bool setup();
 
-    /// Returns ture if we have acquired GPS lock.
-    bool hasLock() const { return hasValidLocation; }
+    /// Returns true if we have acquired GPS lock.
+    virtual bool hasLock();
 
     /// Return true if we are connected to a GPS
     bool isConnected() const { return hasGPS; }

--- a/src/gps/UBloxGPS.cpp
+++ b/src/gps/UBloxGPS.cpp
@@ -196,6 +196,11 @@ bool UBloxGPS::lookForLocation()
     return foundLocation;
 }
 
+bool UBloxGPS::hasLock()
+{
+    return (fixType >= 3 && fixType <= 4);
+}
+
 bool UBloxGPS::whileIdle()
 {
     // if using i2c or serial look too see if any chars are ready

--- a/src/gps/UBloxGPS.h
+++ b/src/gps/UBloxGPS.h
@@ -54,6 +54,7 @@ class UBloxGPS : public GPS
      * @return true if we've acquired a new location
      */
     virtual bool lookForLocation();
+    virtual bool hasLock();
 
     /// If possible force the GPS into sleep/low power mode
     virtual void sleep();


### PR DESCRIPTION
Allow hardware-specific GPS modules (NMEA, UBLOX) to define their own hasLock() function, and do so for UBlox. Apply Principle of Least Astonishment to issue #842.