### PR TITLE
Use portable shebangs in bash and python scripts

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/dump-ram-users.sh
+++ b/bin/dump-ram-users.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 arm-none-eabi-readelf -s -e .pio/build/nrf52dk/firmware.elf | head -80
 
 nm -CSr --size-sort .pio/build/nrf52dk/firmware.elf  | grep '^200'

--- a/bin/gen-images.sh
+++ b/bin/gen-images.sh
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 
 set -e 
 

--- a/bin/genpartitions.py
+++ b/bin/genpartitions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 # This is a layout for 4MB of flash
 # Name,   Type, SubType, Offset,  Size, Flags

--- a/bin/install-bootloader.sh
+++ b/bin/install-bootloader.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # You probably don't want to use this script, it programs a custom bootloader build onto a nrf52 board
 
 set -e 

--- a/bin/install-eink.sh
+++ b/bin/install-eink.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # You probably don't want to use this script, it programs a custom bootloader build onto a nrf52 board
 
 set -e 

--- a/bin/mqtt-listen.sh
+++ b/bin/mqtt-listen.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 mosquitto_sub -h mqtt.meshtastic.org -v -t \$SYS/\# -t msh/+/stat/\# -t msh/+/json/\#
 # mosquitto_sub -h test.mosquitto.org -v -t mesh/\# -F "%j"

--- a/bin/mqtt-send-status.sh
+++ b/bin/mqtt-send-status.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 mosquitto_pub -h mqtt.meshtastic.org -u meshdev -P large4cats -t msh/1/stat/FakeNode -m online -d

--- a/bin/native-gdbserver.sh
+++ b/bin/native-gdbserver.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 pio run --environment native
 gdbserver --once localhost:2345 .pio/build/native/program "$@"

--- a/bin/native-run.sh
+++ b/bin/native-run.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 pio run --environment native
 .pio/build/native/program "$@"

--- a/bin/nrf52-console.sh
+++ b/bin/nrf52-console.sh
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 
 # JLinkRTTViewer
 JLinkRTTClient

--- a/bin/nrf52832-gdbserver.sh
+++ b/bin/nrf52832-gdbserver.sh
@@ -1,3 +1,3 @@
-
+#!/usr/bin/env bash
 
 JLinkGDBServerCLExe -if SWD -select USB -port 2331 -device NRF52832_XXAA

--- a/bin/nrf52833-gdbserver.sh
+++ b/bin/nrf52833-gdbserver.sh
@@ -1,3 +1,3 @@
-
+#!/usr/bin/env bash
 
 JLinkGDBServerCLExe -if SWD -select USB -port 2331 -device NRF52833_XXAA

--- a/bin/nrf52840-gdbserver.sh
+++ b/bin/nrf52840-gdbserver.sh
@@ -1,3 +1,3 @@
-
+#!/usr/bin/env bash
 
 JLinkGDBServerCLExe -if SWD -select USB -port 2331 -device NRF52840_XXAA -SuppressInfoUpdateFW -DisableAutoUpdateFW -rtos GDBServer/RTOSPlugin_FreeRTOS

--- a/bin/program-1.0-tbeam.sh
+++ b/bin/program-1.0-tbeam.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 esptool.py --baud 921600 write_flash 0x10000 release/archive/old/firmware-tbeam-EU865-1.0.0.bin
 echo "Erasing the otadata partition, which will turn off flash flippy-flop and force the first image to be used"
 esptool.py --baud 921600 erase_region 0xe000 0x2000

--- a/bin/program-1.1-tbeam.sh
+++ b/bin/program-1.1-tbeam.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 esptool.py --baud 921600 write_flash 0x10000 release/archive/old/firmware-tbeam-1.1.50.bin

--- a/bin/program-release-heltec.sh
+++ b/bin/program-release-heltec.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/program-release-tbeam.sh
+++ b/bin/program-release-tbeam.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/program-release-universal.sh
+++ b/bin/program-release-universal.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/promote-release.sh
+++ b/bin/promote-release.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e 
 
 echo "This script is only for developers who are publishing new builds on github.  Most users don't need it"

--- a/bin/qspi-flash-test.sh
+++ b/bin/qspi-flash-test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # You probably don't need this - it is a basic test of the serial flash on the TTGO eink board
 
 nrfjprog --qspiini nrf52/ttgo_eink_qpsi.ini --qspieraseall

--- a/bin/read-system-info.sh
+++ b/bin/read-system-info.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 esptool.py --baud 921600 read_flash 0x1000 0xf000 system-info.img

--- a/bin/regen-protos.sh
+++ b/bin/regen-protos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/run-0-monitor.sh
+++ b/bin/run-0-monitor.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 pio run --upload-port /dev/ttyUSB0 -t upload -t monitor

--- a/bin/run-1-monitor.sh
+++ b/bin/run-1-monitor.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 pio run --upload-port /dev/ttyUSB1 -t upload -t monitor

--- a/bin/run-both-monitor.sh
+++ b/bin/run-both-monitor.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e 
 
 echo uploading to usb1

--- a/bin/run-both.sh
+++ b/bin/run-both.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e 
 
 TARG=tbeam

--- a/bin/run-openocd.sh
+++ b/bin/run-openocd.sh
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 
 # /home/kevinh/.platformio/packages/tool-openocd-esp32/bin/openocd -s /home/kevinh/.platformio/packages/tool-openocd-esp32 -c gdb_port pipe; tcl_port disabled; telnet_port disabled -s /home/kevinh/.platformio/packages/tool-openocd-esp32/share/openocd/scripts -f interface/jlink.cfg -f board/esp-wroom-32.cfg
 /home/kevinh/.platformio/packages/tool-openocd-esp32/bin/openocd -s /home/kevinh/.platformio/packages/tool-openocd-esp32 -s /home/kevinh/.platformio/packages/tool-openocd-esp32/share/openocd/scripts -f interface/jlink.cfg -f ./lora32-openocd.cfg

--- a/bin/start-terminal0.sh
+++ b/bin/start-terminal0.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 pio device monitor -b 921600

--- a/bin/start-terminal1.sh
+++ b/bin/start-terminal1.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 pio device monitor -p /dev/ttyUSB1 -b 921600

--- a/bin/test-simulator.sh
+++ b/bin/test-simulator.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 echo "Starting simulator"

--- a/bin/upload-to-bootloader.sh
+++ b/bin/upload-to-bootloader.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 echo "building for t-echo"

--- a/bin/upload-to-rak4631.sh
+++ b/bin/upload-to-rak4631.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 echo "Converting to uf2 for NRF52 Adafruit bootloader"

--- a/bin/upload-usb1.sh
+++ b/bin/upload-usb1.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 pio run --upload-port /dev/ttyUSB1 -t upload

--- a/bin/view-map.sh
+++ b/bin/view-map.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 echo using amap tool to display memory map
 amap .pio/build/output.map


### PR DESCRIPTION
This PR modifies the scripts in `bin` as follows:

* The shebang lines `#!/bin/bash` and `#!/usr/bin/python2` were rewritten to the portable equivalents `#!/usr/bin/env bash` and `#!/usr/bin/env python2`, respectively. This fixes a bug preventing running these scripts (and therefore compiling firmware or running tooling) in environments like NixOS that do not fully follow POSIX, but almost always have `/usr/bin/env` and `/bin/sh` available for compatibility. 
* Most scripts lacking a shebang had `#!/usr/bin/env bash` prepended to them. This should prevent any issues when the user's shell is not compatible with `bash`, since a script without a shebang can [potentially be executed in the currently running shell, or fail to execute at all](https://stackoverflow.com/a/9945113).