### PR TITLE
Install littlefs-python during pio run

### DIFF
--- a/bin/platformio-custom.py
+++ b/bin/platformio-custom.py
@@ -8,6 +8,10 @@ from readprops import readProps
 
 Import("env")
 env.Replace( MKSPIFFSTOOL=env.get("PROJECT_DIR") + '/bin/mklittlefs.py' )
+try:
+    import littlefs
+except ImportError:
+    env.Execute("$PYTHONEXE -m pip install --user littlefs-python")
 
 Import("projenv")
 


### PR DESCRIPTION
Install only if it is missing from the ENV. Caveat: this python module is essentially lib binding and needs Cython and a working compiler as well. this MAY or MAY NOT work.