### PR TITLE
Rebroadcast encrypted messages

### DIFF
--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -44,4 +44,5 @@ void RoutingModule::sendAckNak(Routing_Error err, NodeNum to, PacketId idFrom, C
 RoutingModule::RoutingModule() : ProtobufModule("routing", PortNum_ROUTING_APP, Routing_fields)
 {
     isPromiscuous = true;
+    encryptedOk = true;
 }


### PR DESCRIPTION
This fixes issue #1388. The problem was that the RoutingModule was not set as 'encryptedOk'. 