### PR TITLE
'Station-g1-patch1'

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -156,8 +156,21 @@ class AnalogBatteryLevel : public HasBatteryLevel
     /// If we see a battery voltage higher than physics allows - assume charger is pumping
     /// in power
 
+#ifndef BAT_FULLVOLT
+#define BAT_FULLVOLT 4200
+#endif 
+#ifndef BAT_EMPTYVOLT
+#define BAT_EMPTYVOLT 3270
+#endif 
+#ifndef BAT_CHARGINGVOLT
+#define BAT_CHARGINGVOLT 4210
+#endif 
+#ifndef BAT_NOBATVOLT
+#define BAT_NOBATVOLT 2230
+#endif 
+
     /// For heltecs with no battery connected, the measured voltage is 2204, so raising to 2230 from 2100
-    const float fullVolt = 4200, emptyVolt = 3270, chargingVolt = 4210, noBatVolt = 2230;
+    const float fullVolt = BAT_FULLVOLT, emptyVolt = BAT_EMPTYVOLT, chargingVolt = BAT_CHARGINGVOLT, noBatVolt = BAT_NOBATVOLT;
     float last_read_value = 0.0;
     uint32_t last_read_time_ms = 0;
 };

--- a/variants/station-g1/variant.h
+++ b/variants/station-g1/variant.h
@@ -26,11 +26,16 @@
 //#define SX126X_E22 // Not really an E22 
 // Internally the module hooks the SX1262-DIO2 in to control the TX/RX switch (which is the default for the sx1262interface
 // code)
+#define SX126X_MAX_POWER 16  //Ensure the PA does not exceed the saturation output power. More Info:https://uniteng.com/wiki/doku.php?id=meshtastic:station#rf_design_-_lora_station_edition_g1
 #endif
 
 #define BATTERY_PIN 35    // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
 #define BATTERY_SENSE_SAMPLES 30  //Set the number of samples, It has an effect of increasing sensitivity.
-#define ADC_MULTIPLIER 2.15
+#define ADC_MULTIPLIER 6.45
+#define BAT_FULLVOLT 12600
+#define BAT_EMPTYVOLT 8200
+#define BAT_CHARGINGVOLT 12600
+#define BAT_NOBATVOLT 6690
 
 // different screen
 #define USE_SH1106


### PR DESCRIPTION
Update: protobuf submodule problem has been resolved by stupid way - a new PR :) 
---------------------------------
Sorry, I closed PR https://github.com/meshtastic/Meshtastic-device/pull/1604 Proposal: compatible with various battery packs by mistake, thus I combined the modification of PR https://github.com/meshtastic/Meshtastic-device/pull/1604 with this one.

This PR limited the SX1262 TX power for Station G1 in variant.h:
#define SX126X_MAX_POWER 16 //Ensure the PA does not exceed the saturation output power. More Info:https://uniteng.com/wiki/doku.php?id=meshtastic:station#rf_design_-_lora_station_edition_g1