### PR TITLE
'snow_screen_hotfix'

### DIFF
--- a/variants/nano-g1/variant.h
+++ b/variants/nano-g1/variant.h
@@ -28,3 +28,5 @@
 // code)
 #endif
 
+// different screen
+#define USE_SH1106


### PR DESCRIPTION
Snow Screen Hotfix for Nano G1
--------------------------------------------
I2C Probe has been disabled by this hotfix.