### PR TITLE
#927 add SSL notification at boot

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -147,6 +147,17 @@ static void drawBootScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int1
     drawIconScreen(region, display, state, x, y);
 }
 
+// Used on boot when a certificate is being created
+static void drawSSLScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
+{
+    display->setTextAlignment(TEXT_ALIGN_CENTER);
+    display->setFont(FONT_SMALL);
+    display->drawString(64 + x, y, "Creating SSL certificate");
+
+    display->setFont(FONT_SMALL);
+    display->drawString(64 + x, FONT_HEIGHT_SMALL + y + 2, "Please wait...");
+}
+
 #ifdef HAS_EINK
 /// Used on eink displays while in deep sleep
 static void drawSleepScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
@@ -896,6 +907,16 @@ void Screen::drawDebugInfoWiFiTrampoline(OLEDDisplay *display, OLEDDisplayUiStat
 {
     Screen *screen = reinterpret_cast<Screen *>(state->userData);
     screen->debugInfo.drawFrameWiFi(display, state, x, y);
+}
+
+/* show a message that the SSL cert is being built
+ * it is expected that this will be used during the boot phase */
+void Screen::setSSLFrames()
+{
+    DEBUG_MSG("showing SSL frames\n");
+    static FrameCallback sslFrames[] = {drawSSLScreen};
+    ui.setFrames(sslFrames, 1);
+    ui.update();
 }
 
 // restore our regular frame list

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -220,6 +220,9 @@ class Screen : public concurrency::OSThread
     /// Used to force (super slow) eink displays to draw critical frames
     void forceDisplay();
 
+    /// Draws our SSL cert screen during boot (called from WebServer)
+    void setSSLFrames();
+
   protected:
     /// Updates the UI.
     //

--- a/src/mesh/http/WebServer.cpp
+++ b/src/mesh/http/WebServer.cpp
@@ -1,3 +1,4 @@
+#include "main.h"
 #include "mesh/http/WebServer.h"
 #include "NodeDB.h"
 #include "mesh/http/WiFiAPClient.h"
@@ -77,7 +78,7 @@ static void taskCreateCert(void *parameter)
 {
     prefs.begin("MeshtasticHTTPS", false);
 
-    // Delete the saved certs
+    // Delete the saved certs (used in debugging)
     if (0) {
         DEBUG_MSG("Deleting any saved SSL keys ...\n");
         // prefs.clear();
@@ -166,11 +167,16 @@ void createSSLCert()
                     NULL);          /* Task handle. */
 
         DEBUG_MSG("Waiting for SSL Cert to be generated.\n");
+        int seconds = 0;
         while (!isCertReady) {
             DEBUG_MSG(".");
             delay(1000);
             yield();
             esp_task_wdt_reset();
+            seconds++;
+            if ((seconds == 3) && screen) {
+                screen->setSSLFrames();
+            }
         }
         DEBUG_MSG("SSL Cert Ready!\n");
     }


### PR DESCRIPTION
Resolves #927 by creating a screen that says "Creating SSL Certificate, Please wait..." at boot.