### PR TITLE
Split RAK-4631 targets by base board

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -9,7 +9,7 @@ BOARDS_ESP32="tlora-v2 tlora-v1 tlora_v1_3 tlora-v2-1-1.6 tbeam heltec-v2.0 helt
 #BOARDS_ESP32=tbeam
 
 # FIXME note nrf52840dk build is for some reason only generating a BIN file but not a HEX file nrf52840dk-geeksville is fine
-BOARDS_NRF52="rak4631 t-echo"
+BOARDS_NRF52="rak4631_5005 rak4631_19003 t-echo"
 #BOARDS_NRF52=""
 
 OUTDIR=release/latest

--- a/platformio.ini
+++ b/platformio.ini
@@ -325,12 +325,21 @@ monitor_speed = 115200
 # board_build.ldscript = linker/nrf52840_s140_sim832.ld
 
 ; The very slick RAK wireless RAK 4631 / 4630 board
-[env:rak4631]
+[env:rak4631_5005]
 extends = nrf52840_base
 board = wiscore_rak4631
 # add our variants files to the include and src paths
 # define build flags for the TFT_eSPI library
-build_flags = ${nrf52840_base.build_flags} -Ivariants/WisCore_RAK4631_Board
+build_flags = ${nrf52840_base.build_flags} -Ivariants/WisCore_RAK4631_Board -D RAK_BASE_5005
+src_filter = ${nrf52_base.src_filter} +<../variants/WisCore_RAK4631_Board>
+debug_tool = jlink
+
+[env:rak4631_19003]
+extends = nrf52840_base
+board = wiscore_rak4631
+# add our variants files to the include and src paths
+# define build flags for the TFT_eSPI library
+build_flags = ${nrf52840_base.build_flags} -Ivariants/WisCore_RAK4631_Board -D RAK_BASE_19003
 src_filter = ${nrf52_base.src_filter} +<../variants/WisCore_RAK4631_Board>
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/WisCore_RAK4631_Board/variant.h
+++ b/variants/WisCore_RAK4631_Board/variant.h
@@ -58,12 +58,15 @@ extern "C" {
 /*
  * Buttons
  */
+
 #ifdef RAK_BASE_5005
-#define PIN_BUTTON1 5 // This will default to normal button pin 
+#define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion
+#define BUTTON_NEED_PULLUP
 #endif
 #define PIN_BUTTON2 12
 #define PIN_BUTTON3 24
 #define PIN_BUTTON4 25
+
 
 /*
  * Analog pins
@@ -149,7 +152,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
    SW1       <->  P0.01 (Arduino GPIO number 1)
    A0        <->  P0.04/AIN2 (Arduino Analog A2
    A1        <->  P0.31/AIN7 (Arduino Analog A7
-   SPI_CS    <->  P0.26 (Arduino GPIO number 26)
+   SPI_CS    <->  P0.26 (Arduino GPIO number 26) 
  */
 
 // RAK4630 LoRa module

--- a/variants/WisCore_RAK4631_Board/variant.h
+++ b/variants/WisCore_RAK4631_Board/variant.h
@@ -58,7 +58,9 @@ extern "C" {
 /*
  * Buttons
  */
-#define PIN_BUTTON1 11
+#ifdef RAK_BASE_5005
+#define PIN_BUTTON1 5 // This will default to normal button pin 
+#endif
 #define PIN_BUTTON2 12
 #define PIN_BUTTON3 24
 #define PIN_BUTTON4 25
@@ -169,8 +171,11 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // #define PIN_GPS_RESET (34)
 #define PIN_GPS_EN (34)
 #define PIN_GPS_PPS (17) // Pulse per second input from the GPS
+
+#ifdef RAK_BASE_5005
 #define GPS_RX_PIN PIN_SERIAL1_RX
 #define GPS_TX_PIN PIN_SERIAL1_TX
+#endif
 
 // Battery
 // The battery sense is hooked to pin A0 (5)


### PR DESCRIPTION
Starting to split the RAK-4631 build targets based on pin availability / differences between the base boards