### PR TITLE
[875] Inline pow_neg

### DIFF
--- a/src/gps/GeoCoord.h
+++ b/src/gps/GeoCoord.h
@@ -14,7 +14,7 @@
 
 // Helper functions
 // Raises a number to an exponent, handling negative exponents.
-static double pow_neg(double base, double exponent) {
+static inline double pow_neg(double base, double exponent) {
   if (exponent == 0) {
     return 1;
   } else if (exponent > 0) {


### PR DESCRIPTION
Targets #875 again. Add inline keyword to fix build warning.

May help with https://github.com/meshtastic/Meshtastic-device/pull/876#issuecomment-948587941
