### PR TITLE
Added the last mac address bytes in bluetooth device and default notification pinout to tlora_v2_1_16

### DIFF
--- a/src/esp32/ESP32Bluetooth.cpp
+++ b/src/esp32/ESP32Bluetooth.cpp
@@ -170,7 +170,7 @@ void ESP32Bluetooth::setup()
 
     //NimBLEDevice::deleteAllBonds();
 
-    NimBLEDevice::init("Meshtastic_1234");
+    NimBLEDevice::init(getDeviceName());
     NimBLEDevice::setPower(ESP_PWR_LVL_P9);
 
     NimBLEDevice::setSecurityAuth(true, true, true);

--- a/variants/tlora_v2_1_16/variant.h
+++ b/variants/tlora_v2_1_16/variant.h
@@ -3,6 +3,8 @@
 #define GPS_RX_PIN 15 // per @der_bear on the forum, 36 is incorrect for this board type and 15 is a better pick
 #define GPS_TX_PIN 13
 
+#define EXT_NOTIFY_OUT 2 // Default pin to use for Ext Notify Module.
+
 #define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 // ratio of voltage divider = 2.0 (R42=100k, R43=100k)
 #define ADC_MULTIPLIER 2.2 // 2.0 + 10% for correction of display undervoltage.
@@ -23,3 +25,4 @@
 #define LORA_RESET 14
 #define LORA_DIO1 35 // Not really used
 #define LORA_DIO2 34 // Not really used
+

--- a/variants/tlora_v2_1_16/variant.h
+++ b/variants/tlora_v2_1_16/variant.h
@@ -7,7 +7,7 @@
 
 #define BATTERY_PIN 35 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 // ratio of voltage divider = 2.0 (R42=100k, R43=100k)
-#define ADC_MULTIPLIER 2.2 // 2.0 + 10% for correction of display undervoltage.
+#define ADC_MULTIPLIER 2.11 // 2.0 + 10% for correction of display undervoltage.
 
 #define I2C_SDA 21 // I2C pins for this board
 #define I2C_SCL 22


### PR DESCRIPTION

Added the last mac address bytes in bluetooth device name , becase is very difficult identify the bluetooth connection when has more than two devices.
Add default notification pinout GPIO2 to tlora_v2_1_16 variant
