### PR TITLE
I2C RTC Support (RAK12002)

### DIFF
--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -135,7 +135,7 @@ class ButtonThread : public concurrency::OSThread
         screen->adjustBrightness();
 #endif
         // If user button is held down for 5 seconds, shutdown the device.
-        if (millis() - longPressTime > 5 * 1000) {
+        if ((millis() - longPressTime > 5 * 1000) && (longPressTime > 0)) {
 #ifdef TBEAM_V10
             if (axp192_found == true) {
                 setLed(false);
@@ -144,7 +144,7 @@ class ButtonThread : public concurrency::OSThread
 #elif NRF52_SERIES
             // Do actual shutdown when button released, otherwise the button release
             // may wake the board immediatedly.
-            if (!shutdown_on_long_stop) {
+            if ((!shutdown_on_long_stop) && (millis() > 30 * 1000)) { 
                 screen->startShutdownScreen();
                 DEBUG_MSG("Shutdown from long press");
                 playBeep();
@@ -180,18 +180,22 @@ class ButtonThread : public concurrency::OSThread
 
     static void userButtonPressedLongStart()
     {
-        DEBUG_MSG("Long press start!\n");
-        longPressTime = millis();
+        if (millis() > 30 * 1000) {
+            DEBUG_MSG("Long press start!\n");
+            longPressTime = millis();
+        }
     }
 
     static void userButtonPressedLongStop()
     {
-        DEBUG_MSG("Long press stop!\n");
-        longPressTime = 0;
-        if (shutdown_on_long_stop) {
-            playShutdownMelody();
-            delay(3000);
-            power->shutdown();
+        if (millis() > 30 * 1000){
+            DEBUG_MSG("Long press stop!\n");
+            longPressTime = 0;
+            if (shutdown_on_long_stop) {
+                playShutdownMelody();
+                delay(3000);
+                power->shutdown();
+            }
         }
     }
 };

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -72,7 +72,7 @@ size_t RedirectablePrint::logDebug(const char *format, ...)
 
         // If we are the first message on a report, include the header
         if (!isContinuationMessage) {
-            uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityFromNet);
+            uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice);
             if (rtc_sec > 0) {
                 long hms = rtc_sec % SEC_PER_DAY;
                 // hms += tz.tz_dsttime * SEC_PER_HOUR;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -25,6 +25,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <Arduino.h>
+#ifdef RV3028_RTC
+    #include "Melopero_RV3028.h"
+#endif
+
 // -----------------------------------------------------------------------------
 // Version
 // -----------------------------------------------------------------------------

--- a/src/debug/i2cScan.h
+++ b/src/debug/i2cScan.h
@@ -54,7 +54,16 @@ void scanI2Cdevice(void)
                     DEBUG_MSG("unknown display found\n");
                 }
             }
-
+#ifdef RV3028_RTC
+            if (addr == RV3028_RTC){
+                rtc_found = addr;
+                DEBUG_MSG("RV3028 RTC found\n");
+                Melopero_RV3028 rtc;
+                rtc.initI2C();
+                rtc.writeToRegister(0x35,0x07); // no Clkout
+                rtc.writeToRegister(0x37,0xB4);
+            }
+#endif
             if (addr == CARDKB_ADDR) {
                 cardkb_found = addr;
                 DEBUG_MSG("m5 cardKB found\n");
@@ -81,7 +90,7 @@ void scanI2Cdevice(void)
     if (nDevices == 0)
         DEBUG_MSG("No I2C devices found\n");
     else
-        DEBUG_MSG("done\n");
+        DEBUG_MSG("%i I2C devices found\n",nDevices);
 }
 #else
 void scanI2Cdevice(void) {}

--- a/src/gps/NMEAGPS.cpp
+++ b/src/gps/NMEAGPS.cpp
@@ -65,7 +65,7 @@ The Unix epoch (or Unix time or POSIX time or Unix timestamp) is the number of s
         t.tm_year = d.year() - 1900;
         t.tm_isdst = false;
         if (t.tm_mon > -1){
-            DEBUG_MSG("NMEA GPS time %d-%d-%d %d:%d:%d\n", d.year(), d.month(), t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
+            DEBUG_MSG("NMEA GPS time %02d-%02d-%02d %02d:%02d:%02d\n", d.year(), d.month(), t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
             perhapsSetRTC(RTCQualityGPS, t);
             return true;
         } else

--- a/src/gps/RTC.h
+++ b/src/gps/RTC.h
@@ -5,17 +5,21 @@
 #include <Arduino.h>
 
 enum RTCQuality {
+
     /// We haven't had our RTC set yet
     RTCQualityNone = 0,
 
+    /// We got time from an onboard peripheral after boot.
+    RTCQualityDevice = 1,
+
     /// Some other node gave us a time we can use
-    RTCQualityFromNet = 1,
+    RTCQualityFromNet = 2,
 
     /// Our time is based on NTP
-    RTCQualityNTP= 2,
+    RTCQualityNTP= 3,
 
     /// Our time is based on our own GPS
-    RTCQualityGPS = 3
+    RTCQualityGPS = 4
 };
 
 RTCQuality getRTCQuality();

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1557,7 +1557,7 @@ void DebugInfo::drawFrameSettings(OLEDDisplay *display, OLEDDisplayUiState *stat
     else
         uptime += String(seconds) + "s ";
 
-    uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityFromNet);
+    uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice);
     if (rtc_sec > 0) {
         long hms = rtc_sec % SEC_PER_DAY;
         // hms += tz.tz_dsttime * SEC_PER_HOUR;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,9 @@ uint8_t cardkb_found;
 // The I2C address of the Faces Keyboard (if found)
 uint8_t faceskb_found;
 
+// The I2C address of the RTC Module (if found)
+uint8_t rtc_found;
+
 bool eink_found = true;
 
 uint32_t serialSinceMsec;

--- a/src/main.h
+++ b/src/main.h
@@ -9,6 +9,7 @@ extern uint8_t screen_found;
 extern uint8_t screen_model;
 extern uint8_t cardkb_found;
 extern uint8_t faceskb_found;
+extern uint8_t rtc_found;
 
 extern bool eink_found;
 extern bool axp192_found;

--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -6,13 +6,12 @@
 
 void powerCommandsCheck()
 {
-    DEBUG_MSG("Rebooting\n");
-    
     if (rebootAtMsec && millis() > rebootAtMsec) {
+        DEBUG_MSG("Rebooting\n");
 #ifndef NO_ESP32
         ESP.restart();
 #elif NRF52_SERIES
-    NVIC_SystemReset();
+        NVIC_SystemReset();
 #else
         DEBUG_MSG("FIXME implement reboot for this platform");
 #endif

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -6,6 +6,7 @@ build_flags = ${nrf52840_base.build_flags} -Ivariants/rak4631 -D RAK_4631
 src_filter = ${nrf52_base.src_filter} +<../variants/rak4631>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  melopero/Melopero RV3028@^1.1.0
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ;upload_protocol = jlink

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -198,6 +198,9 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define GPS_RX_PIN PIN_SERIAL1_RX
 #define GPS_TX_PIN PIN_SERIAL1_TX
 
+// RAK12002 RTC Module
+#define RV3028_RTC (uint8_t) 0b1010010
+
 // Battery
 // The battery sense is hooked to pin A0 (5)
 #define BATTERY_PIN PIN_A0

--- a/variants/rak4631_epaper/platformio.ini
+++ b/variants/rak4631_epaper/platformio.ini
@@ -7,6 +7,7 @@ src_filter = ${nrf52_base.src_filter} +<../variants/rak4631_epaper>
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/ZinggJM/GxEPD2.git
+  melopero/Melopero RV3028@^1.1.0
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ;upload_protocol = jlink

--- a/variants/rak4631_epaper/variant.h
+++ b/variants/rak4631_epaper/variant.h
@@ -198,6 +198,9 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define GPS_RX_PIN PIN_SERIAL1_RX
 #define GPS_TX_PIN PIN_SERIAL1_TX
 
+// RAK12002 RTC Module
+#define RV3028_RTC (uint8_t) 0b1010010
+
 // Battery
 // The battery sense is hooked to pin A0 (5)
 #define BATTERY_PIN PIN_A0


### PR DESCRIPTION
 - implement generic support for on-device battery powered RTC Modules.
- implement support for I2C RV-3028 based RTC modules like the RAK12002
- pretty print some debug timestamps

!!! We may have RAK modules in Sensor Slot D pulling IO5 to Low permanently (like the RAK12002 RTC Module). The device will react to Long presses of the device button only 30 seconds after bootup to prevent a reboot loop. This is Particularly important for button-less RAK19003 Baseboard. On other Baseboards with IO-Slot make sure to be careful about Sensor Slot D!