### PR TITLE
Correction for wrong battery display on tlora_v2_1_16 board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = tbeam
+;default_envs = tbeam
 ;default_envs = tbeam0.7
 ;default_envs = heltec-v2.0
 ;default_envs = heltec-v1
@@ -17,7 +17,7 @@ default_envs = tbeam
 ;default_envs = tlora-v1
 ;default_envs = tlora_v1_3
 ;default_envs = tlora-v2
-;default_envs = tlora-v2-1-1.6
+default_envs = tlora-v2-1-1.6
 ;default_envs = lora-relay-v1 # nrf board
 ;default_envs = t-echo
 ;default_envs = nrf52840dk-geeksville

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-;default_envs = tbeam
+default_envs = tbeam
 ;default_envs = tbeam0.7
 ;default_envs = heltec-v2.0
 ;default_envs = heltec-v1
@@ -17,7 +17,7 @@
 ;default_envs = tlora-v1
 ;default_envs = tlora_v1_3
 ;default_envs = tlora-v2
-default_envs = tlora-v2-1-1.6
+;default_envs = tlora-v2-1-1.6
 ;default_envs = lora-relay-v1 # nrf board
 ;default_envs = t-echo
 ;default_envs = nrf52840dk-geeksville

--- a/variants/tlora_v2_1_16/variant.h
+++ b/variants/tlora_v2_1_16/variant.h
@@ -4,6 +4,8 @@
 #define GPS_TX_PIN 13
 
 #define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
+// ratio of voltage divider = 2.0 (R42=100k, R43=100k)
+#define ADC_MULTIPLIER 2.2 // 2.0 + 10% for correction of display undervoltage.
 
 #define I2C_SDA 21 // I2C pins for this board
 #define I2C_SCL 22


### PR DESCRIPTION
Added a ADC_MULTIPLIER for tlora_v2_1_16 board
 the display was showing 3.81V and 60% for a full battery, which measured 4.18V

after adding #define ADC_MULTIPLIER 2.2  the display was within 1% accurate.