### PR TITLE
Re-init config_state after we switch to nodeinfo

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -184,6 +184,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         // Advance when we have sent all of our config objects
         if (config_state > Config_lora_tag) {
             state = STATE_SEND_NODEINFO;
+            config_state = Config_device_tag;
         }
         break;
 


### PR DESCRIPTION
Initial config sending was only being sent on a freshly booted / reset device. This will resolve that hopefully