### PR TITLE
fix a positional timestamp reading bug

### DIFF
--- a/src/gps/UBloxGPS.cpp
+++ b/src/gps/UBloxGPS.cpp
@@ -246,7 +246,6 @@ bool UBloxGPS::lookForLocation()
         // INVALID solution - should never happen
         DEBUG_MSG("Invalid location lat/lon/hae/dop %d/%d/%d/%d - discarded\n",
                 tmp_lat, tmp_lon, tmp_alt_hae, tmp_dop);
-        fixType = 0;
     }
 
     ublox.flushPVT();  // reset ALL freshness flags at the end


### PR DESCRIPTION
In function `UBloxGPS::lookForLocation()`, the positional timestamp was sometimes out of sync with the GPS position (an older value was returned instead), defeating the purpose of a **positional** timestamp. This PR ensures that all data is equally fresh, *or your next pizza is free* :)