### PR TITLE
Upgrade to Sparkfun GNSS 2.0 lib (for now)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,7 +46,7 @@ lib_deps =
   mathertel/OneButton@^2.0.3 ; OneButton library for non-blocking button debounce
   1202 ; CRC32, explicitly needed because dependency is missing in the ble ota update lib
   https://github.com/meshtastic/arduino-fsm.git
-  https://github.com/meshtastic/SparkFun_Ublox_Arduino_Library.git#31015a55e630a2df77d9d714669c621a5bf355ad
+  https://github.com/sparkfun/SparkFun_u-blox_GNSS_Arduino_Library.git#v2.2.8
   https://github.com/meshtastic/RadioLib.git#5582ac30578ff3f53f20630a00b2a8a4b8f92c74
   https://github.com/meshtastic/TinyGPSPlus.git
   https://github.com/meshtastic/AXP202X_Library.git#8404abb6d4b486748636bc6ad72d2a47baaf5460
@@ -97,6 +97,7 @@ build_flags =
   ${arduino_base.build_flags} -Wall -Wextra -Isrc/esp32 -Isrc/esp32-mfix-esp32-psram-cache-issue -lnimble -std=c++11 
   -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG -DMYNEWT_VAL_BLE_HS_LOG_LVL=LOG_LEVEL_CRITICAL
   -DAXP_DEBUG_PORT=Serial -DUSE_NEW_ESP32_BLUETOOTH
+  -DSFE_UBLOX_REDUCED_PROG_MEM -DSFE_UBLOX_DISABLE_AUTO_NMEA
 lib_deps =
   ${arduino_base.lib_deps}
   ${environmental.lib_deps}

--- a/src/gps/UBloxGPS.h
+++ b/src/gps/UBloxGPS.h
@@ -2,7 +2,7 @@
 
 #include "GPS.h"
 #include "Observer.h"
-#include "SparkFun_Ublox_Arduino_Library.h"
+#include "SparkFun_u-blox_GNSS_Arduino_Library.h"
 
 /**
  * A gps class that only reads from the GPS periodically (and FIXME - eventually keeps the gps powered down except when reading)
@@ -11,7 +11,7 @@
  */
 class UBloxGPS : public GPS
 {
-    SFE_UBLOX_GPS ublox;
+    SFE_UBLOX_GNSS ublox;
     uint8_t fixType = 0;
 
   public:


### PR DESCRIPTION
Please TEST this before merging. Compiles and Works for me.
This will remove UBLOX support for chips older than Gen8. Doesn't mean it will stop working but it will fall back to NMEA mode.