### PR TITLE
update minimum_app_version to 1.3.0

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -217,7 +217,7 @@ void NodeDB::init()
     myNodeInfo.error_address = 0;
 
     // likewise - we always want the app requirements to come from the running appload
-    myNodeInfo.min_app_version = 20200; // format is Mmmss (where M is 1+the numeric major number. i.e. 20120 means 1.1.20
+    myNodeInfo.min_app_version = 20300; // format is Mmmss (where M is 1+the numeric major number. i.e. 20120 means 1.1.20
 
     // Note! We do this after loading saved settings, so that if somehow an invalid nodenum was stored in preferences we won't
     // keep using that nodenum forever. Crummy guess at our nodenum (but we will check against the nodedb to avoid conflicts)


### PR DESCRIPTION
update MyNodeInfo `min_app_version` to 1.3.0:
- this is the minimum app version required to work with current device firmware (ie. tells 1.2 apps they are not compatible with 1.3+ firmware).