### PR TITLE
Disaster Radio dev board initial support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,7 @@ default_envs = tbeam
 ;default_envs = nano-g1
 ;default_envs = meshtastic-diy-v1
 ;default_envs = meshtastic-diy-v1.1
+;default_envs = meshtastic-dr-dev
 
 ; board specific config can be moved to the respective 'variants' file.
 ; See https://docs.platformio.org/en/latest/projectconf/section_platformio.html#extra-configs

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -169,6 +169,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // This string must exactly match the case used in release file names or the android updater won't work
 #define HW_VENDOR HardwareModel_DIY_V1
 
+#elif defined(DR_DEV)
+// This string must exactly match the case used in release file names or the android updater won't work
+#define HW_VENDOR HardwareModel_DR_DEV
+
 #elif defined(RAK_11200)
 // This string must exactly match the case used in release file names or the android updater won't work
 #define HW_VENDOR HardwareModel_RAK11200

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -1,0 +1,57 @@
+// For OLED LCD
+#define I2C_SDA 21
+#define I2C_SCL 22
+
+// GPS
+#undef GPS_RX_PIN
+#define GPS_RX_PIN NOT_A_PIN
+
+#define BUTTON_PIN 2 // The middle button GPIO on the T-Beam
+#define BUTTON_NEED_PULLUP
+#define EXT_NOTIFY_OUT 12 // Overridden default pin to use for Ext Notify Module (#975).
+
+#define LORA_DIO0 NOT_A_PIN  // a No connect on the SX1262/SX1268 module
+#define LORA_RESET NOT_A_PIN // RST for SX1276, and for SX1262/SX1268
+#define LORA_DIO1 26  // IRQ for SX1262/SX1268
+#define LORA_DIO2 NOT_A_PIN  // BUSY for SX1262/SX1268
+#define LORA_DIO3     // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
+
+// In transmitting, set TXEN as high communication level，RXEN pin is low level;
+// In receiving, set RXEN as high communication level, TXEN is lowlevel;
+// Before powering off, set TXEN、RXEN as low level.
+#define LORA_RXEN 17  // Input - RF switch RX control, connecting external MCU IO, valid in high level
+#define LORA_TXEN NOT_A_PIN // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
+
+#undef RF95_SCK
+#define RF95_SCK 18
+#undef RF95_MISO
+#define RF95_MISO 19
+#undef RF95_MOSI
+#define RF95_MOSI 23
+#undef RF95_NSS
+#define RF95_NSS 16
+
+// RX/TX for RFM95/SX127x
+#define RF95_RXEN LORA_RXEN
+#define RF95_TXEN LORA_TXEN
+// #define RF95_TCXO <GPIO#>
+
+// common pinouts for SX126X modules
+#define SX126X_CS 16
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+#define SX126X_RXEN LORA_RXEN
+#define SX126X_TXEN LORA_TXEN
+
+// supported modules list
+#define USE_RF95 // RFM95/SX127x
+#define USE_SX1262
+#define USE_SX1268
+#define USE_LLCC68
+
+#ifdef EBYTE_E22
+// Internally the TTGO module hooks the SX126x-DIO2 in to control the TX/RX switch
+// (which is the default for the sx1262interface code)
+#define SX126X_E22
+#endif

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -5,7 +5,7 @@
 // GPS
 #undef GPS_RX_PIN
 #define GPS_RX_PIN NOT_A_PIN
-#define WANT_GPS 0
+#undef WANT_GPS
 
 #define BUTTON_PIN 2 // The middle button GPIO on the T-Beam
 #define BUTTON_NEED_PULLUP

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -5,7 +5,6 @@
 // GPS
 #undef GPS_RX_PIN
 #define GPS_RX_PIN NOT_A_PIN
