### PR TITLE
Factory reset changes

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -112,6 +112,13 @@ bool NodeDB::resetRadioConfig()
     // Update the global myRegion
     initRegion();
 
+    if (didFactoryReset) {
+        config.device.factory_reset = false;
+        DEBUG_MSG("Rebooting due to factory reset");
+        screen->startRebootScreen();
+        rebootAtMsec = millis() + (5 * 1000);
+    }
+
     return didFactoryReset;
 }
 
@@ -122,6 +129,7 @@ bool NodeDB::factoryReset()
     rmDir("/prefs");
     // second, install default state (this will deal with the duplicate mac address issue)
     installDefaultDeviceState();
+    installDefaultConfig();
     // third, write to disk
     saveToDisk();
 #ifdef ARCH_ESP32


### PR DESCRIPTION
# What?

Fixes #1597 

After factory resetting automatically reboot the device, and also overwrite with default config.

After playing around with this for a few hours these changes seem to make factory resetting the device work without boot loops.

# Notes

- I'm not sure if `rmDir("/prefs")` actually does anything, the configs seem to remain in memory and then get saved anyway.
- I may have changed the behavior of factory reset to override all configs, I'm not sure if this is what is intended as there is not much documentation on what its meant to do.