### PR TITLE
RTC Module support for T-Echo and others with PCF8563

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -28,6 +28,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RV3028_RTC
     #include "Melopero_RV3028.h"
 #endif
+#ifdef PCF8563_RTC
+    #include "pcf8563.h"
+#endif
 
 // -----------------------------------------------------------------------------
 // Version

--- a/src/debug/i2cScan.h
+++ b/src/debug/i2cScan.h
@@ -64,6 +64,12 @@ void scanI2Cdevice(void)
                 rtc.writeToRegister(0x37,0xB4);
             }
 #endif
+#ifdef PCF8563_RTC
+            if (addr == PCF8563_RTC){
+                rtc_found = addr;
+                DEBUG_MSG("PCF8563 RTC found\n");
+            }
+#endif
             if (addr == CARDKB_ADDR) {
                 cardkb_found = addr;
                 DEBUG_MSG("m5 cardKB found\n");

--- a/variants/t-echo/platformio.ini
+++ b/variants/t-echo/platformio.ini
@@ -14,4 +14,5 @@ lib_deps =
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2
   adafruit/Adafruit BusIO
+  lewisxhe/PCF8563_Library@^0.0.1
 ;upload_protocol = fs

--- a/variants/t-echo/variant.h
+++ b/variants/t-echo/variant.h
@@ -182,6 +182,9 @@ External serial flash WP25R1635FZUIL0
 #define PIN_SERIAL1_RX PIN_GPS_TX
 #define PIN_SERIAL1_TX PIN_GPS_RX
 
+// PCF8563 RTC Module
+#define PCF8563_RTC 0x51
+
 /*
  * SPI Interfaces
  */


### PR DESCRIPTION
needs to be enabled for the device variant. No generic code inclusion.