-#undef WANT_GPS
 
 #define BUTTON_PIN 2 // The middle button GPIO on the T-Beam
 #define BUTTON_NEED_PULLUP

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -5,14 +5,15 @@
 // GPS
 #undef GPS_RX_PIN
 #define GPS_RX_PIN NOT_A_PIN
+#define WANT_GPS 0
 
 #define BUTTON_PIN 2 // The middle button GPIO on the T-Beam
 #define BUTTON_NEED_PULLUP
 #define EXT_NOTIFY_OUT 12 // Overridden default pin to use for Ext Notify Module (#975).
 
-#define LORA_DIO0 NOT_A_PIN  // a No connect on the SX1262/SX1268 module
-#define LORA_RESET NOT_A_PIN // RST for SX1276, and for SX1262/SX1268
-#define LORA_DIO1 26  // IRQ for SX1262/SX1268
+#define LORA_DIO0 -1  // a No connect on the SX1262/SX1268 module
+#define LORA_RESET -1 // RST for SX1276, and for SX1262/SX1268
+#define LORA_DIO1 27  // IRQ for SX1262/SX1268 (IO26 FOR 22S)
 #define LORA_DIO2 NOT_A_PIN  // BUSY for SX1262/SX1268
 #define LORA_DIO3     // Not connected on PCB, but internally on the TTGO SX1262/SX1268, if DIO3 is high the TXCO is enabled
 
@@ -20,8 +21,8 @@
 // In receiving, set RXEN as high communication level, TXEN is lowlevel;
 // Before powering off, set TXEN、RXEN as low level.
 #define LORA_RXEN 17  // Input - RF switch RX control, connecting external MCU IO, valid in high level
-#define LORA_TXEN NOT_A_PIN // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
-
+#define LORA_TXEN -1 // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
+/*  --PINS FOR THE 900M22S
 #undef RF95_SCK
 #define RF95_SCK 18
 #undef RF95_MISO
@@ -30,6 +31,17 @@
 #define RF95_MOSI 23
 #undef RF95_NSS
 #define RF95_NSS 16
+*/
+
+// PINS FOR THE 900M30S
+#undef RF95_SCK
+#define RF95_SCK 18
+#undef RF95_MISO
+#define RF95_MISO 19
+#undef RF95_MOSI
+#define RF95_MOSI 23
+#undef RF95_NSS
+#define RF95_NSS 33
 
 // RX/TX for RFM95/SX127x
 #define RF95_RXEN LORA_RXEN
@@ -37,9 +49,9 @@
 // #define RF95_TCXO <GPIO#>
 
 // common pinouts for SX126X modules
-#define SX126X_CS 16
+#define SX126X_CS 33
 #define SX126X_DIO1 LORA_DIO1
-#define SX126X_BUSY LORA_DIO2
+#define SX126X_BUSY 35
 #define SX126X_RESET LORA_RESET
 #define SX126X_RXEN LORA_RXEN
 #define SX126X_TXEN LORA_TXEN

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -26,6 +26,6 @@ board_upload.maximum_size = 4194304
 board_upload.maximum_ram_size = 532480
 build_flags =
   ${esp32_base.build_flags}
-  -D DIY_V1
+  -D DR_DEV
   -D EBYTE_E22
   -I variants/diy/dr-dev

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -17,3 +17,15 @@ build_flags =
   -D DIY_V1
   -D EBYTE_E22
   -I variants/diy/v1_1
+
+; Port to Disaster Radio's ESP32-v3 Dev Board
+[env:meshtastic-dr-dev]
+extends = esp32_base
+board = esp32doit-devkit-v1
+board_upload.maximum_size = 4194304
+board_upload.maximum_ram_size = 532480
+build_flags =
+  ${esp32_base.build_flags}
+  -D DIY_V1
+  -D EBYTE_E22
+  -I variants/diy/dr-dev


### PR DESCRIPTION
#1442 

For the Disaster Radio ESP32 v3 board.
This is the bare minimum needed to get one of the radios working, all based off the work of the Hydra project.