### PR TITLE
Adjusted adc_multiplier for heltec2.1 and added adc_mulitplier_override

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -100,6 +100,10 @@ class AnalogBatteryLevel : public HasBatteryLevel
 #ifndef ADC_MULTIPLIER
 #define ADC_MULTIPLIER 2.0
 #endif 
+    // Override variant or default ADC_MULTIPLIER if we have the override pref
+    float operativeAdcMultiplier = radioConfig.preferences.adc_multiplier_override > 0 ?
+        radioConfig.preferences.adc_multiplier_override :
+        ADC_MULTIPLIER;
 
 #ifdef BATTERY_PIN
         // Do not call analogRead() often. 
@@ -109,7 +113,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
             uint32_t raw = analogRead(BATTERY_PIN);
             float scaled;
             #ifndef VBAT_RAW_TO_SCALED
-            scaled = 1000.0 * ADC_MULTIPLIER * (AREF_VOLTAGE / 1024.0) * raw;
+            scaled = 1000.0 * operativeAdcMultiplier * (AREF_VOLTAGE / 1024.0) * raw;
             #else
             scaled = VBAT_RAW_TO_SCALED(raw); //defined in variant.h
             #endif

--- a/variants/heltec_v2.1/variant.h
+++ b/variants/heltec_v2.1/variant.h
@@ -24,8 +24,7 @@
 #define LORA_DIO1 35 // Not really used
 #define LORA_DIO2 34 // Not really used
 
-// ratio of voltage divider = 3.20 (schematic R12=100k, R10=220k)
-// device to device variations, the actual ratio can be between 3.2 and 4
-#define ADC_MULTIPLIER 3.6 // best fit
+#define ADC_MULTIPLIER 3.8
+
 #define BATTERY_PIN 37 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 #define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Plugin.


### PR DESCRIPTION
PLEASE DO NOT MERGE YET. 

Given that there seems to be no silver bullet to fix #769, this change should be considered a tool in the toolbox for dealing with the inconsistency of ADC measurements in the Heltec devices.

I'd like to get some sample data or feedback from other Heltec V2.1 users, because this gave a fairly accurate VBatt on my device, but I suspect there are some differences or quality control issues with the voltage divider circuit production that are causing different devices to be incompatible with the same ADC_MULTIPLIER value.

Here's how you can confirm that your device is indeed the Heltec v2.1 
![image](https://user-images.githubusercontent.com/9000580/152357065-ef813832-8b01-4479-852e-a0880eac7030.png)
