### PR TITLE
When switching to battery, shutdown after on_battery_shutdown_after_secs

### DIFF
--- a/src/PowerFSM.h
+++ b/src/PowerFSM.h
@@ -19,6 +19,7 @@
 #define EVENT_POWER_CONNECTED 13
 #define EVENT_POWER_DISCONNECTED 14
 #define EVENT_FIRMWARE_UPDATE 15 // We just received a new firmware update packet from the phone
+#define EVENT_SHUTDOWN 16 //force a full shutdown now (not just sleep)
 
 extern Fsm powerFSM;
 extern State statePOWER, stateSERIAL;

--- a/src/mesh/generated/radioconfig.pb.h
+++ b/src/mesh/generated/radioconfig.pb.h
@@ -151,6 +151,7 @@ typedef struct _RadioConfig_UserPreferences {
     uint32_t position_flags;
     bool is_always_powered;
     uint32_t auto_screen_carousel_secs;
+    uint32_t on_battery_shutdown_after_secs;
 } RadioConfig_UserPreferences;
 
 typedef struct _RadioConfig {
@@ -195,9 +196,9 @@ extern "C" {
 
 /* Initializer values for message structs */
 #define RadioConfig_init_default                 {false, RadioConfig_UserPreferences_init_default}
-#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0, 0}
 #define RadioConfig_init_zero                    {false, RadioConfig_UserPreferences_init_zero}
-#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define RadioConfig_UserPreferences_position_broadcast_secs_tag 1
@@ -264,6 +265,7 @@ extern "C" {
 #define RadioConfig_UserPreferences_position_flags_tag 150
 #define RadioConfig_UserPreferences_is_always_powered_tag 151
 #define RadioConfig_UserPreferences_auto_screen_carousel_secs_tag 152
+#define RadioConfig_UserPreferences_on_battery_shutdown_after_secs_tag 153
 #define RadioConfig_preferences_tag              1
 
 /* Struct field encoding specification for nanopb */
@@ -337,7 +339,8 @@ X(a, STATIC,   SINGULAR, BOOL,     store_forward_plugin_enabled, 148) \
 X(a, STATIC,   SINGULAR, BOOL,     store_forward_plugin_heartbeat, 149) \
 X(a, STATIC,   SINGULAR, UINT32,   position_flags,  150) \
 X(a, STATIC,   SINGULAR, BOOL,     is_always_powered, 151) \
-X(a, STATIC,   SINGULAR, UINT32,   auto_screen_carousel_secs, 152)
+X(a, STATIC,   SINGULAR, UINT32,   auto_screen_carousel_secs, 152) \
+X(a, STATIC,   SINGULAR, UINT32,   on_battery_shutdown_after_secs, 153)
 #define RadioConfig_UserPreferences_CALLBACK NULL
 #define RadioConfig_UserPreferences_DEFAULT NULL
 
@@ -349,8 +352,8 @@ extern const pb_msgdesc_t RadioConfig_UserPreferences_msg;
 #define RadioConfig_UserPreferences_fields &RadioConfig_UserPreferences_msg
 
 /* Maximum encoded size of messages (where known) */
-#define RadioConfig_size                         444
-#define RadioConfig_UserPreferences_size         441
+#define RadioConfig_size                         451
+#define RadioConfig_UserPreferences_size         448
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
When switching to battery power, the node will shutdown after a user-defined time delay (fully shutdown, not any sort of sleep).  This time limit will also apply if turning on when on battery power.  It is only enabled if on_battery_shutdown_after_secs is greater than 0.

Requires an AXP192 power management chip to work.  