### PR TITLE
adjust for serial wait time during nRF52 bootup

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -854,8 +854,9 @@ int32_t Screen::runOnce()
     }
 
     // Show boot screen for first 3 seconds, then switch to normal operation.
+    // serialSinceMsec adjusts for additional serial wait time during nRF52 bootup
     static bool showingBootScreen = true;
-    if (showingBootScreen && (millis() > 5000)) {
+    if (showingBootScreen && (millis() > (5000 + serialSinceMsec))) {
         DEBUG_MSG("Done with boot screen...\n");
         stopBootScreen();
         showingBootScreen = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ uint8_t cardkb_found;
 // The I2C address of the Faces Keyboard (if found)
 uint8_t faceskb_found;
 
+uint32_t serialSinceMsec;
+
 bool axp192_found;
 
 Router *router = NULL; // Users of router don't care what sort of subclass implements that API
@@ -141,6 +143,8 @@ void setup()
         consoleInit(); // Set serial baud rate and init our mesh console
     }
 #endif
+    
+    serialSinceMsec = millis();
 
     DEBUG_MSG("\n\n//\\ E S H T /\\ S T / C\n\n");
 

--- a/src/main.h
+++ b/src/main.h
@@ -30,6 +30,8 @@ extern uint32_t timeLastPowered;
 extern uint32_t rebootAtMsec;
 extern uint32_t shutdownAtMsec;
 
+extern uint32_t serialSinceMsec;
+
 // If a thread does something that might need for it to be rescheduled ASAP it can set this flag
 // This will supress the current delay and instead try to run ASAP.
 extern bool runASAP;


### PR DESCRIPTION
Without this change the logo will only shortly blip on devices with no serial console detected. This restores the old boot behaviour by counting the 5 seconds after the serial console is initialized.
