### PR TITLE
Do not decrease the `hop_limit` value with new `is_immutable_hop_limit` user preference

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -35,7 +35,13 @@ void FloodingRouter::sniffReceived(const MeshPacket *p, const Routing *c)
         if (p->id != 0) {
             MeshPacket *tosend = packetPool.allocCopy(*p); // keep a copy because we will be sending it
 
-            tosend->hop_limit--; // bump down the hop count
+            if (radioConfig.preferences.is_immutable_hop_limit) {
+                // do not decrease the `hop_limit` value when forwarding messages
+                tosend->hop_limit;
+            }
+            else {
+                tosend->hop_limit--; // bump down the hop count
+            }
 
             printPacket("Rebroadcasting received floodmsg to neighbors", p);
             // Note: we are careful to resend using the original senders node id


### PR DESCRIPTION
Do not decrease the `hop_limit` value when forwarding messages with new `is_immutable_hop_limit` user preference

Needs protobufs regenerated (https://github.com/meshtastic/Meshtastic-protobufs/pull/54).

Use carefully (e.g. for _one_ node which connects two separated groups).
Useful for tightly mounted devices to do not waste `hop_limit` (but enable it only for one node).