### PR TITLE
remove assert; revert a change that cpplint reported as a warning

### DIFF
--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -58,7 +58,7 @@ class PhoneAPI
 
     // Call this when the client drops the connection, resets the state to STATE_SEND_NOTHING
     // Unregisters our observer.  A closed connection **can** be reopened by calling init again.
-    void close();
+    virtual void close();
 
     /**
      * Handle a ToRadio protobuf

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -276,7 +276,7 @@ bool perhapsDecode(MeshPacket *p)
     if (p->which_payloadVariant == MeshPacket_decoded_tag)
         return true; // If packet was already decoded just return
 
-    assert(p->which_payloadVariant == MeshPacket_encrypted_tag);
+    //assert(p->which_payloadVariant == MeshPacket_encrypted_tag);
 
     // Try to find a channel that works with this hash
     for (ChannelIndex chIndex = 0; chIndex < channels.getNumChannels(); chIndex++) {

--- a/suppressions.txt
+++ b/suppressions.txt
@@ -36,3 +36,7 @@ cstyleCast
 // ignore stuff that is not ours
 *:.pio/*
 *:*/libdeps/*
+
+// these two caused issues
+missingOverride
+virtualCallInConstructor


### PR DESCRIPTION
The assert actually causes an issue. I don't think the assert is applicable anymore since we are not encrypting the MQTT payloads.

The cpplint warning actually caused an issue on a client to just "hang". This issue can be replicated by running `meshtastic --set foo foo`. The command should return quickly... instead, without this change, it would just "hang".