### PR TITLE
Add M5Stack CoreInk 1.54 inch e-Ink - HopeRF95 Support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ default_envs = tbeam
 ;default_envs = pca10059_diy_eink
 ;default_envs = meshtastic-diy-v1
 ;default_envs = meshtastic-diy-v1.1
+;default_envs = m5stack-coreink
 
 extra_configs = variants/*/platformio.ini
 

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -31,6 +31,11 @@
 //4.2 inch 300x400 - GxEPD2_420_M01
 #define TECHO_DISPLAY_MODEL GxEPD2_420_M01
 
+#elif defined(PRIVATE_HW)
+//M5Stack CoreInk
+//1.54 inch 200x200 - GxEPD2_154_M09
+#define TECHO_DISPLAY_MODEL GxEPD2_154_M09
+
 #endif
 
 GxEPD2_BW<TECHO_DISPLAY_MODEL, TECHO_DISPLAY_MODEL::HEIGHT> *adafruitDisplay;
@@ -57,6 +62,12 @@ EInkDisplay::EInkDisplay(uint8_t address, int sda, int scl)
 
     //GxEPD2_420_M01
     setGeometry(GEOMETRY_RAWMODE, 300, 400);
+    
+    #elif defined(PRIVATE_HW)
+    
+    //M5Stack_CoreInk 200x200
+    //1.54 inch 200x200 - GxEPD2_154_M09
+    setGeometry(GEOMETRY_RAWMODE, 200, 200);
     
     #endif
     // setGeometry(GEOMETRY_RAWMODE, 128, 64); // old resolution
@@ -108,7 +119,7 @@ bool EInkDisplay::forceDisplay(uint32_t msecLimit)
         // 4.2 inch 300x400 - GxEPD2_420_M01
         //adafruitDisplay->nextPage();
         
-        #elif defined(PCA10059)
+        #elif defined(PCA10059) || defined(PRIVATE_HW)
         adafruitDisplay->nextPage();
         #endif
         
@@ -180,40 +191,15 @@ bool EInkDisplay::connect()
         adafruitDisplay->init(115200, true, 10, false, SPI1, SPISettings(4000000, MSBFIRST, SPI_MODE0));
 
         //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-    //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-        //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-    //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-        //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-    //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-        //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-    //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-        //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-    //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-        //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-    //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
-        //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
         adafruitDisplay->setRotation(3);
         //For 1.54, 2.9 and 4.2
         //adafruitDisplay->setRotation(1);
-
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
-    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);       
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
-    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);       
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
-    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);       
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
-    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);       
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
-    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);       
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
-    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);       
-        adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
+        //adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
     } else {
         (void)adafruitDisplay;
     }      
 }
-#elif defined(PCA10059)
+#elif defined(PCA10059) || defined(PRIVATE_HW)
 {
     auto lowLevel = new TECHO_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);
     adafruitDisplay = new GxEPD2_BW<TECHO_DISPLAY_MODEL, TECHO_DISPLAY_MODEL::HEIGHT>(*lowLevel);
@@ -221,6 +207,8 @@ bool EInkDisplay::connect()
     adafruitDisplay->setRotation(3);
     adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
 }
+#elif defined(PRIVATE_HW)
+ adafruitDisplay->setRotation(0);    
 #endif
    
     

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -67,7 +67,6 @@ EInkDisplay::EInkDisplay(uint8_t address, int sda, int scl)
     
     //M5Stack_CoreInk 200x200
     //1.54 inch 200x200 - GxEPD2_154_M09
-    //setGeometry(GEOMETRY_RAWMODE, 200, 200);
     setGeometry(GEOMETRY_RAWMODE, EPD_HEIGHT, EPD_WIDTH);
 
     #endif

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -31,7 +31,7 @@
 //4.2 inch 300x400 - GxEPD2_420_M01
 #define TECHO_DISPLAY_MODEL GxEPD2_420_M01
 
-#elif defined(PRIVATE_HW)
+#elif defined(M5_COREINK)
 //M5Stack CoreInk
 //1.54 inch 200x200 - GxEPD2_154_M09
 #define TECHO_DISPLAY_MODEL GxEPD2_154_M09
@@ -63,12 +63,13 @@ EInkDisplay::EInkDisplay(uint8_t address, int sda, int scl)
     //GxEPD2_420_M01
     setGeometry(GEOMETRY_RAWMODE, 300, 400);
     
-    #elif defined(PRIVATE_HW)
+    #elif defined(M5_COREINK)
     
     //M5Stack_CoreInk 200x200
     //1.54 inch 200x200 - GxEPD2_154_M09
-    setGeometry(GEOMETRY_RAWMODE, 200, 200);
-    
+    //setGeometry(GEOMETRY_RAWMODE, 200, 200);
+    setGeometry(GEOMETRY_RAWMODE, EPD_HEIGHT, EPD_WIDTH);
+
     #endif
     // setGeometry(GEOMETRY_RAWMODE, 128, 64); // old resolution
     // setGeometry(GEOMETRY_128_64); // We originally used this because I wasn't sure if rawmode worked - it does
@@ -119,7 +120,7 @@ bool EInkDisplay::forceDisplay(uint32_t msecLimit)
         // 4.2 inch 300x400 - GxEPD2_420_M01
         //adafruitDisplay->nextPage();
         
-        #elif defined(PCA10059) || defined(PRIVATE_HW)
+        #elif defined(PCA10059) || defined(M5_COREINK)
         adafruitDisplay->nextPage();
         #endif
         
@@ -192,7 +193,7 @@ bool EInkDisplay::connect()
 
         //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
         adafruitDisplay->setRotation(3);
-        //For 1.54, 2.9 and 4.2 with Partial Updates
+        //For 1.54, 2.9 and 4.2
         //adafruitDisplay->setRotation(1);
         //adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
     } else {
@@ -207,13 +208,12 @@ bool EInkDisplay::connect()
     adafruitDisplay->setRotation(3);
     adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
 }
-#elif defined(PRIVATE_HW)
+#elif defined(M5_COREINK)
     auto lowLevel = new TECHO_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);
     adafruitDisplay = new GxEPD2_BW<TECHO_DISPLAY_MODEL, TECHO_DISPLAY_MODEL::HEIGHT>(*lowLevel);
     adafruitDisplay->init(115200, true, 10, false, SPI, SPISettings(4000000, MSBFIRST, SPI_MODE0));
     adafruitDisplay->setRotation(0);
-    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
-  
+    adafruitDisplay->setPartialWindow(0, 0, EPD_WIDTH, EPD_HEIGHT);
 #endif
    
     

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -192,7 +192,7 @@ bool EInkDisplay::connect()
 
         //RAK14000 2.13 inch b/w 250x122 does not support partial updates 
         adafruitDisplay->setRotation(3);
-        //For 1.54, 2.9 and 4.2
+        //For 1.54, 2.9 and 4.2 with Partial Updates
         //adafruitDisplay->setRotation(1);
         //adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
     } else {

--- a/src/graphics/EInkDisplay2.cpp
+++ b/src/graphics/EInkDisplay2.cpp
@@ -199,7 +199,7 @@ bool EInkDisplay::connect()
         (void)adafruitDisplay;
     }      
 }
-#elif defined(PCA10059) || defined(PRIVATE_HW)
+#elif defined(PCA10059)
 {
     auto lowLevel = new TECHO_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);
     adafruitDisplay = new GxEPD2_BW<TECHO_DISPLAY_MODEL, TECHO_DISPLAY_MODEL::HEIGHT>(*lowLevel);
@@ -208,7 +208,12 @@ bool EInkDisplay::connect()
     adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
 }
 #elif defined(PRIVATE_HW)
- adafruitDisplay->setRotation(0);    
+    auto lowLevel = new TECHO_DISPLAY_MODEL(PIN_EINK_CS, PIN_EINK_DC, PIN_EINK_RES, PIN_EINK_BUSY);
+    adafruitDisplay = new GxEPD2_BW<TECHO_DISPLAY_MODEL, TECHO_DISPLAY_MODEL::HEIGHT>(*lowLevel);
+    adafruitDisplay->init(115200, true, 10, false, SPI, SPISettings(4000000, MSBFIRST, SPI_MODE0));
+    adafruitDisplay->setRotation(0);
+    adafruitDisplay->setPartialWindow(0, 0, displayWidth, displayHeight);
+  
 #endif
    
     

--- a/variants/m5stack_coreink/platformio.ini
+++ b/variants/m5stack_coreink/platformio.ini
@@ -1,0 +1,14 @@
+[env:m5stack-coreink]
+extends = esp32_base
+board = m5stack-coreink
+build_flags = 
+  ${esp32_base.build_flags} -D PRIVATE_HW -I variants/m5stack_coreink
+  ;-D RADIOLIB_VERBOSE
+  -Ofast
+  -D__MCUXPRESSO
+lib_deps = 
+  ${esp32_base.lib_deps}
+  zinggjm/GxEPD2@^1.4.5
+board_build.f_cpu = 240000000L
+upload_protocol = esptool
+upload_port = /dev/ttyACM*

--- a/variants/m5stack_coreink/platformio.ini
+++ b/variants/m5stack_coreink/platformio.ini
@@ -9,6 +9,7 @@ build_flags =
 lib_deps = 
   ${esp32_base.lib_deps}
   zinggjm/GxEPD2@^1.4.5
+  lewisxhe/PCF8563_Library@^0.0.1
 board_build.f_cpu = 240000000L
 upload_protocol = esptool
 upload_port = /dev/ttyACM*

--- a/variants/m5stack_coreink/platformio.ini
+++ b/variants/m5stack_coreink/platformio.ini
@@ -2,10 +2,13 @@
 extends = esp32_base
 board = m5stack-coreink
 build_flags = 
-  ${esp32_base.build_flags} -D PRIVATE_HW -I variants/m5stack_coreink
+  ${esp32_base.build_flags} -D M5_COREINK -I variants/m5stack_coreink
   ;-D RADIOLIB_VERBOSE
   -Ofast
   -D__MCUXPRESSO
+  -DEPD_HEIGHT=200
+  -DEPD_WIDTH=200
+  -DM5STACK
 lib_deps = 
   ${esp32_base.lib_deps}
   zinggjm/GxEPD2@^1.4.5

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -1,0 +1,44 @@
+#define I2C_SDA 32 //-1
+#define I2C_SCL 33 //-1
+
+//#define LED_PIN 10
+
+#define BUTTON_NEED_PULLUP
+#define BUTTON_PIN 5
+
+//Wheel
+// Down 37
+// Push 38
+// Up 39
+
+// Top Physical Button 5
+
+#undef RF95_SCK
+#undef RF95_MISO
+#undef RF95_MOSI
+#undef RF95_NSS
+#define USE_RF95
+
+#define RF95_SCK  18 //13
+#define RF95_MISO 34 //26
+#define RF95_MOSI 23 //25 
+#define RF95_NSS 14 
+#define LORA_DIO0 25 //32 now moved from ext port
+#define LORA_RESET 26 //33 now moved from ext port
+#define LORA_DIO1 RADIOLIB_NC
+#define LORA_DIO2 RADIOLIB_NC
+
+#define NO_GPS
+// This board has no GPS for now
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#define HAS_EINK
+//https://docs.m5stack.com/en/core/coreink
+#define PIN_EINK_EN    -1
+#define PIN_EINK_CS    9          // EPD_CS
+#define PIN_EINK_BUSY  4          // EPD_BUSY
+#define PIN_EINK_DC    15          // EPD_D/C
+#define PIN_EINK_RES   -1          // Connected to GPIO0 but no needed !!!! maybe causing issue ?
+#define PIN_EINK_SCLK  18           // EPD_SCLK
+#define PIN_EINK_MOSI  23          // EPD_MOSI

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -1,7 +1,7 @@
 #define I2C_SDA 21 //-1
 #define I2C_SCL 22 //-1
 
-//#define LED_PIN 10
+#define LED_PIN 10
 
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -1,7 +1,10 @@
-#define I2C_SDA 32 //-1
-#define I2C_SCL 33 //-1
+#define I2C_SDA 21 //-1
+#define I2C_SCL 22 //-1
 
 //#define LED_PIN 10
+
+// PCF8563 RTC Module
+#define PCF8563_RTC 0x51
 
 #define BUTTON_NEED_PULLUP
 #define BUTTON_PIN 5

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -1,7 +1,7 @@
 #define I2C_SDA 21 //-1
 #define I2C_SCL 22 //-1
 
-#define LED_PIN 10
+//#define LED_PIN 10
 
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -38,6 +38,7 @@
 
 #define HAS_EINK
 //https://docs.m5stack.com/en/core/coreink
+//https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/schematic/Core/coreink/coreink_sch.pdf
 #define PIN_EINK_EN    -1
 #define PIN_EINK_CS    9          // EPD_CS
 #define PIN_EINK_BUSY  4          // EPD_BUSY

--- a/variants/m5stack_coreink/variant.h
+++ b/variants/m5stack_coreink/variant.h
@@ -3,6 +3,7 @@
 
 //#define LED_PIN 10
 
+#include "pcf8563.h"
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51
 


### PR DESCRIPTION
Kindly review and comment

This adds support for the M5Stack CoreInk with a HopeRF95 SPI LoRa module connected to the port on the back of the device

Working
HopeRF RFM95W SX1276
User button
Reset button
WiFi/Bluetooth
E-ink with fast partial updates (GDEW0154M09)
Meshtastic-cli configuration via SoftAP ( thanks [@caveman99](https://meshtastic.discourse.group/u/caveman99) )
Currently not working
serial meshtastic-cli support - hardware issue ?
GPIO0 is wired from E-Ink RESET to the UART (This is what i believe is to be the issue)
Still Todo
Real Time Clock (might be already supported ? BM8563) - Tested with 1.3.12 firmware
Buzzer ( [@caveman99](https://meshtastic.discourse.group/u/caveman99) already has this with the M5 Core)
Battery Monitoring ? - Does not have an actual pin for this

as discussed on Forum

https://meshtastic.discourse.group/t/wip-m5-stack-coreink-hoperf-rf95w-sx1276-lora-radio-support/5829

https://docs.m5stack.com/en/core/coreink
https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/schematic/Core/coreink/coreink_sch.pdf


![image](https://user-images.githubusercontent.com/22388007/171466391-64209ee2-4bc6-4450-bd71-99e03a2789bf.png)
https://static-cdn.m5stack.com/resource/docs/products/core/coreink/coreink_03.webp
![image](https://user-images.githubusercontent.com/22388007/171466422-efeca39e-7a3c-49f8-b640-fa15630b7376.png)

