### PR TITLE
add stm32wl5e platform and wio-e5 variant

### DIFF
--- a/boards/generic_wl5e.json
+++ b/boards/generic_wl5e.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WLxx -DSTM32WLE5xx -DARDUINO_GENERIC_WLE5CCUX",
+    "f_cpu": "48000000L",
+    "mcu": "stm32wle5ccu",
+    "variant": "STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U",
+    "product_line": "STM32WLE5xx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32WLE5CC",
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WLE5_CM4.svd"
+  },
+  "frameworks": ["arduino"],
+  "name": "BB-STM32WL",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "cmsis-dap",
+    "protocols": [
+      "cmsis-dap"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wl-series.html",
+  "vendor": "ST"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -185,3 +185,23 @@ lib_deps =
   ${arduino_base.lib_deps}
   ${environmental_base.lib_deps}
   https://github.com/kokke/tiny-AES-c.git
+
+[stm32wl5e_base]
+platform = ststm32
+board = generic_wl5e
+framework = arduino
+build_type = debug
+build_flags = 
+  ${arduino_base.build_flags}
+  -Isrc/platform/stm32wl -g
+  -DHAL_SUBGHZ_MODULE_ENABLED
+#  Arduino/PlatformIO framework-arduinoststm32 package does not presently have SUBGHZSPI support
+#  -DPIN_SPI_MOSI=PINSUBGHZSPIMOSI -DPIN_SPI_MISO=PINSUBGHZSPIMISO -DPIN_SPI_SCK=PINSUBGHZSPISCK
+build_src_filter = 
+  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mqtt/> -<graphics> -<input> -<buzz> -<modules/Telemetry> -<platform/nrf52> -<platform/portduino> -<platform/rp2040>
+lib_deps =
+  ${env.lib_deps}
+  https://github.com/jgromes/RadioLib.git
+  https://github.com/kokke/tiny-AES-c.git
+lib_ignore = 
+  mathertel/OneButton@^2.0.3

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -43,6 +43,10 @@ RadioLibInterface::RadioLibInterface(RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq
     : NotifiedWorkerThread("RadioIf"), module(cs, irq, rst, busy, spi, spiSettings), iface(_iface)
 {
     instance = this;
+#if defined(ARCH_STM32WL) && defined(USE_SX1262)
+    module.setCb_digitalWrite(stm32wl_emulate_digitalWrite);
+    module.setCb_digitalRead(stm32wl_emulate_digitalRead);
+#endif
 }
 
 #ifdef ARCH_ESP32

--- a/src/platform/stm32wl/STM32WLCryptoEngine.cpp
+++ b/src/platform/stm32wl/STM32WLCryptoEngine.cpp
@@ -1,0 +1,36 @@
+#include "configuration.h"
+#include "CryptoEngine.h"
+#include "aes.hpp"
+
+class STM32WLCryptoEngine : public CryptoEngine
+{
+  public:
+    STM32WLCryptoEngine() {}
+
+    ~STM32WLCryptoEngine() {}
+
+    /**
+     * Encrypt a packet
+     *
+     * @param bytes is updated in place
+     */
+    virtual void encrypt(uint32_t fromNode, uint64_t packetNum, size_t numBytes, uint8_t *bytes) override
+    {
+        if (key.length > 0) {
+            AES_ctx ctx;
+            initNonce(fromNode, packetNum);
+            AES_init_ctx_iv(&ctx, key.bytes, nonce);
+            AES_CTR_xcrypt_buffer(&ctx, bytes, numBytes);
+        }
+    }
+
+    virtual void decrypt(uint32_t fromNode, uint64_t packetNum, size_t numBytes, uint8_t *bytes) override
+    {
+        // For CTR, the implementation is the same
+        encrypt(fromNode, packetNum, numBytes, bytes);
+    }
+
+  private:
+};
+
+CryptoEngine *crypto = new STM32WLCryptoEngine();

--- a/src/platform/stm32wl/architecture.h
+++ b/src/platform/stm32wl/architecture.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#define ARCH_STM32WL
+
+//
+// defaults for STM32WL architecture
+//
+
+//
+// set HW_VENDOR
+//
+
+#ifndef HW_VENDOR
+    #define HW_VENDOR HardwareModel_PRIVATE_HW
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void stm32wl_emulate_digitalWrite(long unsigned int pin, long unsigned int value);
+    int stm32wl_emulate_digitalRead(long unsigned int pin);
+#ifdef __cplusplus
+}
+#endif
+
+/* virtual pins for stm32wl_emulate_digitalWrite() / stm32wl_emulate_digitalRead() to recognize */
+#define SX126X_CS    1000
+#define SX126X_DIO1  1001
+#define SX126X_RESET 1003
+#define SX126X_BUSY  1004
+

--- a/src/platform/stm32wl/layer.c
+++ b/src/platform/stm32wl/layer.c
@@ -1,0 +1,67 @@
+#include <stdbool.h>
+#include "architecture.h"
+#include "stm32wlxx.h"
+#include "stm32wlxx_hal.h"
+
+void HardFault_Handler(void)
+{
+    asm("bkpt");
+}
+
+void stm32wl_emulate_digitalWrite(long unsigned int pin, long unsigned int value)
+{
+    switch (pin)
+    {
+        case SX126X_CS: /* active low */
+            if (value)
+                LL_PWR_UnselectSUBGHZSPI_NSS();
+            else
+                LL_PWR_SelectSUBGHZSPI_NSS();
+            break;
+        case SX126X_RESET: /* active low */
+            if (value)
+                LL_RCC_RF_DisableReset();
+            else
+            {
+                LL_RCC_RF_EnableReset();
+                LL_RCC_HSE_EnableTcxo();
+                LL_RCC_HSE_Enable();
+                while (!LL_RCC_HSE_IsReady());
+            }
+            break;
+        default:
+            asm("bkpt");
+            break;
+    }
+}
+
+static bool irq_happened;
+
+void SUBGHZ_Radio_IRQHandler(void)
+{
+    NVIC_DisableIRQ(SUBGHZ_Radio_IRQn);
+    irq_happened = true;   
+}
+
+int stm32wl_emulate_digitalRead(long unsigned int pin)
+{
+    int outcome = 0;
+
+    switch (pin)
+    {
+        case SX126X_BUSY:
+//            return ((LL_PWR_IsActiveFlag_RFBUSYMS() & LL_PWR_IsActiveFlag_RFBUSYS()) == 1UL);
+            outcome = LL_PWR_IsActiveFlag_RFBUSYS();
+            break;
+        case SX126X_DIO1:
+        default:
+            NVIC_ClearPendingIRQ(SUBGHZ_Radio_IRQn);
+            irq_happened = false;
+            NVIC_EnableIRQ(SUBGHZ_Radio_IRQn);
+            for (int i = 0; i < 64; i++) asm("nop");
+            outcome = irq_happened;
+            break;
+    }
+    return outcome;
+}
+

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -1,0 +1,27 @@
+#include <stm32wle5xx.h>
+#include <stm32wlxx_hal.h>
+#include "configuration.h"
+#include "RTC.h"
+
+void setBluetoothEnable(bool on) {}
+
+void playStartMelody() {}
+
+void updateBatteryLevel(uint8_t level) {}
+
+void getMacAddr(uint8_t *dmac)
+{
+    for (int i = 0; i < 6; i++)
+        dmac[i] = i;
+}
+
+void cpuDeepSleep(uint64_t msecToWake) {}
+
+/* pacify libc_nano */
+extern "C" {
+int _gettimeofday( struct timeval *tv, void *tzvp )
+{
+    return -1;
+}
+}
+

--- a/variants/wio-e5/platformio.ini
+++ b/variants/wio-e5/platformio.ini
@@ -1,0 +1,4 @@
+[env:wio-e5]
+extends = stm32wl5e_base
+build_flags = ${stm32wl5e_base.build_flags} -Ivariants/wio-e5 -DHAL_DAC_MODULE_ONLY
+  -DSERIAL_UART_INSTANCE=1 -DPIN_SERIAL_RX=PB7 -DPIN_SERIAL_TX=PB6

--- a/variants/wio-e5/variant.h
+++ b/variants/wio-e5/variant.h
@@ -1,0 +1,29 @@
+/*
+Wio-E5 mini (formerly LoRa-E5 mini)
+https://www.seeedstudio.com/LoRa-E5-mini-STM32WLE5JC-p-4869.html
+https://www.seeedstudio.com/LoRa-E5-Wireless-Module-p-4745.html
+*/
+
+/*
+This variant is a work in progress.
+Do not expect a working Meshtastic device with this target.
+*/
+
+#ifndef _VARIANT_WIOE5_
+#define _VARIANT_WIOE5_
+
+//Arduino/PlatformIO support for SUBGHZSPI is not currently available
+//#define USE_SX1262
+
+#ifdef USE_SX1262
+    #define HAS_RADIO 1
+
+    /* module only transmits through RFO_HP */
+    #define SX126X_RXEN PA5
+    #define SX126X_TXEN PA4
+
+    /* TCXO fed by internal LDO option behind PB0 pin */
+    #define SX126X_E22
+#endif
+
+#endif


### PR DESCRIPTION
The STM32WL series combines a STM32 core and a SX1262 into a single chip.  There is no USB functionality in the STM32 core, so a USB serial adapter must also be included in the design (as one finds in the various ESP32 boards).

There is no Bluetooth; it would have to be a direct USB connection.  There might also be a future for this chip for REMOTE_HARDWARE_APP usage, but I haven't looked at that.

This is still a work in progress, but I wanted to commit something to keep the ball rolling.  DO NOT BUY one of these boards expecting to have a functional solution.  Also, one would need a "JTAG" (really SWD) ARM debug pod to do anything.

The biggest stumbling block is that Meshtastic uses Arduino / PlatformIO.  It is like a child's paint-with-water coloring book; as long as the invisible paint is the color that you wanted, great... but if not, tough luck.

In this case, the STM32 Arduino library doesn't support SPI comms with the SUBGHZSPI peripheral, and RadioLib uses Arduino (including SPI) as its foundation.  I've [provided a PR for STM32 Arduino](https://github.com/stm32duino/Arduino_Core_STM32/pull/1803) to make it possible, but we'll see if that gets accepted.  Moreover, even if it does get accepted, PlatformIO is already two years behind in its package of the STM32 Arduino library.

So, in this PR, in platform.ini I've commented out the build_flags that depend on this, and similarly I've commented out USE_SX1262 in ./variants/wio-e5/variant.h.  So, with the PR, it just uses the simulated radio.

Speaking of the Wio-E5 mini (formerly called LoRa-E5 mini... the LoRa trade group is cracking down on entities using its trademark in product names), I did buy a few STM32WL targets, but this one looked the most promising for Meshtastic usage (since it is basically USB-C on one side (CH340 USB-UART) and antenna on the other, and it comes with a short USB cable and a nice looking antenna).

![mwio](https://user-images.githubusercontent.com/12226419/184554337-573751f6-2d36-4e88-a0b4-60e77c1d6789.jpg)

An important gotcha with the Wio-E5 is that it is pre-programmed with their proprietary LoRa AT command firmware.  Seeedstudio make a big fuss on their web site about how they have a bootloader and how to recognize when it is operational, but then when you read further and try to make use of it yourself, you find that you have to first erase the chip (using an external debugger connected to pins that you must solder on) to unlock the firmware, and that also erases the bootloader.  Great job at wasting peoples' time, Seeedstudio. :(  So, a SWD debugger is needed.  Note that SEGGER, which is normally the gold standard of debuggers, can't unlock the chip (at least at the present J-Link version) with their normal software.  I had employ OpenOCD to make headway on that.  So, I must point out again that, presently, this is NOT for the casual user!

Another gotcha is that RadioLib wants to be able to control/poll the "DIO1" interrupt line, BUSY, and RESET  as GPIO pins.  When the peripheral is internal to the chip, that is not practical.  Moreover, there is no way to poll the SUBGHZRADIO interrupt line on the STM32WL... period.  (The interrupt is also a combination of the SX1262 interrupt *and* BUSY.)  My workaround is a bit ugly (using the RadioLib callbacks for digitalWrite and digitalRead to translate internal signals into simulated GPIO signals), but then so is the situation that forced me to write it like that.

Another gotcha is that Meshtastic makes heavy use of floating-point values, both for calculations and in debug print statements.  The STM32 Arduino PlatformIO platform appears to be using newlib without float support in sprintf, so lots of values don't appear in the debug logs.

Another gotcha is that (like you may have already found with existing PCBs used with Meshtastic) each STM32WL PCB implementation will likely have different assignments for pins for UART, RF switch controls, etc.  Thankfully Meshtastic-device has that construct already, although RadioLib can't fathom the notion of devices that use distinct PA_HI and PA_LO switch positions.  So, don't expect that  one STM32WL firmware image will work on different PCB designs.

I haven't been able to test interoperability with existing Meshtastic devices.  My experience so far with Meshtastic devices has been pretty horrible.  I bought several ESP32 off Amazon, and there seems to be no quality control.  A user might get one or two Meshtastic messages when first powering the devices up, but then it quickly gets into a funk where messages get NAKed and then later nothing seems to work.  Leave it off overnight and it briefly works again.  (For anyone about to say that I didn't have the devices far enough from each other, I tried cabling in all sort of different RF attenuators with no success.)

I think that covers everything... at least all that I can remember at the moment.
