### PR TITLE
Fix execution halt in nrf devices on assert and add --reboot support on nrf

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -121,7 +121,7 @@ lib_deps =
 ; Common settings for ESP targes, mixin with extends = esp32_base
 [esp32_base]
 extends = arduino_base
-platform = espressif32
+platform = espressif32@3.5.0
 src_filter = 
   ${arduino_base.src_filter} -<nrf52/>
 upload_speed = 921600

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -714,6 +714,8 @@ void powerCommandsCheck()
 #ifndef NO_ESP32
         DEBUG_MSG("Rebooting for update\n");
         ESP.restart();
+#elif NRF52_SERIES
+    NVIC_SystemReset();
 #else
         DEBUG_MSG("FIXME implement reboot for this platform");
 #endif

--- a/src/nrf52/main-nrf52.cpp
+++ b/src/nrf52/main-nrf52.cpp
@@ -32,8 +32,8 @@ void __attribute__((noreturn)) __assert_func(const char *file, int line, const c
 {
     DEBUG_MSG("assert failed %s: %d, %s, test=%s\n", file, line, func, failedexpr);
     // debugger_break(); FIXME doesn't work, possibly not for segger
-    while (1)
-        ; // FIXME, reboot!
+    // Reboot cpu
+    NVIC_SystemReset();
 }
 
 void getMacAddr(uint8_t *dmac)


### PR DESCRIPTION
Workaround for #1395 until we can fix individual cases and fail gracefully.
Bundling a fix for #1399 while we're touching reboot functions.