### PR TITLE
Update MQTT.cpp

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -356,7 +356,7 @@ String MQTT::downstreamPacketToJson(MeshPacket *mp)
                                 {"payload", msgPayload}};
 
     // serialize and return it
-    std::string jsonStr = jsonObj.dump();
+    static std::string jsonStr = jsonObj.dump();
     DEBUG_MSG("serialized json message: %s\n", jsonStr.c_str());
 
     return jsonStr.c_str();


### PR DESCRIPTION
Fix returning pointer to local variable that will become invalid when returning.

I am new to Meshtastic and was just browsing the code trying to become familiar with what is being done. I noticed what looked like a bug to me. I think making the local variable static is a quick easy fix but feel free to correct me if you are more familiar with what the code is doing.

More info:
'return jsonStr.c_str();' returns the address of the local variable jsonStr which is deallocated when the function returns.
This will work as long as jsonStr is not overwritten before it is used but there is no predicting when it will stop working.
