### PR TITLE
Get side effects out of DEBUG_MSG

### DIFF
--- a/src/mesh/http/WiFiAPClient.cpp
+++ b/src/mesh/http/WiFiAPClient.cpp
@@ -209,7 +209,7 @@ bool initWifi(bool forceSoftAP)
                     DEBUG_MSG("Starting (Forced) WIFI AP: ssid=%s, ok=%d\n", softAPssid, ok);
 
                 } else {
-                    int ok = WiFi.softAP(wifiName, wifiPsw)
+                    int ok = WiFi.softAP(wifiName, wifiPsw);
                     DEBUG_MSG("Starting WIFI AP: ssid=%s, ok=%d\n", wifiName, ok);
                 }
 

--- a/src/mesh/http/WiFiAPClient.cpp
+++ b/src/mesh/http/WiFiAPClient.cpp
@@ -205,11 +205,12 @@ bool initWifi(bool forceSoftAP)
                 if (forcedSoftAP) {
                     const char *softAPssid = "meshtasticAdmin";
                     const char *softAPpasswd = "12345678";
-
-                    DEBUG_MSG("Starting (Forced) WIFI AP: ssid=%s, ok=%d\n", softAPssid, WiFi.softAP(softAPssid, softAPpasswd));
+                    int ok = WiFi.softAP(softAPssid, softAPpasswd);
+                    DEBUG_MSG("Starting (Forced) WIFI AP: ssid=%s, ok=%d\n", softAPssid, ok);
 
                 } else {
-                    DEBUG_MSG("Starting WIFI AP: ssid=%s, ok=%d\n", wifiName, WiFi.softAP(wifiName, wifiPsw));
+                    int ok = WiFi.softAP(wifiName, wifiPsw)
+                    DEBUG_MSG("Starting WIFI AP: ssid=%s, ok=%d\n", wifiName, ok);
                 }
 
                 WiFi.softAPConfig(apIP, apIP, IPAddress(255, 255, 255, 0));


### PR DESCRIPTION
Bugfix for https://github.com/meshtastic/Meshtastic-gui-installer/issues/155

The existing code has side effects that happen in a DEBUG_MSG macro, but this macro (and its side effects) disappear when you build without debug mode.