### PR TITLE
add DHT22

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -44,9 +44,6 @@ shift "$((OPTIND-1))"
     shift
 }
 
-# check that esptool is installed
-"$PYTHON" -m esptool -h >/dev/null 2>&1 || echo "Error: esptool was not found."; exit 1
-
 if [ -f "${FILENAME}" ]; then
 	echo "Trying to flash ${FILENAME}, but first erasing and writing system information"
 	"$PYTHON" -m esptool  erase_flash

--- a/src/mesh/generated/radioconfig.pb.h
+++ b/src/mesh/generated/radioconfig.pb.h
@@ -92,7 +92,10 @@ typedef enum _InputEventChar {
 
 typedef enum _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType {
     RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11 = 0,
-    RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DS18B20 = 1
+    RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DS18B20 = 1,
+    RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT12 = 2,
+    RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT21 = 3,
+    RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22 = 4
 } RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType;
 
 /* Struct definitions */
@@ -176,7 +179,7 @@ typedef struct _RadioConfig_UserPreferences {
     InputEventChar rotary1_event_ccw;
     InputEventChar rotary1_event_press;
     bool canned_message_plugin_enabled;
-    char canned_message_plugin_allow_input_origin[16];
+    char canned_message_plugin_allow_input_source[16];
     char canned_message_plugin_messages[1024];
     bool canned_message_plugin_send_bell;
 } RadioConfig_UserPreferences;
@@ -217,8 +220,8 @@ typedef struct _RadioConfig {
 #define _InputEventChar_ARRAYSIZE ((InputEventChar)(InputEventChar_BACK+1))
 
 #define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MIN RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11
-#define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MAX RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DS18B20
-#define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_ARRAYSIZE ((RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType)(RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DS18B20+1))
+#define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_MAX RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22
+#define _RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_ARRAYSIZE ((RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType)(RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22+1))
 
 
 #ifdef __cplusplus
@@ -310,7 +313,7 @@ extern "C" {
 #define RadioConfig_UserPreferences_rotary1_event_ccw_tag 165
 #define RadioConfig_UserPreferences_rotary1_event_press_tag 166
 #define RadioConfig_UserPreferences_canned_message_plugin_enabled_tag 170
-#define RadioConfig_UserPreferences_canned_message_plugin_allow_input_origin_tag 171
+#define RadioConfig_UserPreferences_canned_message_plugin_allow_input_source_tag 171
 #define RadioConfig_UserPreferences_canned_message_plugin_messages_tag 172
 #define RadioConfig_UserPreferences_canned_message_plugin_send_bell_tag 173
 #define RadioConfig_preferences_tag              1
@@ -401,7 +404,7 @@ X(a, STATIC,   SINGULAR, UENUM,    rotary1_event_cw, 164) \
 X(a, STATIC,   SINGULAR, UENUM,    rotary1_event_ccw, 165) \
 X(a, STATIC,   SINGULAR, UENUM,    rotary1_event_press, 166) \
 X(a, STATIC,   SINGULAR, BOOL,     canned_message_plugin_enabled, 170) \
-X(a, STATIC,   SINGULAR, STRING,   canned_message_plugin_allow_input_origin, 171) \
+X(a, STATIC,   SINGULAR, STRING,   canned_message_plugin_allow_input_source, 171) \
 X(a, STATIC,   SINGULAR, STRING,   canned_message_plugin_messages, 172) \
 X(a, STATIC,   SINGULAR, BOOL,     canned_message_plugin_send_bell, 173)
 #define RadioConfig_UserPreferences_CALLBACK NULL

--- a/src/plugins/CannedMessagePlugin.cpp
+++ b/src/plugins/CannedMessagePlugin.cpp
@@ -81,9 +81,9 @@ int CannedMessagePlugin::splitConfiguredMessages()
 int CannedMessagePlugin::handleInputEvent(const InputEvent *event)
 {
     if (
-        (strlen(radioConfig.preferences.canned_message_plugin_allow_input_origin) > 0) &&
-        (strcmp(radioConfig.preferences.canned_message_plugin_allow_input_origin, event->source) != 0) &&
-        (strcmp(radioConfig.preferences.canned_message_plugin_allow_input_origin, "_any") != 0))
+        (strlen(radioConfig.preferences.canned_message_plugin_allow_input_source) > 0) &&
+        (strcmp(radioConfig.preferences.canned_message_plugin_allow_input_source, event->source) != 0) &&
+        (strcmp(radioConfig.preferences.canned_message_plugin_allow_input_source, "_any") != 0))
     {
         // Event source is not accepted.
         return 0;

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -86,6 +86,13 @@ int32_t EnvironmentalMeasurementPlugin::runOnce()
                 DEBUG_MSG("EnvironmentalMeasurement: Opened DS18B20 on pin: %d\n",
                           radioConfig.preferences.environmental_measurement_plugin_sensor_pin);
                 return (DS18B20_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
+            case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22:
+                dht = new DHT(radioConfig.preferences.environmental_measurement_plugin_sensor_pin, DHT22);
+                this->dht->begin();
+                this->dht->read();
+                DEBUG_MSG("EnvironmentalMeasurement: Opened DHT22 on pin: %d\n",
+                          radioConfig.preferences.environmental_measurement_plugin_sensor_pin);
+                return (DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             default:
                 DEBUG_MSG("EnvironmentalMeasurement: Invalid sensor type selected; Disabling plugin");
                 return (INT32_MAX);
@@ -132,6 +139,8 @@ int32_t EnvironmentalMeasurementPlugin::runOnce()
                 return (DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DS18B20:
                 return (DS18B20_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
+            case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22:
+                return (DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             default:
                 return (DEFAULT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             }
@@ -264,6 +273,15 @@ bool EnvironmentalMeasurementPlugin::sendOurEnvironmentalMeasurement(NodeNum des
             DEBUG_MSG("EnvironmentalMeasurement: FAILED TO READ DATA\n");
             return false;
         }
+    case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22:
+        if (!this->dht->read(true)) {
+            sensor_read_error_count++;
+            DEBUG_MSG("EnvironmentalMeasurement: FAILED TO READ DATA\n");
+            return false;
+        }
+        m.relative_humidity = this->dht->readHumidity();
+        m.temperature = this->dht->readTemperature();
+        break;
     default:
         DEBUG_MSG("EnvironmentalMeasurement: Invalid sensor type selected; Disabling plugin");
         return false;

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -71,10 +71,11 @@ int32_t EnvironmentalMeasurementPlugin::runOnce()
             // therefore, we should only enable the sensor loop if measurement is also enabled
             switch (radioConfig.preferences.environmental_measurement_plugin_sensor_type) {
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11:
+            case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT12:
                 dht = new DHT(radioConfig.preferences.environmental_measurement_plugin_sensor_pin, DHT11);
                 this->dht->begin();
                 this->dht->read();
-                DEBUG_MSG("EnvironmentalMeasurement: Opened DHT11 on pin: %d\n",
+                DEBUG_MSG("EnvironmentalMeasurement: Opened DHT11/DHT12 on pin: %d\n",
                           radioConfig.preferences.environmental_measurement_plugin_sensor_pin);
                 return (DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DS18B20:
@@ -86,11 +87,12 @@ int32_t EnvironmentalMeasurementPlugin::runOnce()
                 DEBUG_MSG("EnvironmentalMeasurement: Opened DS18B20 on pin: %d\n",
                           radioConfig.preferences.environmental_measurement_plugin_sensor_pin);
                 return (DS18B20_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
+            case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT21:
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22:
                 dht = new DHT(radioConfig.preferences.environmental_measurement_plugin_sensor_pin, DHT22);
                 this->dht->begin();
                 this->dht->read();
-                DEBUG_MSG("EnvironmentalMeasurement: Opened DHT22 on pin: %d\n",
+                DEBUG_MSG("EnvironmentalMeasurement: Opened DHT21/DHT22 on pin: %d\n",
                           radioConfig.preferences.environmental_measurement_plugin_sensor_pin);
                 return (DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             default:
@@ -136,9 +138,11 @@ int32_t EnvironmentalMeasurementPlugin::runOnce()
 
             switch (radioConfig.preferences.environmental_measurement_plugin_sensor_type) {
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11:
+            case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT12:
                 return (DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DS18B20:
                 return (DS18B20_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
+            case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT21:
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22:
                 return (DHT_SENSOR_MINIMUM_WAIT_TIME_BETWEEN_READS);
             default:
@@ -254,6 +258,7 @@ bool EnvironmentalMeasurementPlugin::sendOurEnvironmentalMeasurement(NodeNum des
 
     switch (radioConfig.preferences.environmental_measurement_plugin_sensor_type) {
     case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11:
+    case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT12:
         if (!this->dht->read(true)) {
             sensor_read_error_count++;
             DEBUG_MSG("EnvironmentalMeasurement: FAILED TO READ DATA\n");
@@ -273,6 +278,7 @@ bool EnvironmentalMeasurementPlugin::sendOurEnvironmentalMeasurement(NodeNum des
             DEBUG_MSG("EnvironmentalMeasurement: FAILED TO READ DATA\n");
             return false;
         }
+    case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT21:
     case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT22:
         if (!this->dht->read(true)) {
             sensor_read_error_count++;

--- a/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
+++ b/src/plugins/esp32/EnvironmentalMeasurementPlugin.cpp
@@ -70,6 +70,7 @@ int32_t EnvironmentalMeasurementPlugin::runOnce()
             // it's possible to have this plugin enabled, only for displaying values on the screen.
             // therefore, we should only enable the sensor loop if measurement is also enabled
             switch (radioConfig.preferences.environmental_measurement_plugin_sensor_type) {
+
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT11:
             case RadioConfig_UserPreferences_EnvironmentalMeasurementSensorType_DHT12:
                 dht = new DHT(radioConfig.preferences.environmental_measurement_plugin_sensor_pin, DHT11);


### PR DESCRIPTION
Add DHT22 sensor (similar to the DHT11 sensor, but the library does different stuff):

For example, from DHT.cpp:

```
    switch (_type) {
    case DHT11:
    case DHT12:
      f = data[0] + data[1] * 0.1;
      break;
    case DHT22:
    case DHT21:
      f = ((word)data[0]) << 8 | data[1];
      f *= 0.1;
      break;
    }
```
