### PR TITLE
set Team field via Admin plugin

### DIFF
--- a/src/plugins/AdminPlugin.cpp
+++ b/src/plugins/AdminPlugin.cpp
@@ -137,8 +137,13 @@ void AdminPlugin::handleSetOwner(const User &o)
         strcpy(owner.id, o.id);
     }
     if (owner.is_licensed != o.is_licensed) {
-        changed = true;
+        changed = 1;
         owner.is_licensed = o.is_licensed;
+    }
+
+    if ((!changed || o.team) && (owner.team != o.team)) {
+        changed = 1;
+        owner.team = o.team;
     }
 
     if (changed) // If nothing really changed, don't broadcast on the network or write to flash


### PR DESCRIPTION
Enable setting the new Team field (https://github.com/meshtastic/Meshtastic-protobufs/pull/33) via the Admin plugin, same as owner name, shortname etc.