### PR TITLE
Respect GPS pins set in variant.h

### DIFF
--- a/src/esp32/architecture.h
+++ b/src/esp32/architecture.h
@@ -77,11 +77,15 @@
 //
 
 #define GPS_SERIAL_NUM 1
+#ifndef GPS_RX_PIN
 #define GPS_RX_PIN 34
+#endif
+#ifndef GPS_TX_PIN
 #ifdef USE_JTAG
 #define GPS_TX_PIN -1
 #else
 #define GPS_TX_PIN 12
+#endif
 #endif
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
I noticed GPS on my tlora 2.1-1.6 boards stopped working after some update in the last 6mo.

I then noticed this in the compile output:
```
In file included from src/configuration.h:134:0,
                 from src/NodeStatus.h:4,
                 from src/mesh/NodeDB.h:8,
                 from src/mesh/Channels.h:4,
                 from src/mesh/Router.h:3,
                 from src/mesh/Router.cpp:1:
src/esp32/architecture.h:81:0: warning: "GPS_RX_PIN" redefined
 #define GPS_RX_PIN 34
 ^
In file included from src/configuration.h:130:0,
                 from src/NodeStatus.h:4,
                 from src/mesh/NodeDB.h:8,
                 from src/mesh/Channels.h:4,
                 from src/mesh/Router.h:3,
                 from src/mesh/Router.cpp:1:
variants/tlora_v2_1_16/variant.h:3:0: note: this is the location of the previous definition
 #define GPS_RX_PIN 15 // per @der_bear on the forum, 36 is incorrect for this board type and 15 is a better pick
 ^
In file included from src/configuration.h:134:0,
                 from src/mesh/SX1262Interface.cpp:1:
src/esp32/architecture.h:81:0: warning: "GPS_RX_PIN" redefined
 #define GPS_RX_PIN 34
 ^
In file included from src/configuration.h:130:0,
                 from src/mesh/SX1262Interface.cpp:1:
variants/tlora_v2_1_16/variant.h:3:0: note: this is the location of the previous definition
 #define GPS_RX_PIN 15 // per @der_bear on the forum, 36 is incorrect for this board type and 15 is a better pick
 ^
In file included from src/configuration.h:134:0,
                 from src/mesh/SX1268Interface.cpp:1:
src/esp32/architecture.h:81:0: warning: "GPS_RX_PIN" redefined
 #define GPS_RX_PIN 34
 ^
In file included from src/configuration.h:130:0,
                 from src/mesh/SX1268Interface.cpp:1:
variants/tlora_v2_1_16/variant.h:3:0: note: this is the location of the previous definition
 #define GPS_RX_PIN 15 // per @der_bear on the forum, 36 is incorrect for this board type and 15 is a better pick
```

This change makes order-of-import between `architecture.h` & `variant.h` flexible, and fixes the pins.