### PR TITLE
Only save devicestate on GPS reset

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -330,7 +330,7 @@ int32_t GPS::runOnce()
         if(devicestate.did_gps_reset && (millis() > 60000) && !hasFlow()) {
             DEBUG_MSG("GPS is not communicating, trying factory reset on next bootup.\n");
             devicestate.did_gps_reset = false;
-            nodeDB.saveToDisk();
+            nodeDB.saveDeviceStateToDisk();
         }
 #endif
     }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -435,6 +435,16 @@ void NodeDB::saveChannelsToDisk()
     }
 }
 
+void NodeDB::saveDeviceStateToDisk() 
+{
+    if (!devicestate.no_save) {
+#ifdef FSCom
+        FSCom.mkdir("/prefs");
+#endif
+        saveProto(prefFileName, DeviceState_size, sizeof(devicestate), DeviceState_fields, &devicestate);
+    }
+}
+
 void NodeDB::saveToDisk()
 {
     if (!devicestate.no_save) {

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -44,7 +44,7 @@ class NodeDB
     void init();
 
     /// write to flash
-    void saveToDisk(), saveChannelsToDisk();
+    void saveToDisk(), saveChannelsToDisk(), saveDeviceStateToDisk();
 
     /** Reinit radio config if needed, because either:
      * a) sometimes a buggy android app might send us bogus settings or


### PR DESCRIPTION
We don't need to save all of NodeDb on GPS reset requested. 
I'm trying to minimize FS operations due to all of the issues occuring on NRF.