### PR TITLE
Update and configure ExNotify platforms

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -171,7 +171,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define I2C_SCL 22
 
 #define BUTTON_PIN 38     // The middle button GPIO on the T-Beam
-#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed
+//#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented anywhere.
+#define EXT_NOTIFY_PIN 13 // Default pin to use for Ext Notify Plugin.
 
 #define LED_INVERTED 1
 #define LED_PIN 4 // Newer tbeams (1.1) have an extra led on GPIO4
@@ -213,6 +214,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define BUTTON_PIN 39
 #define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define EXT_NOTIFY_PIN 13 // Default pin to use for Ext Notify Plugin.
 
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module
@@ -316,6 +318,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define HW_VENDOR HardwareModel_HELTEC_V2_1
 
 #define BATTERY_PIN 37 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+#define EXT_NOTIFY_PIN 13 // Default pin to use for Ext Notify Plugin.
 
 #endif
 
@@ -338,6 +341,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LED_PIN 2     // If defined we will blink this LED
 #define BUTTON_PIN 0  // If defined, this will be used for user button presses
 #define BUTTON_NEED_PULLUP
+#define EXT_NOTIFY_PIN 13 // Default pin to use for Ext Notify Plugin.
 
 #define USE_RF95
 #define LORA_DIO0 26 // a No connect on the SX1262 module

--- a/src/plugins/ExternalNotificationPlugin.cpp
+++ b/src/plugins/ExternalNotificationPlugin.cpp
@@ -44,7 +44,7 @@
 */
 
 // Default configurations
-#define EXT_NOTIFICATION_PLUGIN_OUTPUT 13
+#define EXT_NOTIFICATION_PLUGIN_OUTPUT EXT_NOTIFY_PIN
 #define EXT_NOTIFICATION_PLUGIN_OUTPUT_MS 1000
 
 #define ASCII_BELL 0x07
@@ -84,21 +84,25 @@ int32_t ExternalNotificationPlugin::runOnce()
 
 void ExternalNotificationPlugin::setExternalOn()
 {
+    #ifdef EXT_NOTIFY_PIN
     externalCurrentState = 1;
     externalTurnedOn = millis();
 
     digitalWrite((radioConfig.preferences.ext_notification_plugin_output ? radioConfig.preferences.ext_notification_plugin_output
                                                                          : EXT_NOTIFICATION_PLUGIN_OUTPUT),
                  (radioConfig.preferences.ext_notification_plugin_active ? true : false));
+    #endif
 }
 
 void ExternalNotificationPlugin::setExternalOff()
 {
+    #ifdef EXT_NOTIFY_PIN
     externalCurrentState = 0;
 
     digitalWrite((radioConfig.preferences.ext_notification_plugin_output ? radioConfig.preferences.ext_notification_plugin_output
                                                                          : EXT_NOTIFICATION_PLUGIN_OUTPUT),
                  (radioConfig.preferences.ext_notification_plugin_active ? false : true));
+    #endif
 }
 
 // --------
@@ -111,6 +115,7 @@ ExternalNotificationPlugin::ExternalNotificationPlugin()
     boundChannel = Channels::gpioChannel;
 
 #ifndef NO_ESP32
+    #ifdef EXT_NOTIFY_PIN
 
     /*
         Uncomment the preferences below if you want to use the plugin
@@ -140,12 +145,14 @@ ExternalNotificationPlugin::ExternalNotificationPlugin()
         DEBUG_MSG("External Notification Plugin Disabled\n");
         enabled = false;
     }
+    #endif
 #endif
 }
 
 ProcessMessage ExternalNotificationPlugin::handleReceived(const MeshPacket &mp)
 {
 #ifndef NO_ESP32
+    #ifdef EXT_NOTIFY_PIN
 
     if (radioConfig.preferences.ext_notification_plugin_enabled) {
 
@@ -173,6 +180,7 @@ ProcessMessage ExternalNotificationPlugin::handleReceived(const MeshPacket &mp)
     } else {
         DEBUG_MSG("External Notification Plugin Disabled\n");
     }
+    #endif
 
 #endif
 


### PR DESCRIPTION
Updates ExternalNotification Plugin so that it pulls a default gpio pin from the board configuration defined as `EXT_NOTIFY_PIN`. I've added in as many platforms that I could find that safely use the current default pin of 13. Other board maintainers please add a safe default gpio define as required.

I've removed the function BUTTON_PIN_ALT from tbeam 1.0, as this is an undocumented addition that only exists on this board. This should close issue #929.