### PR TITLE
Remove OSThread from UpDown Input.

### DIFF
--- a/src/input/UpDownInterruptBase.cpp
+++ b/src/input/UpDownInterruptBase.cpp
@@ -2,8 +2,7 @@
 #include "UpDownInterruptBase.h"
 
 UpDownInterruptBase::UpDownInterruptBase(
-    const char *name) :
-    concurrency::OSThread(name)
+    const char *name)
 {
     this->_originName = name;
 }
@@ -31,11 +30,6 @@ void UpDownInterruptBase::init(
         this->_pinDown, this->_pinUp, pinPress);
 }
 
-int32_t UpDownInterruptBase::runOnce()
-{
-    return 30000; // TODO: technically this can be MAX_INT
-}
-
 void UpDownInterruptBase::intPressHandler()
 {
     InputEvent e;
@@ -43,7 +37,6 @@ void UpDownInterruptBase::intPressHandler()
     DEBUG_MSG("GPIO event Press\n");
     e.inputEvent = this->_eventPressed;
     this->notifyObservers(&e);
-    setIntervalFromNow(20); // TODO: this modifies a non-volatile variable!
 }
 
 void UpDownInterruptBase::intDownHandler()
@@ -53,7 +46,6 @@ void UpDownInterruptBase::intDownHandler()
     DEBUG_MSG("GPIO event Down\n");
     e.inputEvent = this->_eventDown;
     this->notifyObservers(&e);
-    setIntervalFromNow(20);
 }
 
 void UpDownInterruptBase::intUpHandler()
@@ -63,5 +55,4 @@ void UpDownInterruptBase::intUpHandler()
     DEBUG_MSG("GPIO event Up\n");
     e.inputEvent = this->_eventUp;
     this->notifyObservers(&e);
-    setIntervalFromNow(20);
 }

--- a/src/input/UpDownInterruptBase.h
+++ b/src/input/UpDownInterruptBase.h
@@ -4,8 +4,7 @@
 #include "InputBroker.h"
 
 class UpDownInterruptBase :
-    public Observable<const InputEvent *>,
-    private concurrency::OSThread
+    public Observable<const InputEvent *>
 {
   public:
     explicit UpDownInterruptBase(
@@ -18,8 +17,6 @@ class UpDownInterruptBase :
     void intDownHandler();
     void intUpHandler();
 
-  protected:
-    virtual int32_t runOnce() override;
   private:
     uint8_t _pinDown = 0;
     uint8_t _pinUp = 0;


### PR DESCRIPTION
The UpDown Input is purely interrupt driven and doesn't need an empty OSThread.
