### PR TITLE
Plugins refactoring: `handleReceived` return enumeration `ProcessMessage`

### DIFF
--- a/src/mesh/MeshPlugin.cpp
+++ b/src/mesh/MeshPlugin.cpp
@@ -116,7 +116,7 @@ void MeshPlugin::callPlugins(const MeshPacket &mp)
                     printPacket("packet on wrong channel, but can't respond", &mp);
             } else {
 
-                bool handled = pi.handleReceived(mp);
+                ProcessMessage handled = pi.handleReceived(mp);
 
                 // Possibly send replies (but only if the message was directed to us specifically, i.e. not for promiscious
                 // sniffing) also: we only let the one plugin send a reply, once that happens, remaining plugins are not
@@ -140,7 +140,7 @@ void MeshPlugin::callPlugins(const MeshPacket &mp)
                     pi.myReply = NULL;
                 }
 
-                if (handled) {
+                if (handled == ProcessMessage::STOP) {
                     DEBUG_MSG("Plugin %s handled and skipped other processing\n", pi.name);
                     break;
                 }

--- a/src/mesh/MeshPlugin.h
+++ b/src/mesh/MeshPlugin.h
@@ -9,6 +9,18 @@
 #include <OLEDDisplayUi.h>
 #endif
 
+/** handleReceived return enumeration
+ * 
+ * Use ProcessMessage::CONTINUE to allows other modules to process a message.
+ * 
+ * Use ProcessMessage::STOP to stop further message processing.
+ */
+enum class ProcessMessage
+{
+  CONTINUE = 0,
+  STOP = 1,
+};
+
 /** A baseclass for any mesh "plugin".
  *
  * A plugin allows you to add new features to meshtastic device code, without needing to know messaging details.
@@ -87,9 +99,9 @@ class MeshPlugin
 
     /** Called to handle a particular incoming message
 
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    @return ProcessMessage::STOP if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
-    virtual bool handleReceived(const MeshPacket &mp) { return false; }
+    virtual ProcessMessage handleReceived(const MeshPacket &mp) { return ProcessMessage::CONTINUE; }
 
     /** Messages can be received that have the want_response bit set.  If set, this callback will be invoked
      * so that subclasses can (optionally) send a response back to the original sender.

--- a/src/mesh/ProtobufPlugin.h
+++ b/src/mesh/ProtobufPlugin.h
@@ -49,9 +49,9 @@ template <class T> class ProtobufPlugin : protected SinglePortPlugin
   private:
     /** Called to handle a particular incoming message
 
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    @return ProcessMessage::STOP if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
-    virtual bool handleReceived(const MeshPacket &mp)
+    virtual ProcessMessage handleReceived(const MeshPacket &mp)
     {
         // FIXME - we currently update position data in the DB only if the message was a broadcast or destined to us
         // it would be better to update even if the message was destined to others.
@@ -70,6 +70,6 @@ template <class T> class ProtobufPlugin : protected SinglePortPlugin
                 DEBUG_MSG("Error decoding protobuf plugin!\n");
         }
 
-        return handleReceivedProtobuf(mp, decoded);
+        return handleReceivedProtobuf(mp, decoded) ? ProcessMessage::STOP : ProcessMessage::CONTINUE;
     }
 };

--- a/src/plugins/ExternalNotificationPlugin.cpp
+++ b/src/plugins/ExternalNotificationPlugin.cpp
@@ -143,7 +143,7 @@ ExternalNotificationPlugin::ExternalNotificationPlugin()
 #endif
 }
 
-bool ExternalNotificationPlugin::handleReceived(const MeshPacket &mp)
+ProcessMessage ExternalNotificationPlugin::handleReceived(const MeshPacket &mp)
 {
 #ifndef NO_ESP32
 
@@ -176,5 +176,5 @@ bool ExternalNotificationPlugin::handleReceived(const MeshPacket &mp)
 
 #endif
 
-    return false; // Very important to never return TRUE here.  TRUE means we handled the packet and we will stop letting other plugins see it
+    return ProcessMessage::CONTINUE; // Let others look at this message also if they want
 }

--- a/src/plugins/ExternalNotificationPlugin.h
+++ b/src/plugins/ExternalNotificationPlugin.h
@@ -24,9 +24,9 @@ class ExternalNotificationPlugin : public SinglePortPlugin, private concurrency:
 
     /** Called to handle a particular incoming message
 
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    @return ProcessMessage::STOP if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
-    virtual bool handleReceived(const MeshPacket &mp);
+    virtual ProcessMessage handleReceived(const MeshPacket &mp);
 
     virtual int32_t runOnce();
 };

--- a/src/plugins/SerialPlugin.cpp
+++ b/src/plugins/SerialPlugin.cpp
@@ -157,7 +157,7 @@ void SerialPluginRadio::sendPayload(NodeNum dest, bool wantReplies)
     service.sendToMesh(p);
 }
 
-bool SerialPluginRadio::handleReceived(const MeshPacket &mp)
+ProcessMessage SerialPluginRadio::handleReceived(const MeshPacket &mp)
 {
 #ifndef NO_ESP32
 
@@ -207,5 +207,5 @@ bool SerialPluginRadio::handleReceived(const MeshPacket &mp)
 
 #endif
 
-    return true; // Let others look at this message also if they want
+    return ProcessMessage::CONTINUE; // Let others look at this message also if they want
 }

--- a/src/plugins/SerialPlugin.h
+++ b/src/plugins/SerialPlugin.h
@@ -45,9 +45,9 @@ class SerialPluginRadio : public SinglePortPlugin
 
     /** Called to handle a particular incoming message
 
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    @return ProcessMessage::STOP if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
-    virtual bool handleReceived(const MeshPacket &mp);
+    virtual ProcessMessage handleReceived(const MeshPacket &mp);
 };
 
 extern SerialPluginRadio *serialPluginRadio;

--- a/src/plugins/TextMessagePlugin.cpp
+++ b/src/plugins/TextMessagePlugin.cpp
@@ -5,7 +5,7 @@
 
 TextMessagePlugin *textMessagePlugin;
 
-bool TextMessagePlugin::handleReceived(const MeshPacket &mp)
+ProcessMessage TextMessagePlugin::handleReceived(const MeshPacket &mp)
 {
     auto &p = mp.decoded;
     DEBUG_MSG("Received text msg from=0x%0x, id=0x%x, msg=%.*s\n", mp.from, mp.id, p.payload.size, p.payload.bytes);
@@ -18,5 +18,5 @@ bool TextMessagePlugin::handleReceived(const MeshPacket &mp)
     powerFSM.trigger(EVENT_RECEIVED_TEXT_MSG);
     notifyObservers(&mp);
 
-    return false; // Let others look at this message also if they want
+    return ProcessMessage::CONTINUE; // Let others look at this message also if they want
 }

--- a/src/plugins/TextMessagePlugin.h
+++ b/src/plugins/TextMessagePlugin.h
@@ -17,9 +17,9 @@ class TextMessagePlugin : public SinglePortPlugin, public Observable<const MeshP
 
     /** Called to handle a particular incoming message
 
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    @return ProcessMessage::STOP if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
-    virtual bool handleReceived(const MeshPacket &mp);
+    virtual ProcessMessage handleReceived(const MeshPacket &mp);
 };
 
 extern TextMessagePlugin *textMessagePlugin;

--- a/src/plugins/esp32/RangeTestPlugin.cpp
+++ b/src/plugins/esp32/RangeTestPlugin.cpp
@@ -123,7 +123,7 @@ void RangeTestPluginRadio::sendPayload(NodeNum dest, bool wantReplies)
     powerFSM.trigger(EVENT_CONTACT_FROM_PHONE);
 }
 
-bool RangeTestPluginRadio::handleReceived(const MeshPacket &mp)
+ProcessMessage RangeTestPluginRadio::handleReceived(const MeshPacket &mp)
 {
 #ifndef NO_ESP32
 
@@ -181,7 +181,7 @@ bool RangeTestPluginRadio::handleReceived(const MeshPacket &mp)
 
 #endif
 
-    return true; // Let others look at this message also if they want
+    return ProcessMessage::CONTINUE; // Let others look at this message also if they want
 }
 
 /// Ported from my old java code, returns distance in meters along the globe

--- a/src/plugins/esp32/RangeTestPlugin.h
+++ b/src/plugins/esp32/RangeTestPlugin.h
@@ -50,9 +50,9 @@ class RangeTestPluginRadio : public SinglePortPlugin
 
     /** Called to handle a particular incoming message
 
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    @return ProcessMessage::STOP if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
-    virtual bool handleReceived(const MeshPacket &mp);
+    virtual ProcessMessage handleReceived(const MeshPacket &mp);
 };
 
 extern RangeTestPluginRadio *rangeTestPluginRadio;

--- a/src/plugins/esp32/StoreForwardPlugin.cpp
+++ b/src/plugins/esp32/StoreForwardPlugin.cpp
@@ -191,7 +191,7 @@ void StoreForwardPlugin::sendPayloadWelcome(NodeNum dest, bool wantReplies)
     service.sendToMesh(p);
 }
 
-bool StoreForwardPlugin::handleReceived(const MeshPacket &mp)
+ProcessMessage StoreForwardPlugin::handleReceived(const MeshPacket &mp)
 {
 #ifndef NO_ESP32
     if (radioConfig.preferences.store_forward_plugin_enabled) {
@@ -217,7 +217,7 @@ bool StoreForwardPlugin::handleReceived(const MeshPacket &mp)
 
 #endif
 
-    return true; // Let others look at this message also if they want
+    return ProcessMessage::CONTINUE; // Let others look at this message also if they want
 }
 
 StoreForwardPlugin::StoreForwardPlugin()

--- a/src/plugins/esp32/StoreForwardPlugin.h
+++ b/src/plugins/esp32/StoreForwardPlugin.h
@@ -51,9 +51,9 @@ class StoreForwardPlugin : public SinglePortPlugin, private concurrency::OSThrea
 
     /** Called to handle a particular incoming message
 
-    @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+    @return ProcessMessage::STOP if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
-    virtual bool handleReceived(const MeshPacket &mp);
+    virtual ProcessMessage handleReceived(const MeshPacket &mp);
 };
 
 extern StoreForwardPlugin *storeForwardPlugin;


### PR DESCRIPTION
This preventing developers to use wrong processing message returns.

Use `ProcessMessage::CONTINUE` to allows other modules to process a message.
Use `ProcessMessage::STOP` to stop further message processing.