### PR TITLE
use nRF52 Hardware Cryptography

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "proto"]
 	path = proto
 	url = https://github.com/meshtastic/Meshtastic-protobufs.git
-[submodule "sdk-nrfxlib"]
-	path = sdk-nrfxlib
-	url = https://github.com/nrfconnect/sdk-nrfxlib.git
 [submodule "design"]
 	path = design
 	url = https://github.com/meshtastic/meshtastic-design.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -130,7 +130,6 @@ build_type = debug ; I'm debugging with ICE a lot now
 build_flags = 
   ${arduino_base.build_flags} -Wno-unused-variable 
   -Isrc/nrf52
-  -Isdk-nrfxlib/crypto/nrf_oberon/include -Lsdk-nrfxlib/crypto/nrf_oberon/lib/cortex-m4/hard-float/ -lliboberon_3.0.7 
 src_filter = 
   ${arduino_base.src_filter} -<esp32/> -<nimble/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mqtt/>
 lib_ignore =
@@ -142,8 +141,7 @@ build_flags = ${nrf52_base.build_flags}
 lib_deps =
   ${arduino_base.lib_deps}
   ${environmental.lib_deps}
-  Adafruit nRFCrypto
-; https://github.com/Kongduino/Adafruit_nRFCrypto.git
+  https://github.com/Kongduino/Adafruit_nRFCrypto.git
 
 ; Note: By default no lora device is created for this build - it uses a simulated interface
 [env:nrf52840dk]

--- a/src/nrf52/NRF52CryptoEngine.cpp
+++ b/src/nrf52/NRF52CryptoEngine.cpp
@@ -1,7 +1,6 @@
 #include "configuration.h"
 #include "CryptoEngine.h"
-#include "ocrypto_aes_ctr.h"
-// #include <Adafruit_nRFCrypto.h>
+#include <Adafruit_nRFCrypto.h>
 
 class NRF52CryptoEngine : public CryptoEngine
 {
@@ -20,12 +19,16 @@ class NRF52CryptoEngine : public CryptoEngine
 //        DEBUG_MSG("NRF52 encrypt!\n");
 
         if (key.length > 0) {
-            ocrypto_aes_ctr_ctx ctx;
-
+            nRFCrypto.begin();
+            nRFCrypto_AES ctx;
+            uint8_t myLen = ctx.blockLen(numBytes);
+            char encBuf[myLen] = {0};
+            memcpy(encBuf, bytes, numBytes);
             initNonce(fromNode, packetId);
-            ocrypto_aes_ctr_init(&ctx, key.bytes, key.length, nonce);
-
-            ocrypto_aes_ctr_encrypt(&ctx, bytes, bytes, numBytes);
+            ctx.begin();
+            ctx.Process(encBuf, numBytes, nonce, key.bytes, key.length, (char*)bytes, ctx.encryptFlag, ctx.ctrMode);
+            ctx.end();
+            nRFCrypto.end();
         }
     }
 
@@ -34,60 +37,20 @@ class NRF52CryptoEngine : public CryptoEngine
 //        DEBUG_MSG("NRF52 decrypt!\n");
 
         if (key.length > 0) {
-            ocrypto_aes_ctr_ctx ctx;
-
+            nRFCrypto.begin();
+            nRFCrypto_AES ctx;
+            uint8_t myLen = ctx.blockLen(numBytes);
+            char decBuf[myLen] = {0};
+            memcpy(decBuf, bytes, numBytes);
             initNonce(fromNode, packetId);
-            ocrypto_aes_ctr_init(&ctx, key.bytes, key.length, nonce);
-
-            ocrypto_aes_ctr_decrypt(&ctx, bytes, bytes, numBytes);
+            ctx.begin();
+            ctx.Process(decBuf, numBytes, nonce, key.bytes, key.length, (char*)bytes, ctx.decryptFlag, ctx.ctrMode);
+            ctx.end();
+            nRFCrypto.end();
         }
     }
 
   private:
 };
-
-    // /**
-    //  * Encrypt a packet
-    //  *
-    //  * @param bytes is updated in place
-    //  */
-    // virtual void encrypt(uint32_t fromNode, uint64_t packetId, size_t numBytes, uint8_t *bytes) override
-    // {
-    //     DEBUG_MSG("NRF52 encrypt!\n");
-
-    //     if (key.length > 0) {
-    //         nRFCrypto_AES ctx;
-    //         uint8_t myLen = ctx.blockLen(numBytes);
-    //         char encBuf[myLen] = {0};
-    //         memcpy(encBuf, bytes, numBytes);
-    //         initNonce(fromNode, packetId);
-    //         nRFCrypto.begin();
-    //         ctx.begin();
-    //         ctx.Process(encBuf, numBytes, nonce, key.bytes, key.length, (char*)bytes, ctx.encryptFlag, ctx.ctrMode);
-    //         ctx.end();
-    //         nRFCrypto.end();
-    //     }
-    // }
-
-    // virtual void decrypt(uint32_t fromNode, uint64_t packetId, size_t numBytes, uint8_t *bytes) override
-    // {
-    //     DEBUG_MSG("NRF52 decrypt!\n");
-
-    //     if (key.length > 0) {
-    //         nRFCrypto_AES ctx;
-    //         uint8_t myLen = ctx.blockLen(numBytes);
-    //         char decBuf[myLen] = {0};
-    //         memcpy(decBuf, bytes, numBytes);
-    //         initNonce(fromNode, packetId);
-    //         nRFCrypto.begin();
-    //         ctx.begin();
-    //         ctx.Process(decBuf, numBytes, nonce, key.bytes, key.length, (char*)bytes, ctx.decryptFlag, ctx.ctrMode);
-    //         ctx.end();
-    //         nRFCrypto.end();
-    //     }
-    // }
-
-//   private:
-// };
 
 CryptoEngine *crypto = new NRF52CryptoEngine();


### PR DESCRIPTION
Removes the need for the sdk-nrfxlib submodule