### PR TITLE
Fix radio module declaration for `NRF52_SERIES` in `variant.h`-files

### DIFF
--- a/variants/WisCore_RAK4631_Board/variant.h
+++ b/variants/WisCore_RAK4631_Board/variant.h
@@ -151,6 +151,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
  */
 
 // RAK4630 LoRa module
+#define USE_SX1262
 #define SX126X_CS (42)
 #define SX126X_DIO1 (47)
 #define SX126X_BUSY (46)

--- a/variants/eink0.1/variant.h
+++ b/variants/eink0.1/variant.h
@@ -178,6 +178,7 @@ External serial flash WP25R1635FZUIL0
  * Lora radio
  */
 
+#define USE_SX1262
 #define SX126X_CS (0 + 24) // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 (0 + 20)
 // Note DIO2 is attached internally to the module to an analog switch for TX/RX switching

--- a/variants/lora_isp4520/variant.h
+++ b/variants/lora_isp4520/variant.h
@@ -57,6 +57,7 @@
 #define WIRE_INTERFACES_COUNT 0
 
 // GPIOs the SX1262 is connected
+#define USE_SX1262
 #define SX126X_CS 1    // aka SPI_NSS
 #define SX126X_DIO1 (4)
 #define SX126X_BUSY (5) 

--- a/variants/lora_relay_v1/variant.h
+++ b/variants/lora_relay_v1/variant.h
@@ -116,6 +116,9 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // I2C device addresses
 #define I2C_ADDR_BQ27441 0x55 // Battery gauge
 
+// SX1262 declaration
+#define USE_SX1262
+
 // CUSTOM GPIOs the SX1262
 #define SX126X_CS (32)
 

--- a/variants/lora_relay_v2/variant.h
+++ b/variants/lora_relay_v2/variant.h
@@ -136,6 +136,9 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // I2C device addresses
 #define I2C_ADDR_BQ27441 0x55 // Battery gauge
 
+// SX1262 declaration
+#define USE_SX1262
+
 // CUSTOM GPIOs the SX1262
 #define SX126X_CS (32)
 

--- a/variants/pca10056-rc-clock/variant.h
+++ b/variants/pca10056-rc-clock/variant.h
@@ -140,6 +140,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define EXTERNAL_FLASH_USE_QSPI
 
 // CUSTOM GPIOs the SX1262MB2CAS shield when installed on the NRF52840-DK development board
+#define USE_SX1262
 #define SX126X_CS (32 + 8)      // P1.08
 #define SX126X_DIO1 (32 + 6)    // P1.06
 #define SX126X_BUSY (32 + 4)    // P1.04

--- a/variants/ppr/variant.h
+++ b/variants/ppr/variant.h
@@ -129,6 +129,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define PIN_WIRE_SCL (32)
 
 // CUSTOM GPIOs the SX1262
+#define USE_SX1262
 #define SX126X_CS (10)
 #define SX126X_DIO1 (20)
 #define SX1262_DIO2 (26)

--- a/variants/ppr1/variant.h
+++ b/variants/ppr1/variant.h
@@ -152,6 +152,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define PIN_WIRE_SCL (32)
 
 // CUSTOM GPIOs the SX1262
+#define USE_SX1262
 #define SX126X_CS (0 + 10) // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 (0 + 20)
 #define SX1262_DIO2 (0 + 26)

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -180,6 +180,7 @@ External serial flash WP25R1635FZUIL0
  * Lora radio
  */
 
+#define USE_SX1262
 #define SX126X_CS (0 + 24) // FIXME - we really should define LORA_CS instead
 #define SX126X_DIO1 (0 + 20)
 // Note DIO2 is attached internally to the module to an analog switch for TX/RX switching


### PR DESCRIPTION
Due to changing radio module initialization, need to explicit define `USE_SX1262` in:
- [x] variants/WisCore_RAK4631_Board/variant.h
- [x] variants/eink0.1/variant.h
- [x] variants/lora_isp4520/variant.h
- [x] variants/lora_relay_v1/variant.h
- [x] variants/lora_relay_v2/variant.h
- [x] variants/pca10056-rc-clock/variant.h
- [x] variants/ppr/variant.h
- [x] variants/ppr1/variant.h
- [x] variants/t-echo/variant.h