### PR TITLE
CI/CD for building on GitLab instance

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,50 @@
+image: python:latest
+
+variables:
+  # make sure GitLab check out submodules
+  GIT_SUBMODULE_STRATEGY: recursive
+
+stages:
+  - buildall
+  - upload
+
+build:
+  stage: buildall
+
+  before_script:
+    # we need zip later for packaging
+    - "apt update;apt -y install zip"
+    - "pip install -U platformio"
+
+  script:
+    # clean up residues from previous run
+    - rm -rf release
+    - bin/build-all.sh
+
+  # This is for my local environment, if your runners are tagged differently, modify or remove  
+  tags:
+    - dockerized
+
+  # The files which are to be made available in GitLab
+  artifacts:
+    paths:
+      - release/archive/firmware*.zip
+
+
+upload:
+  image: curlimages/curl:latest
+
+  stage: upload
+
+  script:
+    - |
+      PACKAGE_REGISTRY_URL="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/${CI_PROJECT_NAME}/master"
+      cd release/archive
+      for f in *.zip; do
+      curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --upload-file ${f} ${PACKAGE_REGISTRY_URL}/${f}
+      done
+      echo 'Package uploaded!'
+      
+  # This is for my local environment, if your runners are tagged differently, modify or remove
+  tags:
+    - dockerized  


### PR DESCRIPTION
This yml is basically a GitLab CI/CD wrapper for build-all.sh that makes sure the submodules are checked out. After building it pushes a release package to the GitLab registry. Not needed for building on github!

Be ware, this does not run any tests or linting on the code. If it builds, it's uploaded.