### PR TITLE
Plaintext publish to MQTT

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -13,6 +13,7 @@ MQTT *mqtt;
 
 String statusTopic = "msh/1/stat/";
 String cryptTopic = "msh/1/c/"; // msh/1/c/CHANNELID/NODEID
+String txtTopic = "msh/1/txt/"; // msh/1/txt/CHANNELID/NODEID
 
 void MQTT::mqttCallback(char *topic, byte *payload, unsigned int length)
 {
@@ -193,5 +194,13 @@ void MQTT::onSend(const MeshPacket &mp, ChannelIndex chIndex)
         DEBUG_MSG("publish %s, %u bytes\n", topic.c_str(), numBytes);
 
         pubSub.publish(topic.c_str(), bytes, numBytes, false);
+
+        // publish to txt topic for messages of type TEXT_MESSAGE_APP
+        if (mp.decoded.portnum == PortNum_TEXT_MESSAGE_APP) {
+            String plaintextTopic = txtTopic + channelId + "/" + owner.id;
+            DEBUG_MSG("publish txt %s, %u bytes\n", topic.c_str(), numBytes);
+            auto &p = mp.decoded;
+            pubSub.publish(plaintextTopic.c_str(), p.payload.bytes, p.payload.size, false);
+        }
     }
 }


### PR DESCRIPTION
This adds decoded plaintext message publishing to the MQTT feature. Incoming messages of type `TEXT_MESSAGE_APP` are published (in addition to the raw message publish) as decoded plaintext to the topic `msh/1/txt/CHANNELID/NODEID`.

The purpose is to make integration with generic clients like Home Assistant easier. Remote nodes can send stringified JSON payload that can directly decoded and used in HA automations without any extra plugins or manual decoding.

This is obviously a first attempt, some questions:

- should this be configurable with a setting like `enable_mqtt_plaintext`? I'd argue this does not need to be configurable. As long as MQTT is enabled, it emits messages to the bus. `stat` messages are also directly published and are always enabled. As the txt messages are published to a different topic, the consumer can do the selection on their side.
- is there a case where `mp.decoded` may be null? Is is guaranteed that the payload is already decrypted when reaching this point? The source and the doc on `payloadVariant` is not clear to me.
- the sender id is not added to the published message. I'd argue this should be left to the payload (as with other metadata) to keep the message as clean as possible and not create the requirement of some sort of envelope. In theory, the sender could be added to the topic, for example in the form of `msh/1/txt/CHANNELID/LOCAL_NODEID/REMOTE_NODEID`, but I am unsure if this would violate usual MQTT best practice.

Btw, this is a PR against `master`, but current `master` does not work for me when I enable Wifi and MQTT. My node (Heltec 2.1) boots into a crash loop on startup. `1.2.57` works fine though.