### PR TITLE
Fix SSD1306 OLED pinout on TLORA_V1_3

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -428,8 +428,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 
-#define I2C_SDA 4 // I2C pins for this board
-#define I2C_SCL 15
+#define I2C_SDA 21 // I2C pins for this board
+#define I2C_SCL 22
 
 #define RESET_OLED 16 // If defined, this pin will be used to reset the display controller
 


### PR DESCRIPTION
The V1.3 board OLED pinout changed from V1
Now on pin SDA(21) and SCL(22) not SDA(4) and SCL(15)

LILYGO Product Page
http://www.lilygo.cn/prod_view.aspx?TypeId=50060&Id=1253&FId=t3:50060:3

Product Pin
https://ae01.alicdn.com/kf/H098cb5d5159841b398fcfd4ebf705725W.jpg

## Thank you for sending in a pull request, here's some tips to get started!

(Please delete all these tips and replace with your text)

- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentially duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor and the 'clang-format' extension,
  because automatically follows our indentation rules and it's auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
