### PR TITLE
Split platformio.ini into one file for each board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,6 +28,10 @@ default_envs = tbeam
 ;default_envs = meshtastic-diy-v1
 ;default_envs = meshtastic-diy-v1.1
 
+; board specific config can be moved to the respective 'variants' file.
+; See https://docs.platformio.org/en/latest/projectconf/section_platformio.html#extra-configs
+extra_configs = variants/*/platformio.ini
+
 [common]
 ; common is not currently used
 
@@ -163,89 +167,6 @@ board_build.partitions = partition-table.csv
 
 ; -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
 
-; The 1.0 release of the TBEAM board 
-[env:tbeam]
-extends = esp32_base
-board = ttgo-t-beam
-lib_deps =
-  ${esp32_base.lib_deps}
-build_flags = 
-  ${esp32_base.build_flags} -D TBEAM_V10  -I variants/tbeam
-
-; The original TBEAM board without the AXP power chip and a few other changes
-; Note: I've heard reports this didn't work.  Disabled until someone with a 0.7 can test and debug.
-[env:tbeam0.7]
-extends = esp32_base
-board = ttgo-t-beam
-build_flags = 
-  ${esp32_base.build_flags} -D TBEAM_V07 -I variants/tbeam_v07
-
-[env:heltec-v1]
-;build_type = debug ; to make it possible to step through our jtag debugger 
-extends = esp32_base
-board = heltec_wifi_lora_32
-build_flags = 
-  ${esp32_base.build_flags} -D HELTEC_V1 -I variants/heltec_v1
-
-[env:heltec-v2.0]
-;build_type = debug ; to make it possible to step through our jtag debugger 
-extends = esp32_base
-board = heltec_wifi_lora_32_V2
-build_flags = 
-  ${esp32_base.build_flags} -D HELTEC_V2_0 -I variants/heltec_v2
-
-[env:heltec-v2.1]
-;build_type = debug ; to make it possible to step through our jtag debugger 
-extends = esp32_base
-board = heltec_wifi_lora_32_V2
-build_flags = 
-  ${esp32_base.build_flags} -D HELTEC_V2_1 -I variants/heltec_v2.1
-
-[env:tlora-v1]
-extends = esp32_base
-board = ttgo-lora32-v1
-build_flags = 
-  ${esp32_base.build_flags} -D TLORA_V1 -I variants/tlora_v1
-
-; note: the platformio definition for lora32-v2 seems stale, it is missing a pins_arduino.h file, therefore I don't think it works
-[env:tlora_v1_3]
-extends = esp32_base
-board = ttgo-lora32-v1
-build_flags = 
-  ${esp32_base.build_flags} -D TLORA_V1_3 -I variants/tlora_v1_3
-
-[env:tlora-v2]
-extends = esp32_base
-board = ttgo-lora32-v1
-build_flags = 
-  ${esp32_base.build_flags} -D TLORA_V2 -I variants/tlora_v2
-
-[env:tlora-v2-1-1.6]
-extends = esp32_base
-board = ttgo-lora32-v1
-build_flags = 
-  ${esp32_base.build_flags} -D TLORA_V2_1_16 -I variants/tlora_v2_1_16
-
-; Meshtastic DIY v1 by Nano VHF Schematic based on ESP32-WROOM-32 (38 pins) devkit & EBYTE E22 SX1262/SX1268 module
-[env:meshtastic-diy-v1]
-extends = esp32_base
-board = esp32doit-devkit-v1
-build_flags =
-  ${esp32_base.build_flags}
-  -D DIY_V1
-  -D EBYTE_E22
-  -I variants/meshtastic_diy_v1
-
-; Meshtastic DIY v1.1 new schematic based on ESP32-WROOM-32 & SX1262/SX1268 modules
-[env:meshtastic-diy-v1.1]
-extends = esp32_base
-board = esp32doit-devkit-v1
-build_flags =
-  ${esp32_base.build_flags}
-  -D DIY_V1
-  -D EBYTE_E22
-  -I variants/diy/v1_1
-
 ; The Heltec Cubecell plus 
 ; IMPORTANT NOTE: This target doesn't yet work and probably won't ever work.  I'm keeping it around for now.
 ; For more details see my post in the forum.
@@ -320,37 +241,11 @@ lib_deps =
   # Adafruit TinyUSB Arduino
   # add Adafruit nRFCrypto platform IO automated scan is broken
 
-[env:lora_isp4520]
-extends = nrf52_base
-board = lora_isp4520
-
-# add our variants files to the include and src paths
-build_flags = ${nrf52_base.build_flags} -Ivariants/lora_isp4520
-
-# No screen and GPS on the board. We still need RTC.cpp for the RTC clock.
-src_filter = ${nrf52_base.src_filter} +<../variants/lora_isp4520> -<graphics> -<gps> +<gps/GPS.cpp> +<gps/RTC.cpp>
-lib_ignore = ${nrf52_base.lib_ignore} 
-  ESP8266_SSD1306
-  SparkFun Ublox Arduino Library
-  AXP202X_Library
-  TinyGPSPlus
-
-upload_protocol = jlink
-monitor_port = /dev/ttyUSB0
-
 ; The NRF52840-dk development board
 ; Note: By default no lora device is created for this build - it uses a simulated interface
 [env:nrf52840dk]
 extends = nrf52840_base
 board = nrf52840_dk
-
-; The NRF52840-dk development board, but @geeksville's board - which has a busted oscilliator 
-[env:nrf52840dk-geeksville]
-extends = nrf52840_base
-board = nrf52840_dk_modified
-# add our variants files to the include and src paths
-build_flags = ${nrf52_base.build_flags} -Ivariants/pca10056-rc-clock
-src_filter = ${nrf52_base.src_filter} +<../variants/pca10056-rc-clock>
 
 ; Note: By default no lora device is created for this build - it uses a simulated interface
 [env:feather_nrf52832]
@@ -368,165 +263,3 @@ monitor_speed = 115200
 
 # For experimenting with RAM sizes
 # board_build.ldscript = linker/nrf52840_s140_sim832.ld
-
-; The very slick RAK wireless RAK 4631 / 4630 board
-[env:rak4631_5005]
-extends = nrf52840_base
-board = wiscore_rak4631
-# add our variants files to the include and src paths
-# define build flags for the TFT_eSPI library
-build_flags = ${nrf52840_base.build_flags} -Ivariants/WisCore_RAK4631_Board -D RAK_BASE_5005
-src_filter = ${nrf52_base.src_filter} +<../variants/WisCore_RAK4631_Board>
-debug_tool = jlink
-
-[env:rak4631_19003]
-extends = nrf52840_base
-board = wiscore_rak4631
-# add our variants files to the include and src paths
-# define build flags for the TFT_eSPI library
-build_flags = ${nrf52840_base.build_flags} -Ivariants/WisCore_RAK4631_Board -D RAK_BASE_19003
-src_filter = ${nrf52_base.src_filter} +<../variants/WisCore_RAK4631_Board>
-debug_tool = jlink
-; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
-;upload_protocol = jlink
-
-; The PPR board
-[env:ppr]
-extends = nrf52_base
-board = ppr
-lib_deps = 
-  ${arduino_base.lib_deps}
-  UC1701
-
-; The PPR board
-[env:ppr1]
-extends = nrf52_base
-board = ppr1
-build_flags = ${nrf52_base.build_flags} -Ivariants/ppr1
-src_filter = ${nrf52_base.src_filter} +<../variants/ppr1>
-lib_deps = 
-  ${arduino_base.lib_deps}
-
-; First prototype eink/nrf52840/sx1262 device
-[env:t-echo]
-extends = nrf52840_base
-board = t-echo
-debug_tool = jlink
-upload_protocol = jlink
-# add our variants files to the include and src paths
-# define build flags for the TFT_eSPI library - NOTE: WE NOT LONGER USE TFT_eSPI, it was for an earlier version of the TTGO eink screens
-# -DBUSY_PIN=3 -DRST_PIN=2 -DDC_PIN=28 -DCS_PIN=30
-# add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
-build_flags = ${nrf52840_base.build_flags} -Ivariants/t-echo 
-src_filter = ${nrf52_base.src_filter} +<../variants/t-echo>
-lib_deps = 
-  ${nrf52840_base.lib_deps}
-  https://github.com/geeksville/GxEPD2.git
-  adafruit/Adafruit BusIO
-;upload_protocol = fs
-
-; First prototype eink/nrf52840/sx1262 device (removed from build because didn't ship in quantity)
-;[env:eink0.1]
-;extends = nrf52840_base
-;board = eink0.1
-;# add our variants files to the include and src paths
-;# define build flags for the TFT_eSPI library
-;build_flags = ${nrf52_base.build_flags} -Ivariants/eink0.1
-;  -DBUSY_PIN=3 -DRST_PIN=2 -DDC_PIN=28 -DCS_PIN=30
-;src_filter = ${nrf52_base.src_filter} +<../variants/eink0.1>
-;lib_deps = 
-;  ${nrf52840_base.lib_deps}
-;  https://github.com/geeksville/EPD_Libraries.git
-;  TFT_eSPI
-
-; The https://github.com/BigCorvus/SX1262-LoRa-BLE-Relay board by @BigCorvus
-[env:lora-relay-v1]
-extends = nrf52840_base
-board = lora-relay-v1
-# add our variants files to the include and src paths
-# define build flags for the TFT_eSPI library
-build_flags = ${nrf52840_base.build_flags} -Ivariants/lora_relay_v1
-  -DUSER_SETUP_LOADED
-  -DTFT_WIDTH=80
-  -DTFT_HEIGHT=160
-  -DST7735_GREENTAB160x80
-  -DST7735_DRIVER
-  -DTFT_CS=ST7735_CS
-  -DTFT_DC=ST7735_RS
-  -DTFT_RST=ST7735_RESET
-  -DSPI_FREQUENCY=27000000
-src_filter = ${nrf52_base.src_filter} +<../variants/lora_relay_v1>
-lib_deps = 
-  ${nrf52840_base.lib_deps}
-  SparkFun BQ27441 LiPo Fuel Gauge Arduino Library
-  TFT_eSPI
-
-; The https://github.com/BigCorvus/LoRa-BLE-Relay-v2 board by @BigCorvus
-[env:lora-relay-v2]
-extends = nrf52840_base
-board = lora-relay-v2
-# add our variants files to the include and src paths
-# define build flags for the TFT_eSPI library
-build_flags = ${nrf52840_base.build_flags} -Ivariants/lora_relay_v2
-  -DUSER_SETUP_LOADED
-  -DTFT_WIDTH=80
-  -DTFT_HEIGHT=160
-  -DST7735_GREENTAB160x80
-  -DST7735_DRIVER
-  -DTFT_CS=ST7735_CS
-  -DTFT_DC=ST7735_RS
-  -DTFT_RST=ST7735_RESET
-  -DSPI_FREQUENCY=27000000
-  -DTFT_WR=ST7735_SDA
-  -DTFT_SCLK=ST7735_SCK
-src_filter = ${nrf52_base.src_filter} +<../variants/lora_relay_v2>
-lib_deps = 
-  ${nrf52840_base.lib_deps}
-  SparkFun BQ27441 LiPo Fuel Gauge Arduino Library
-  TFT_eSPI
-
-; The Portduino based sim environment on top of any host OS, all hardware will be simulated
-[env:native]
-platform = https://github.com/geeksville/platform-native.git 
-src_filter = 
-  ${env.src_filter} 
-  -<esp32/> 
-  -<nimble/> 
-  -<nrf52/> 
-  -<mesh/http/> 
-  -<plugins/esp32>
-  -<plugins/EnvironmentalMeasurementPlugin.cpp*>
-  +<../variants/portduino>
-build_flags = ${arduino_base.build_flags} -O0 -I variants/portduino
-framework = arduino
-board = cross_platform
-lib_deps =
-  ${arduino_base.lib_deps}
-  rweather/Crypto
-
-; The Portduino based sim environment on top of a linux OS and touching linux hardware devices
-[env:linux]
-platform = https://github.com/geeksville/platform-native.git 
-src_filter = 
-  ${env.src_filter} 
-  -<esp32/> 
-  -<nimble/> 
-  -<nrf52/> 
-  -<mesh/http/> 
-  -<plugins/esp32>
-  -<plugins/EnvironmentalMeasurementPlugin.cpp*>
-  +<../variants/portduino>
-build_flags = ${arduino_base.build_flags} -O0 -lgpiod -I variants/portduino
-framework = arduino
-board = linux_hardware
-lib_deps =
-  ${arduino_base.lib_deps}
-  rweather/Crypto
-
-; The GenieBlocks LORA prototype board
-; note: @geeksville disabled because genieblocks_lora is not checked into the boards directory, please send in a PR to add it ;-)
-;[env:genieblocks_lora]
-;extends = esp32_base
-;board = genieblocks_lora
-;build_flags = 
-;  ${esp32_base.build_flags} -D GENIEBLOCKS -Ivariants/genieblocks

--- a/variants/WisCore_RAK4631_Board/platformio.ini
+++ b/variants/WisCore_RAK4631_Board/platformio.ini
@@ -1,0 +1,20 @@
+; The very slick RAK wireless RAK 4631 / 4630 board
+[env:rak4631_5005]
+extends = nrf52840_base
+board = wiscore_rak4631
+# add our variants files to the include and src paths
+# define build flags for the TFT_eSPI library
+build_flags = ${nrf52840_base.build_flags} -Ivariants/WisCore_RAK4631_Board -D RAK_BASE_5005
+src_filter = ${nrf52_base.src_filter} +<../variants/WisCore_RAK4631_Board>
+debug_tool = jlink
+
+[env:rak4631_19003]
+extends = nrf52840_base
+board = wiscore_rak4631
+# add our variants files to the include and src paths
+# define build flags for the TFT_eSPI library
+build_flags = ${nrf52840_base.build_flags} -Ivariants/WisCore_RAK4631_Board -D RAK_BASE_19003
+src_filter = ${nrf52_base.src_filter} +<../variants/WisCore_RAK4631_Board>
+debug_tool = jlink
+; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
+;upload_protocol = jlink

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -1,0 +1,9 @@
+; Meshtastic DIY v1.1 new schematic based on ESP32-WROOM-32 & SX1262/SX1268 modules
+[env:meshtastic-diy-v1.1]
+extends = esp32_base
+board = esp32doit-devkit-v1
+build_flags =
+  ${esp32_base.build_flags}
+  -D DIY_V1
+  -D EBYTE_E22
+  -I variants/diy/v1_1

--- a/variants/eink0.1/platformio.ini
+++ b/variants/eink0.1/platformio.ini
@@ -1,0 +1,13 @@
+; First prototype eink/nrf52840/sx1262 device (removed from build because didn't ship in quantity)
+;[env:eink0.1]
+;extends = nrf52840_base
+;board = eink0.1
+;# add our variants files to the include and src paths
+;# define build flags for the TFT_eSPI library
+;build_flags = ${nrf52_base.build_flags} -Ivariants/eink0.1
+;  -DBUSY_PIN=3 -DRST_PIN=2 -DDC_PIN=28 -DCS_PIN=30
+;src_filter = ${nrf52_base.src_filter} +<../variants/eink0.1>
+;lib_deps = 
+;  ${nrf52840_base.lib_deps}
+;  https://github.com/geeksville/EPD_Libraries.git
+;  TFT_eSPI

--- a/variants/genieblocks/platformio.ini
+++ b/variants/genieblocks/platformio.ini
@@ -1,0 +1,7 @@
+; The GenieBlocks LORA prototype board
+; note: @geeksville disabled because genieblocks_lora is not checked into the boards directory, please send in a PR to add it ;-)
+;[env:genieblocks_lora]
+;extends = esp32_base
+;board = genieblocks_lora
+;build_flags = 
+;  ${esp32_base.build_flags} -D GENIEBLOCKS -Ivariants/genieblocks

--- a/variants/heltec_v1/platformio.ini
+++ b/variants/heltec_v1/platformio.ini
@@ -1,0 +1,6 @@
+[env:heltec-v1]
+;build_type = debug ; to make it possible to step through our jtag debugger 
+extends = esp32_base
+board = heltec_wifi_lora_32
+build_flags = 
+  ${esp32_base.build_flags} -D HELTEC_V1 -I variants/heltec_v1

--- a/variants/heltec_v2.1/platformio.ini
+++ b/variants/heltec_v2.1/platformio.ini
@@ -1,0 +1,6 @@
+[env:heltec-v2.1]
+;build_type = debug ; to make it possible to step through our jtag debugger 
+extends = esp32_base
+board = heltec_wifi_lora_32_V2
+build_flags = 
+  ${esp32_base.build_flags} -D HELTEC_V2_1 -I variants/heltec_v2.1

--- a/variants/heltec_v2/platformio.ini
+++ b/variants/heltec_v2/platformio.ini
@@ -1,0 +1,6 @@
+[env:heltec-v2.0]
+;build_type = debug ; to make it possible to step through our jtag debugger 
+extends = esp32_base
+board = heltec_wifi_lora_32_V2
+build_flags = 
+  ${esp32_base.build_flags} -D HELTEC_V2_0 -I variants/heltec_v2

--- a/variants/lora_isp4520/platformio.ini
+++ b/variants/lora_isp4520/platformio.ini
@@ -1,0 +1,17 @@
+[env:lora_isp4520]
+extends = nrf52_base
+board = lora_isp4520
+
+# add our variants files to the include and src paths
+build_flags = ${nrf52_base.build_flags} -Ivariants/lora_isp4520
+
+# No screen and GPS on the board. We still need RTC.cpp for the RTC clock.
+src_filter = ${nrf52_base.src_filter} +<../variants/lora_isp4520> -<graphics> -<gps> +<gps/GPS.cpp> +<gps/RTC.cpp>
+lib_ignore = ${nrf52_base.lib_ignore} 
+  ESP8266_SSD1306
+  SparkFun Ublox Arduino Library
+  AXP202X_Library
+  TinyGPSPlus
+
+upload_protocol = jlink
+monitor_port = /dev/ttyUSB0

--- a/variants/lora_relay_v1/platformio.ini
+++ b/variants/lora_relay_v1/platformio.ini
@@ -1,0 +1,21 @@
+; The https://github.com/BigCorvus/SX1262-LoRa-BLE-Relay board by @BigCorvus
+[env:lora-relay-v1]
+extends = nrf52840_base
+board = lora-relay-v1
+# add our variants files to the include and src paths
+# define build flags for the TFT_eSPI library
+build_flags = ${nrf52840_base.build_flags} -Ivariants/lora_relay_v1
+  -DUSER_SETUP_LOADED
+  -DTFT_WIDTH=80
+  -DTFT_HEIGHT=160
+  -DST7735_GREENTAB160x80
+  -DST7735_DRIVER
+  -DTFT_CS=ST7735_CS
+  -DTFT_DC=ST7735_RS
+  -DTFT_RST=ST7735_RESET
+  -DSPI_FREQUENCY=27000000
+src_filter = ${nrf52_base.src_filter} +<../variants/lora_relay_v1>
+lib_deps = 
+  ${nrf52840_base.lib_deps}
+  SparkFun BQ27441 LiPo Fuel Gauge Arduino Library
+  TFT_eSPI

--- a/variants/lora_relay_v2/platformio.ini
+++ b/variants/lora_relay_v2/platformio.ini
@@ -1,0 +1,23 @@
+; The https://github.com/BigCorvus/LoRa-BLE-Relay-v2 board by @BigCorvus
+[env:lora-relay-v2]
+extends = nrf52840_base
+board = lora-relay-v2
+# add our variants files to the include and src paths
+# define build flags for the TFT_eSPI library
+build_flags = ${nrf52840_base.build_flags} -Ivariants/lora_relay_v2
+  -DUSER_SETUP_LOADED
+  -DTFT_WIDTH=80
+  -DTFT_HEIGHT=160
+  -DST7735_GREENTAB160x80
+  -DST7735_DRIVER
+  -DTFT_CS=ST7735_CS
+  -DTFT_DC=ST7735_RS
+  -DTFT_RST=ST7735_RESET
+  -DSPI_FREQUENCY=27000000
+  -DTFT_WR=ST7735_SDA
+  -DTFT_SCLK=ST7735_SCK
+src_filter = ${nrf52_base.src_filter} +<../variants/lora_relay_v2>
+lib_deps = 
+  ${nrf52840_base.lib_deps}
+  SparkFun BQ27441 LiPo Fuel Gauge Arduino Library
+  TFT_eSPI

--- a/variants/meshtastic_diy_v1/platformio.ini
+++ b/variants/meshtastic_diy_v1/platformio.ini
@@ -1,0 +1,9 @@
+; Meshtastic DIY v1 by Nano VHF Schematic based on ESP32-WROOM-32 (38 pins) devkit & EBYTE E22 SX1262/SX1268 module
+[env:meshtastic-diy-v1]
+extends = esp32_base
+board = esp32doit-devkit-v1
+build_flags =
+  ${esp32_base.build_flags}
+  -D DIY_V1
+  -D EBYTE_E22
+  -I variants/meshtastic_diy_v1

--- a/variants/pca10056-rc-clock/platformio.ini
+++ b/variants/pca10056-rc-clock/platformio.ini
@@ -1,0 +1,7 @@
+; The NRF52840-dk development board, but @geeksville's board - which has a busted oscilliator 
+[env:nrf52840dk-geeksville]
+extends = nrf52840_base
+board = nrf52840_dk_modified
+# add our variants files to the include and src paths
+build_flags = ${nrf52_base.build_flags} -Ivariants/pca10056-rc-clock
+src_filter = ${nrf52_base.src_filter} +<../variants/pca10056-rc-clock>

--- a/variants/portduino/platformio.ini
+++ b/variants/portduino/platformio.ini
@@ -1,0 +1,37 @@
+; The Portduino based sim environment on top of any host OS, all hardware will be simulated
+[env:native]
+platform = https://github.com/geeksville/platform-native.git 
+src_filter = 
+  ${env.src_filter} 
+  -<esp32/> 
+  -<nimble/> 
+  -<nrf52/> 
+  -<mesh/http/> 
+  -<plugins/esp32>
+  -<plugins/EnvironmentalMeasurementPlugin.cpp*>
+  +<../variants/portduino>
+build_flags = ${arduino_base.build_flags} -O0 -I variants/portduino
+framework = arduino
+board = cross_platform
+lib_deps =
+  ${arduino_base.lib_deps}
+  rweather/Crypto
+
+; The Portduino based sim environment on top of a linux OS and touching linux hardware devices
+[env:linux]
+platform = https://github.com/geeksville/platform-native.git 
+src_filter = 
+  ${env.src_filter} 
+  -<esp32/> 
+  -<nimble/> 
+  -<nrf52/> 
+  -<mesh/http/> 
+  -<plugins/esp32>
+  -<plugins/EnvironmentalMeasurementPlugin.cpp*>
+  +<../variants/portduino>
+build_flags = ${arduino_base.build_flags} -O0 -lgpiod -I variants/portduino
+framework = arduino
+board = linux_hardware
+lib_deps =
+  ${arduino_base.lib_deps}
+  rweather/Crypto

--- a/variants/ppr/platformio.ini
+++ b/variants/ppr/platformio.ini
@@ -1,0 +1,7 @@
+; The PPR board
+[env:ppr]
+extends = nrf52_base
+board = ppr
+lib_deps = 
+  ${arduino_base.lib_deps}
+  UC1701

--- a/variants/ppr1/platformio.ini
+++ b/variants/ppr1/platformio.ini
@@ -1,0 +1,8 @@
+; The PPR board
+[env:ppr1]
+extends = nrf52_base
+board = ppr1
+build_flags = ${nrf52_base.build_flags} -Ivariants/ppr1
+src_filter = ${nrf52_base.src_filter} +<../variants/ppr1>
+lib_deps = 
+  ${arduino_base.lib_deps}

--- a/variants/t-echo/platformio.ini
+++ b/variants/t-echo/platformio.ini
@@ -1,0 +1,17 @@
+; First prototype eink/nrf52840/sx1262 device
+[env:t-echo]
+extends = nrf52840_base
+board = t-echo
+debug_tool = jlink
+upload_protocol = jlink
+# add our variants files to the include and src paths
+# define build flags for the TFT_eSPI library - NOTE: WE NOT LONGER USE TFT_eSPI, it was for an earlier version of the TTGO eink screens
+# -DBUSY_PIN=3 -DRST_PIN=2 -DDC_PIN=28 -DCS_PIN=30
+# add -DCFG_SYSVIEW if you want to use the Segger systemview tool for OS profiling.
+build_flags = ${nrf52840_base.build_flags} -Ivariants/t-echo 
+src_filter = ${nrf52_base.src_filter} +<../variants/t-echo>
+lib_deps = 
+  ${nrf52840_base.lib_deps}
+  https://github.com/geeksville/GxEPD2.git
+  adafruit/Adafruit BusIO
+;upload_protocol = fs

--- a/variants/tbeam/platformio.ini
+++ b/variants/tbeam/platformio.ini
@@ -1,0 +1,8 @@
+; The 1.0 release of the TBEAM board 
+[env:tbeam]
+extends = esp32_base
+board = ttgo-t-beam
+lib_deps =
+  ${esp32_base.lib_deps}
+build_flags = 
+  ${esp32_base.build_flags} -D TBEAM_V10  -I variants/tbeam

--- a/variants/tbeam_v07/platformio.ini
+++ b/variants/tbeam_v07/platformio.ini
@@ -1,0 +1,6 @@
+; The original TBEAM board without the AXP power chip and a few other changes
+[env:tbeam0.7]
+extends = esp32_base
+board = ttgo-t-beam
+build_flags = 
+  ${esp32_base.build_flags} -D TBEAM_V07 -I variants/tbeam_v07

--- a/variants/tlora_v1/platformio.ini
+++ b/variants/tlora_v1/platformio.ini
@@ -1,0 +1,5 @@
+[env:tlora-v1]
+extends = esp32_base
+board = ttgo-lora32-v1
+build_flags = 
+  ${esp32_base.build_flags} -D TLORA_V1 -I variants/tlora_v1

--- a/variants/tlora_v1_3/platformio.ini
+++ b/variants/tlora_v1_3/platformio.ini
@@ -1,0 +1,5 @@
+[env:tlora_v1_3]
+extends = esp32_base
+board = ttgo-lora32-v1
+build_flags = 
+  ${esp32_base.build_flags} -D TLORA_V1_3 -I variants/tlora_v1_3

--- a/variants/tlora_v2/platformio.ini
+++ b/variants/tlora_v2/platformio.ini
@@ -1,0 +1,5 @@
+[env:tlora-v2]
+extends = esp32_base
+board = ttgo-lora32-v1
+build_flags = 
+  ${esp32_base.build_flags} -D TLORA_V2 -I variants/tlora_v2

--- a/variants/tlora_v2_1_16/platformio.ini
+++ b/variants/tlora_v2_1_16/platformio.ini
@@ -1,0 +1,5 @@
+[env:tlora-v2-1-1.6]
+extends = esp32_base
+board = ttgo-lora32-v1
+build_flags = 
+  ${esp32_base.build_flags} -D TLORA_V2_1_16 -I variants/tlora_v2_1_16


### PR DESCRIPTION
only leaving platform definitions and a handful of stale (?) boards around..

Side benefit: someone could add their local prototype board(s) in an extra folder (variant.h/cpp and platformio.ini) and not commit. 

TODO:
- add a magic ENUM in the HardwareModel protobuf for 'private firmware', pretty much like the private_app portnumber
