### PR TITLE
Enable OEM Bootlogo, needs protobuf update

### DIFF
--- a/src/mesh/generated/deviceonly.pb.c
+++ b/src/mesh/generated/deviceonly.pb.c
@@ -12,4 +12,8 @@ PB_BIND(DeviceState, DeviceState, 4)
 PB_BIND(ChannelFile, ChannelFile, 2)
 
 
+PB_BIND(OEMStore, OEMStore, 2)
+
+
+
 

--- a/src/mesh/generated/deviceonly.pb.h
+++ b/src/mesh/generated/deviceonly.pb.h
@@ -11,6 +11,17 @@
 #error Regenerate this file with the current version of nanopb generator.
 #endif
 
+/* Enum definitions */
+/* TODO: REPLACE */
+typedef enum _ScreenFonts { 
+    /* TODO: REPLACE */
+    ScreenFonts_FONT_SMALL = 0, 
+    /* TODO: REPLACE */
+    ScreenFonts_FONT_MEDIUM = 1, 
+    /* TODO: REPLACE */
+    ScreenFonts_FONT_LARGE = 2 
+} ScreenFonts;
+
 /* Struct definitions */
 /* The on-disk saved channels */
 typedef struct _ChannelFile { 
@@ -33,7 +44,7 @@ typedef struct _DeviceState {
     User owner; 
     /* TODO: REPLACE */
     pb_size_t node_db_count;
-    NodeInfo node_db[80]; 
+    NodeInfo node_db[64]; 
     /* Received packets saved for delivery to the phone */
     pb_size_t receive_queue_count;
     MeshPacket receive_queue[1]; 
@@ -53,16 +64,40 @@ typedef struct _DeviceState {
     bool did_gps_reset; 
 } DeviceState;
 
+typedef PB_BYTES_ARRAY_T(2048) OEMStore_oem_icon_bits_t;
+/* This can be used for customizing the firmware distribution. If populated,
+ show a secondary bootup screen with cuatom logo and text for 2.5 seconds. */
+typedef struct _OEMStore { 
+    /* The Logo width in Px */
+    uint32_t oem_icon_width; 
+    /* The Logo height in Px */
+    uint32_t oem_icon_height; 
+    /* The Logo in xbm bytechar format */
+    OEMStore_oem_icon_bits_t oem_icon_bits; 
+    /* Use this font for the OEM text. */
+    ScreenFonts oem_font; 
+    /* Use this font for the OEM text. */
+    char oem_text[40]; 
+} OEMStore;
+
+
+/* Helper constants for enums */
+#define _ScreenFonts_MIN ScreenFonts_FONT_SMALL
+#define _ScreenFonts_MAX ScreenFonts_FONT_LARGE
+#define _ScreenFonts_ARRAYSIZE ((ScreenFonts)(ScreenFonts_FONT_LARGE+1))
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define DeviceState_init_default                 {false, MyNodeInfo_init_default, false, User_init_default, 0, {NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default}, 0, {MeshPacket_init_default}, false, MeshPacket_init_default, 0, 0, 0}
+#define DeviceState_init_default                 {false, MyNodeInfo_init_default, false, User_init_default, 0, {NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default, NodeInfo_init_default}, 0, {MeshPacket_init_default}, false, MeshPacket_init_default, 0, 0, 0}
 #define ChannelFile_init_default                 {0, {Channel_init_default, Channel_init_default, Channel_init_default, Channel_init_default, Channel_init_default, Channel_init_default, Channel_init_default, Channel_init_default}}
-#define DeviceState_init_zero                    {false, MyNodeInfo_init_zero, false, User_init_zero, 0, {NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero}, 0, {MeshPacket_init_zero}, false, MeshPacket_init_zero, 0, 0, 0}
+#define OEMStore_init_default                    {0, 0, {0, {0}}, _ScreenFonts_MIN, ""}
+#define DeviceState_init_zero                    {false, MyNodeInfo_init_zero, false, User_init_zero, 0, {NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero, NodeInfo_init_zero}, 0, {MeshPacket_init_zero}, false, MeshPacket_init_zero, 0, 0, 0}
 #define ChannelFile_init_zero                    {0, {Channel_init_zero, Channel_init_zero, Channel_init_zero, Channel_init_zero, Channel_init_zero, Channel_init_zero, Channel_init_zero, Channel_init_zero}}
+#define OEMStore_init_zero                       {0, 0, {0, {0}}, _ScreenFonts_MIN, ""}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define ChannelFile_channels_tag                 1
@@ -74,6 +109,11 @@ extern "C" {
 #define DeviceState_version_tag                  8
 #define DeviceState_no_save_tag                  9
 #define DeviceState_did_gps_reset_tag            11
+#define OEMStore_oem_icon_width_tag              1
+#define OEMStore_oem_icon_height_tag             2
+#define OEMStore_oem_icon_bits_tag               3
+#define OEMStore_oem_font_tag                    4
+#define OEMStore_oem_text_tag                    5
 
 /* Struct field encoding specification for nanopb */
 #define DeviceState_FIELDLIST(X, a) \
@@ -99,16 +139,28 @@ X(a, STATIC,   REPEATED, MESSAGE,  channels,          1)
 #define ChannelFile_DEFAULT NULL
 #define ChannelFile_channels_MSGTYPE Channel
 
+#define OEMStore_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   oem_icon_width,    1) \
+X(a, STATIC,   SINGULAR, UINT32,   oem_icon_height,   2) \
+X(a, STATIC,   SINGULAR, BYTES,    oem_icon_bits,     3) \
+X(a, STATIC,   SINGULAR, UENUM,    oem_font,          4) \
+X(a, STATIC,   SINGULAR, STRING,   oem_text,          5)
+#define OEMStore_CALLBACK NULL
+#define OEMStore_DEFAULT NULL
+
 extern const pb_msgdesc_t DeviceState_msg;
 extern const pb_msgdesc_t ChannelFile_msg;
+extern const pb_msgdesc_t OEMStore_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
 #define DeviceState_fields &DeviceState_msg
 #define ChannelFile_fields &ChannelFile_msg
+#define OEMStore_fields &OEMStore_msg
 
 /* Maximum encoded size of messages (where known) */
 #define ChannelFile_size                         832
-#define DeviceState_size                         23903
+#define DeviceState_size                         19327
+#define OEMStore_size                            2106
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
This adds a secondary boot screen with OEM info. The necessary oem.proto file needs to be in the data/prefs directory while building the firmware and LittleFS image. There's currently no way to add it to an existing setup.
