### PR TITLE
Set last gps coordinates after comparison

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -169,10 +169,6 @@ int32_t PositionModule::runOnce()
                 float distance = GeoCoord::latLongToMeter(lastGpsLatitude * 1e-7, lastGpsLongitude * 1e-7,
                                                           node->position.latitude_i * 1e-7, node->position.longitude_i * 1e-7);
 
-                // Set the current coords as our last ones, after we've compared distance with current
-                lastGpsLatitude = node->position.latitude_i;
-                lastGpsLongitude = node->position.longitude_i;
-
                 // Yes, this has a bunch of magic numbers. Sorry. This is to make the scale non-linear.
                 const float distanceTravelMath = 1203 / (sqrt(pow(myNodeInfo.bitrate, 1.5) / 1.1));
                 uint32_t distanceTravelThreshold =
@@ -190,6 +186,10 @@ int32_t PositionModule::runOnce()
                     DEBUG_MSG("Sending smart pos@%x:6 to mesh (wantReplies=%d, d=%d, dtt=%d, tt=%d)\n", node2->position.pos_timestamp,
                               requestReplies, distance, distanceTravelThreshold, timeTravel);
                     sendOurPosition(NODENUM_BROADCAST, requestReplies);
+
+                    // Set the current coords as our last ones, after we've compared distance with current and decided to send
+                    lastGpsLatitude = node->position.latitude_i;
+                    lastGpsLongitude = node->position.longitude_i;
 
                     /* Update lastGpsSend to now. This means if the device is stationary, then
                        getPref_position_broadcast_secs will still apply.

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -169,23 +169,26 @@ int32_t PositionModule::runOnce()
                 float distance = GeoCoord::latLongToMeter(lastGpsLatitude * 1e-7, lastGpsLongitude * 1e-7,
                                                           node->position.latitude_i * 1e-7, node->position.longitude_i * 1e-7);
 
+                // Set the current coords as our last ones, after we've compared distance with current
+                lastGpsLatitude = node->position.latitude_i;
+                lastGpsLongitude = node->position.longitude_i;
+
                 // Yes, this has a bunch of magic numbers. Sorry. This is to make the scale non-linear.
                 const float distanceTravelMath = 1203 / (sqrt(pow(myNodeInfo.bitrate, 1.5) / 1.1));
-                uint32_t distanceTravel =
+                uint32_t distanceTravelThreshold =
                     (distanceTravelMath >= distanceTravelMinimum) ? distanceTravelMath : distanceTravelMinimum;
 
                 // Yes, this has a bunch of magic numbers. Sorry.
                 uint32_t timeTravel =
                     ((1500 / myNodeInfo.bitrate) >= timeTravelMinimum) ? (1500 / myNodeInfo.bitrate) : timeTravelMinimum;
-
                 // If the distance traveled since the last update is greater than 100 meters
                 //   and it's been at least 60 seconds since the last update
-                if ((abs(distance) >= distanceTravel) && (now - lastGpsSend >= timeTravel * 1000)) {
+                if ((abs(distance) >= distanceTravelThreshold) && (now - lastGpsSend) >= (timeTravel * 1000)) {
                     bool requestReplies = currentGeneration != radioGeneration;
                     currentGeneration = radioGeneration;
 
-                    DEBUG_MSG("Sending smart pos@%x:6 to mesh (wantReplies=%d, dt=%d, tt=%d)\n", node2->position.pos_timestamp,
-                              requestReplies, distanceTravel, timeTravel);
+                    DEBUG_MSG("Sending smart pos@%x:6 to mesh (wantReplies=%d, d=%d, dtt=%d, tt=%d)\n", node2->position.pos_timestamp,
+                              requestReplies, distance, distanceTravelThreshold, timeTravel);
                     sendOurPosition(NODENUM_BROADCAST, requestReplies);
 
                     /* Update lastGpsSend to now. This means if the device is stationary, then


### PR DESCRIPTION
Turns out we weren't saving the last gps coordinates, causing the distance calculation to come up with arbitrarily large numbers every time. This was making a stationary node transmit position packets at the most frequent interval for the bitrate.
![image](https://user-images.githubusercontent.com/9000580/178269283-00c10ea3-7682-4744-8074-bb9f0221a9a0.png)
