### PR TITLE
Reduce baud rate of upload and monitoring for RAK-11200

### DIFF
--- a/src/mesh/generated/module_config.pb.h
+++ b/src/mesh/generated/module_config.pb.h
@@ -115,7 +115,7 @@ typedef struct _ModuleConfig_TelemetryConfig {
     uint32_t environment_sensor_pin; 
 } ModuleConfig_TelemetryConfig;
 
-/* TODO: REPLACE */
+/* Module Config */
 typedef struct _ModuleConfig { 
     /* TODO: REPLACE */
     pb_size_t which_payloadVariant;

--- a/variants/rak11200/platformio.ini
+++ b/variants/rak11200/platformio.ini
@@ -3,3 +3,5 @@ extends = esp32_base
 board = wiscore_rak11200
 build_flags = 
   ${esp32_base.build_flags} -D RAK_11200 -I variants/rak11200
+upload_speed = 115200
+monitor_speed = 115200

--- a/variants/rak11200/variant.h
+++ b/variants/rak11200/variant.h
@@ -82,3 +82,5 @@ static const uint8_t SCK = 33;
 #define SX126X_TXEN (-1)
 #define SX126X_RXEN (WB_IO3)
 #define SX126X_E22 // DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
+
+#define CONSOLE_MAX_BAUD 115200


### PR DESCRIPTION
There seem to be issues operating at 921600, so I've bumped the baud rate down to 115200 to work reliably.
We need to look at adding a baud argument to meshtastic-python's noproto command now