### PR TITLE
Overridden default pin to use for Ext Notify Plugin (#975)

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -243,6 +243,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define GPS_TX_PIN 12 // not connected
 
 #define BUTTON_PIN 39 // The middle button GPIO on the T-Beam
+#define EXT_NOTIFY_OUT 12 // Overridden default pin to use for Ext Notify Plugin (#975).
 
 #define LORA_DIO0 26  // a No connect on the SX1262/SX1268 module
 #define LORA_RESET 23 // RST for SX1276, and for SX1262/SX1268


### PR DESCRIPTION
In Meshtastic DIY `GPIO13` is used for `SX126X_TXEN`, so we choose `GPIO12` as default for Ext Notification Plugin.
