### PR TITLE
fix owner name update issue (off #900)

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -112,7 +112,11 @@ bool MeshService::reloadConfig()
 /// The owner User record just got updated, update our node DB and broadcast the info into the mesh
 void MeshService::reloadOwner()
 {
+    // DEBUG_MSG("reloadOwner()\n");
+    // update our local data directly
+    nodeDB.updateUser(nodeDB.getNodeNum(), owner);
     assert(nodeInfoPlugin);
+    // update everyone else
     if (nodeInfoPlugin)
         nodeInfoPlugin->sendOurNodeInfo();
     nodeDB.saveToDisk();


### PR DESCRIPTION
This update fixes an (un-numbered) issue discovered by @osmanovv and mentioned briefly during issue #900 diagnostics:

> I tried to flush TBEAM again and also noticed that I cannot set owner via CLR

The issue was caused by my recently introduced message loop avoidance features, and is fixed by short-circuiting the original message loopback that was relied on to update the owner name in nodeDB.