### PR TITLE
Configure bluetooth name based on owner's short name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,8 +97,15 @@ const char *getDeviceName()
     getMacAddr(dmac);
 
     // Meshtastic_ab3c
-    static char name[20];
-    sprintf(name, "Meshtastic_%02x%02x", dmac[4], dmac[5]);
+    static char name[30];
+    // If we have an owner shortname and it is short.
+    if (owner.short_name != NULL
+	&& strlen(owner.short_name) >= 2
+	&& strlen(owner.short_name) < 10) {
+      sprintf(name, "Meshtastic_%s", owner.short_name);
+    } else {
+      sprintf(name, "Meshtastic_%02x%02x", dmac[4], dmac[5]);
+    }
     return name;
 }
 

--- a/src/nrf52/NRF52Bluetooth.cpp
+++ b/src/nrf52/NRF52Bluetooth.cpp
@@ -225,6 +225,11 @@ void NRF52Bluetooth::setup()
     Bluefruit.autoConnLed(false);
     Bluefruit.begin();
 
+    // Clear existing data.
+    Bluefruit.Advertising.stop();
+    Bluefruit.Advertising.clearData();
+    Bluefruit.ScanResponse.clearData();
+
     // Set the advertised device name (keep it short!)
     Bluefruit.setName(getDeviceName());
 


### PR DESCRIPTION
I started setting up a bunch of meshtastic radio's and I couldn't tell them apart so easily, so I made the Bluetooth name be based on the owner's short name.