### PR TITLE
Destroy HTTPS Client on unpack error

### DIFF
--- a/src/mesh/http/ContentHandler.cpp
+++ b/src/mesh/http/ContentHandler.cpp
@@ -755,7 +755,7 @@ void handleUpdateSPIFFS(HTTPRequest *req, HTTPResponse *res)
         if (!TARUnpacker->tarStreamExpander(streamptr, streamSize, SPIFFS, "/static")) {
             res->printf("tarStreamExpander failed with return code #%d\n", TARUnpacker->tarGzGetError());
             Serial.printf("tarStreamExpander failed with return code #%d\n", TARUnpacker->tarGzGetError());
-
+            client->stop();
             return;
         } else {
             /*
@@ -773,6 +773,7 @@ void handleUpdateSPIFFS(HTTPRequest *req, HTTPResponse *res)
     } else {
         res->printf("Failed to establish http connection\n");
         Serial.println("Failed to establish http connection");
+        client->stop();
         return;
     }
 


### PR DESCRIPTION
This gives you more than one try to update the embedded Web IF without rebooting the device. This can also be cherry-picked for 1.3