### PR TITLE
Fix for T-echo to not have Critical Error #3 on startup

### DIFF
--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -180,6 +180,7 @@ External serial flash WP25R1635FZUIL0
  * Lora radio
  */
 
+#define USE_SX1262
 #define SX126X_CS (0 + 24) // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 (0 + 20)
 // Note DIO2 is attached internally to the module to an analog switch for TX/RX switching


### PR DESCRIPTION
I can't say I understand why this fixes it or if this is the right fix, but this fixes it.

When deploying current master on the T-echo, it starts up with `Critical Error #3` , which [apparently is a radio error](https://github.com/meshtastic/Meshtastic-protobufs/blob/master/mesh.proto#L777). The breakage seems to have been introduced in da61090dc53cf200e2a13bb66e1485045f0a5c92 (098f38fb8319e311bc2c40e7324ae19325a81e63 seems to run fine).