### PR TITLE
Add debug to monitor radio reconfiguration for #1014

### DIFF
--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -70,6 +70,10 @@ bool RF95Interface::init()
     int res = lora->begin(getFreq(), bw, sf, cr, syncWord, power, currentLimit, preambleLength);
     DEBUG_MSG("RF95 init result %d\n", res);
 
+    DEBUG_MSG("Frequency set to %f\n", getFreq());    
+    DEBUG_MSG("Bandwidth set to %f\n", bw);    
+    DEBUG_MSG("Power output set to %d\n", power);    
+
     // current limit was removed from module' ctor
     // override default value (60 mA)
     res = lora->setCurrentLimit(currentLimit);

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -56,6 +56,10 @@ bool SX126xInterface<T>::init()
     // \todo Display actual typename of the adapter, not just `SX126x`
     DEBUG_MSG("SX126x init result %d\n", res);
 
+    DEBUG_MSG("Frequency set to %f\n", getFreq());    
+    DEBUG_MSG("Bandwidth set to %f\n", bw);    
+    DEBUG_MSG("Power output set to %d\n", power);    
+
     // current limit was removed from module' ctor
     // override default value (60 mA)
     res = lora.setCurrentLimit(currentLimit);


### PR DESCRIPTION
Add debug to monitor radio reconfiguration for #1014

Every time radio is configured, will print debug details:

    DEBUG_MSG("Frequency set to %f\n", getFreq());    
    DEBUG_MSG("Bandwidth set to %f\n", bw);    
    DEBUG_MSG("Power output set to %d\n", power);  