### PR TITLE
Fix typo in calculation of NUM_ONLINE_SECS constant

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -439,7 +439,7 @@ uint32_t sinceLastSeen(const NodeInfo *n)
     return delta;
 }
 
-#define NUM_ONLINE_SECS (60 & 60 * 2) // 2 hrs to consider someone offline
+#define NUM_ONLINE_SECS (60 * 60 * 2) // 2 hrs to consider someone offline
 
 size_t NodeDB::getNumOnlineNodes()
 {


### PR DESCRIPTION
This fixes a bug introduced by a typo in 446fb857cc15b50b8ebb56960ae7e446d69b4465 – I think someone accidentally typed an `&` instead of `*`.