### PR TITLE
Low battery level counter for NRF52

### DIFF
--- a/src/power.h
+++ b/src/power.h
@@ -37,6 +37,9 @@ class Power : private concurrency::OSThread
 
     /// Setup a simple ADC input based battery sensor
     bool analogInit();
+
+  private:
+    uint8_t low_voltage_counter;
 };
 
 extern Power *power;


### PR DESCRIPTION
Added a counter that counts low battery level detections.
If there are 4 in a row we go to deep sleep.
The battery sense on the RAK4631 seems to be a bit unstable and may
generate  'false' low voltage readings.
My RAK4631 has been running for 7 days now with this fix.
It did 3 days without it.
I still do not have a T-Echo so on that board IT IS NOT TESTED.
(But I hope it will improve things there too)

This fixes #852 


