### PR TITLE
add the user as distinct message source - fixing #900

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -140,7 +140,7 @@ void MeshService::handleToRadio(MeshPacket &p)
 
     // Send the packet into the mesh
 
-    sendToMesh(packetPool.allocCopy(p));
+    sendToMesh(packetPool.allocCopy(p), RX_SRC_USER);
 
     bool loopback = false; // if true send any packet the phone sends back itself (for testing)
     if (loopback) {
@@ -157,12 +157,12 @@ bool MeshService::cancelSending(PacketId id)
     return router->cancelSending(nodeDB.getNodeNum(), id);
 }
 
-void MeshService::sendToMesh(MeshPacket *p)
+void MeshService::sendToMesh(MeshPacket *p, RxSource src)
 {
     nodeDB.updateFrom(*p); // update our local DB for this packet (because phone might have sent position packets etc...)
 
     // Note: We might return !OK if our fifo was full, at that point the only option we have is to drop it
-    router->sendLocal(p);
+    router->sendLocal(p, src);
 }
 
 void MeshService::sendNetworkPing(NodeNum dest, bool wantReplies)

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -75,7 +75,7 @@ class MeshService
     /// Send a packet into the mesh - note p must have been allocated from packetPool.  We will return it to that pool after
     /// sending. This is the ONLY function you should use for sending messages into the mesh, because it also updates the nodedb
     /// cache
-    void sendToMesh(MeshPacket *p);
+    void sendToMesh(MeshPacket *p, RxSource src = RX_SRC_LOCAL);
 
     /** Attempt to cancel a previously sent packet from this _local_ node.  Returns true if a packet was found we could cancel */
     bool cancelSending(PacketId id);

--- a/src/mesh/MeshTypes.h
+++ b/src/mesh/MeshTypes.h
@@ -20,7 +20,8 @@ typedef uint32_t PacketId; // A packet sequence number
  */
 enum RxSource {
     RX_SRC_LOCAL,  // message was generated locally
-    RX_SRC_RADIO   // message was received from radio mesh
+    RX_SRC_RADIO,   // message was received from radio mesh
+    RX_SRC_USER    // message was received from end-user device
 };
 
 /**

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -145,7 +145,7 @@ void Router::setReceivedMessage()
     runASAP = true;
 }
 
-ErrorCode Router::sendLocal(MeshPacket *p)
+ErrorCode Router::sendLocal(MeshPacket *p, RxSource src)
 {
     // No need to deliver externally if the destination is the local node
     if (p->to == nodeDB.getNodeNum()) {
@@ -161,7 +161,7 @@ ErrorCode Router::sendLocal(MeshPacket *p)
         // If we are sending a broadcast, we also treat it as if we just received it ourself
         // this allows local apps (and PCs) to see broadcasts sourced locally
         if (p->to == NODENUM_BROADCAST) {
-            handleReceived(p, RX_SRC_LOCAL);
+            handleReceived(p, src);
         }
 
         return send(p);

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -45,7 +45,7 @@ class Router : protected concurrency::OSThread
      *
      * NOTE: This method will free the provided packet (even if we return an error code)
      */
-    ErrorCode sendLocal(MeshPacket *p);
+    ErrorCode sendLocal(MeshPacket *p, RxSource src = RX_SRC_RADIO);
 
     /** Attempt to cancel a previously sent packet.  Returns true if a packet was found we could cancel */
     bool cancelSending(NodeNum from, PacketId id);


### PR DESCRIPTION
Tentative emergency fix for issue #900 
Add the end-user (BLE or USB API) as the third `RxSource` in the internal message workflow. This should allow user messages to be processed by the device, while preserving the loopback-prevention feature introduced in #880 