### PR TITLE
Add t-beam sx1268 support

### DIFF
--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -14,6 +14,7 @@
 // not found then probe for SX1262
 #define USE_RF95
 #define USE_SX1262
+#define USE_SX1268
 
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 23


### PR DESCRIPTION
Add tbeam sx1268 support,tbeam  plans to use sx1268 in the 433MHZ version, so turn on the option to support sx1268 in the variant, it has been tested in the device and works well