### PR TITLE
Add mqtt_username and mqtt_password user preferences

### DIFF
--- a/src/mesh/generated/radioconfig.pb.h
+++ b/src/mesh/generated/radioconfig.pb.h
@@ -153,6 +153,8 @@ typedef struct _RadioConfig_UserPreferences {
     uint32_t auto_screen_carousel_secs;
     uint32_t on_battery_shutdown_after_secs;
     uint32_t hop_limit;
+    char mqtt_username[32];
+    char mqtt_password[32];
 } RadioConfig_UserPreferences;
 
 typedef struct _RadioConfig {
@@ -197,9 +199,9 @@ extern "C" {
 
 /* Initializer values for message structs */
 #define RadioConfig_init_default                 {false, RadioConfig_UserPreferences_init_default}
-#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_default {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0, 0, 0, "", ""}
 #define RadioConfig_init_zero                    {false, RadioConfig_UserPreferences_init_zero}
-#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0, 0, 0}
+#define RadioConfig_UserPreferences_init_zero    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", "", 0, _RegionCode_MIN, _ChargeCurrent_MIN, 0, _LocationSharing_MIN, _GpsOperation_MIN, 0, 0, 0, 0, 0, 0, 0, "", 0, _GpsCoordinateFormat_MIN, 0, 0, 0, 0, 0, {0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN, 0, 0, 0, 0, 0, 0, 0, 0, "", ""}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define RadioConfig_UserPreferences_position_broadcast_secs_tag 1
@@ -268,6 +270,8 @@ extern "C" {
 #define RadioConfig_UserPreferences_auto_screen_carousel_secs_tag 152
 #define RadioConfig_UserPreferences_on_battery_shutdown_after_secs_tag 153
 #define RadioConfig_UserPreferences_hop_limit_tag 154
+#define RadioConfig_UserPreferences_mqtt_username_tag 155
+#define RadioConfig_UserPreferences_mqtt_password_tag 156
 #define RadioConfig_preferences_tag              1
 
 /* Struct field encoding specification for nanopb */
@@ -343,7 +347,9 @@ X(a, STATIC,   SINGULAR, UINT32,   position_flags,  150) \
 X(a, STATIC,   SINGULAR, BOOL,     is_always_powered, 151) \
 X(a, STATIC,   SINGULAR, UINT32,   auto_screen_carousel_secs, 152) \
 X(a, STATIC,   SINGULAR, UINT32,   on_battery_shutdown_after_secs, 153) \
-X(a, STATIC,   SINGULAR, UINT32,   hop_limit,       154)
+X(a, STATIC,   SINGULAR, UINT32,   hop_limit,       154) \
+X(a, STATIC,   SINGULAR, STRING,   mqtt_username,   155) \
+X(a, STATIC,   SINGULAR, STRING,   mqtt_password,   156)
 #define RadioConfig_UserPreferences_CALLBACK NULL
 #define RadioConfig_UserPreferences_DEFAULT NULL
 
@@ -355,8 +361,8 @@ extern const pb_msgdesc_t RadioConfig_UserPreferences_msg;
 #define RadioConfig_UserPreferences_fields &RadioConfig_UserPreferences_msg
 
 /* Maximum encoded size of messages (where known) */
-#define RadioConfig_size                         458
-#define RadioConfig_UserPreferences_size         455
+#define RadioConfig_size                         526
+#define RadioConfig_UserPreferences_size         523
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -68,9 +68,22 @@ void MQTT::reconnect()
     if (wantsLink()) {
         const char *serverAddr = "mqtt.meshtastic.org"; // default hostname
         int serverPort = 1883;                          // default server port
+        const char *mqttUsername = "meshdev";
+        const char *mqttPassword = "large4cats";
 
-        if (*radioConfig.preferences.mqtt_server)
+        if (*radioConfig.preferences.mqtt_server) {
             serverAddr = radioConfig.preferences.mqtt_server; // Override the default
+            mqttUsername = radioConfig.preferences.mqtt_username; //do not use the hardcoded credentials for a custom mqtt server
+            mqttPassword = radioConfig.preferences.mqtt_password;
+        } else {
+            //we are using the default server.  Use the hardcoded credentials by default, but allow overriding
+            if (*radioConfig.preferences.mqtt_username && radioConfig.preferences.mqtt_username[0] != '\0') {
+                mqttUsername = radioConfig.preferences.mqtt_username;
+            }
+            if (*radioConfig.preferences.mqtt_password && radioConfig.preferences.mqtt_password[0] != '\0') {
+                mqttPassword = radioConfig.preferences.mqtt_password;
+            }
+        }
 
         String server = String(serverAddr);
         int delimIndex = server.indexOf(':');
@@ -82,9 +95,9 @@ void MQTT::reconnect()
         }
         pubSub.setServer(serverAddr, serverPort);
 
-        DEBUG_MSG("Connecting to MQTT server %s, port: %d\n", serverAddr, serverPort);
+        DEBUG_MSG("Connecting to MQTT server %s, port: %d, username: %s, password %s\n", serverAddr, serverPort, mqttUsername, mqttPassword);
         auto myStatus = (statusTopic + owner.id);
-        bool connected = pubSub.connect(owner.id, "meshdev", "large4cats", myStatus.c_str(), 1, true, "offline");
+        bool connected = pubSub.connect(owner.id, mqttUsername, mqttPassword, myStatus.c_str(), 1, true, "offline");
         if (connected) {
             DEBUG_MSG("MQTT connected\n");
             enabled = true; // Start running background process again


### PR DESCRIPTION
Added mqtt username and password to the UserPreferences (I have a corresponding pull request for the protobufs [here](https://github.com/meshtastic/Meshtastic-protobufs/pull/61) )

If the default server is used, it will default to the hardcoded credentials, but not for a custom mqtt server.