### PR TITLE
Enable TXEN and RXEN for Waveshare LoRa Module

### DIFF
--- a/variants/Dongle_nRF52840-pca10059-v1/variant.h
+++ b/variants/Dongle_nRF52840-pca10059-v1/variant.h
@@ -139,8 +139,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define SX126X_DIO1    (0 + 29)       // DIO1        P0.29
 #define SX126X_BUSY    (0 + 2)        // LORA_BUSY	  P0.02
 #define SX126X_RESET   (32 + 15)      // LORA_RESET  P1.15
-#define SX126X_TXEN    (-1)           // TXEN        P1.13 NiceRF 868 dont use
-#define SX126X_RXEN    (-1)           // RXEN        P1.10 NiceRF 868 dont use
+#define SX126X_TXEN    (32 + 13)      // TXEN        P1.13 NiceRF 868 dont use
+#define SX126X_RXEN    (32 + 10)      // RXEN        P1.10 NiceRF 868 dont use
 #define SX126X_E22
 
 #define PIN_GPS_EN     (-1)


### PR DESCRIPTION
This change enables RXEN TXEN for the use of the Waveshare Core1262-868M Anti-Interference SX1262 LoRa Module, EU868 Band
https://www.waveshare.com/core1262-868m.htm
