### PR TITLE
Define battery pin

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -327,6 +327,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define GPS_RX_PIN 36
 #define GPS_TX_PIN 37
 
+#define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+
 #define I2C_SDA 4 // I2C pins for this board
 #define I2C_SCL 15
 


### PR DESCRIPTION
I propose we define `BATTERY_PIN` for `HardwareModel_TLORA_V1` the same way we have this defined for `HardwareModel_TLORA_V2`.

I can confirm it works well on my `TLORA_V1` devices. I currently have this setup running on both TLORA versions mentioned here with the same voltage divider setup without issues.