### PR TITLE
initial CardKB I2C Support

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -126,7 +126,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 // -----------------------------------------------------------------------------
-// OLED
+// OLED & Input
 // -----------------------------------------------------------------------------
 
 #define SSD1306_ADDRESS 0x3C
@@ -142,6 +142,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Define if screen should be mirrored left to right
 // #define SCREEN_MIRROR
+
+// The m5stack I2C Keyboard
+#define CARDKB_ADDR 0x5F
 
 // -----------------------------------------------------------------------------
 // GPS

--- a/src/debug/i2cScan.h
+++ b/src/debug/i2cScan.h
@@ -19,6 +19,10 @@ void scanI2Cdevice(void)
                 screen_found = addr;
                 DEBUG_MSG("ssd1306 display found\n");
             }
+            if (addr == CARDKB_ADDR) {
+                cardkb_found = addr;
+                DEBUG_MSG("m5 cardKB found\n");
+            }
             if (addr == ST7567_ADDRESS) {
                 screen_found = addr;
                 DEBUG_MSG("st7567 display found\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,9 @@ meshtastic::NodeStatus *nodeStatus = new meshtastic::NodeStatus();
 /// The I2C address of our display (if found)
 uint8_t screen_found;
 
+// The I2C address the keyboard (if found)
+uint8_t cardkb_found;
+
 bool axp192_found;
 
 Router *router = NULL; // Users of router don't care what sort of subclass implements that API
@@ -432,6 +435,17 @@ void loop()
     }
 #endif
 
+// TODO: Move to Input broker, this is only a POC
+    if (cardkb_found == CARDKB_ADDR){
+        Wire.requestFrom(CARDKB_ADDR, 1);
+        while(Wire.available()) {
+            char c = Wire.read();
+            if (c == 0x0d) { // enter
+                powerFSM.trigger(EVENT_PRESS);
+            }
+        }
+    }
+    
     // TODO: This should go into a thread handled by FreeRTOS.
     // handleWebResponse();
 

--- a/src/main.h
+++ b/src/main.h
@@ -6,6 +6,7 @@
 #include "graphics/Screen.h"
 
 extern uint8_t screen_found;
+extern uint8_t cardkb_found;
 extern bool axp192_found;
 extern bool isCharging;
 extern bool isUSBPowered;


### PR DESCRIPTION
This ties in with the existing I2C Support for the Screen and scans for the presence of a CardKB Keyboard. If it is detected, the ENTER key (provisionally) doubles as the 'user key' and will forward to the next screen. Next step is to tie that in with the InputBroker (and Canned Messages Module) to provide up/down/enter/cancel and ultimately freetext message input.