### PR TITLE
[Meshtastic DIY v1]

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = tbeam
+;default_envs = tbeam
 ;default_envs = tbeam0.7
 ;default_envs = heltec-v2.0
 ;default_envs = tlora-v1
@@ -21,6 +21,7 @@ default_envs = tbeam
 ;default_envs = native # lora-relay-v1 # nrf52840dk-geeksville # linux # or if you'd like to change the default to something like lora-relay-v1 put that here
 ;default_envs = rak4631
 ;default_envs = rak4630
+default_envs = meshtastic-diy-v1
 
 [common]
 ; common is not currently used
@@ -189,6 +190,15 @@ extends = esp32_base
 board = ttgo-lora32-v1
 build_flags = 
   ${esp32_base.build_flags} -D TLORA_V2_1_16
+
+; Meshtastic DIY v1 by Nano VHF Schematic based on ESP32-WROOM-32 (38 pins) devkit & EBYTE E22 SX1262/SX1268 module
+[env:meshtastic-diy-v1]
+extends = esp32_base
+board = esp32doit-devkit-v1
+build_flags =
+  ${esp32_base.build_flags}
+  -D DIY_V1
+  -D EBYTE_E22
 
 ; The Heltec Cubecell plus 
 ; IMPORTANT NOTE: This target doesn't yet work and probably won't ever work.  I'm keeping it around for now.

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -226,6 +226,45 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define GPS_RX_PIN 12
 #define GPS_TX_PIN 15
 
+#elif defined(DIY_V1)
+// This string must exactly match the case used in release file names or the android updater won't work
+#define HW_VENDOR HardwareModel_DIY_V1
+
+// For OLED LCD
+#define I2C_SDA 21
+#define I2C_SCL 22
+
+#define BUTTON_PIN 39 // The middle button GPIO on the T-Beam
+
+#define LORA_DIO0 26  // a No connect on the SX1262/SX1268 module
+#define LORA_RESET 23 // RST for SX1276, and for SX1262/SX1268
+#define LORA_DIO1 33  // IRQ for SX1262/SX1268
+#define LORA_DIO2 32  // BUSY for SX1262/SX1268
+#define LORA_DIO3     // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
+
+#define RF95_SCK 5
+#define RF95_MISO 19
+#define RF95_MOSI 27
+#define RF95_NSS 18
+
+// supported modules list
+#define USE_SX1262
+#define USE_SX1268
+
+// common pinouts for SX126X modules
+#define SX126X_CS 18 // NSS for SX126X
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+#define SX126X_RXEN 14
+#define SX126X_TXEN 13
+
+#ifdef EBYTE_E22
+// Internally the TTGO module hooks the SX126x-DIO2 in to control the TX/RX switch
+// (which is the default for the sx1262interface code)
+#define SX126X_E22
+#endif
+
 #elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
 
 // the default ESP32 Pin of 15 is the Oled SCL, set to 36 and 37 and works fine.

--- a/src/mesh/generated/mesh.pb.h
+++ b/src/mesh/generated/mesh.pb.h
@@ -29,7 +29,8 @@ typedef enum _HardwareModel {
     HardwareModel_GENIEBLOCKS = 35,
     HardwareModel_NRF52_UNKNOWN = 36,
     HardwareModel_PORTDUINO = 37,
-    HardwareModel_ANDROID_SIM = 38
+    HardwareModel_ANDROID_SIM = 38,
+    HardwareModel_DIY_V1 = 39
 } HardwareModel;
 
 typedef enum _Constants {


### PR DESCRIPTION
New device board - [Meshtastic DIY v1] by @NanoVHF Schematic based on ESP32-WROOM-32 (38 pins) devkit & EBYTE E22 SX1262/SX1268 module

Subproject reference: https://github.com/NanoVHF/Meshtastic-DIY