### PR TITLE
i2cScan probe adds another ssd1306 subclass new to output logs correctly

### DIFF
--- a/src/detect/i2cScan.h
+++ b/src/detect/i2cScan.h
@@ -45,7 +45,7 @@ uint8_t oled_probe(byte addr)
 
         if (r == 0x08 || r == 0x00) {
             o_probe = 2; // SH1106
-        } else if ( r == 0x03 || r == 0x06 || r == 0x07) {
+        } else if ( r == 0x03 || r == 0x04 || r == 0x06 || r == 0x07) {
             o_probe = 1; // SSD1306
         }
         c++;


### PR DESCRIPTION
As the title, the following log will be output when it is recognized：

```
//\ E S H T /\ S T / C

??:??:?? 0 booted, wake cause 0 (boot count 1), reset_reason=reset
.pio/libdeps/tbeam/LittleFS_esp32/src/lfs.c:1076:error: Corrupted dir pair at {0x0, 0x1}
E (27) esp_littlefs: mount failed,  (-84)
E (30) esp_littlefs: Failed to initialize LittleFS
??:??:?? 0 Filesystem files:
??:??:?? 0 I2C device found at address 0x34
??:??:?? 0 axp192 PMU found
??:??:?? 0 I2C device found at address 0x3c
??:??:?? 0 0x4 subtype probed in 2 tries
??:??:?? 0 unknown display found

```



After the repair, get the normal output of the log：
```
//\ E S H T /\ S T / C

??:??:?? 0 booted, wake cause 0 (boot count 1), reset_reason=reset
??:??:?? 0 Filesystem files:
??:??:?? 0   /prefs/channels.proto (53 Bytes)
??:??:?? 0   /prefs/config.proto (40 Bytes)
??:??:?? 0   /prefs/db.proto (144 Bytes)
??:??:?? 0   /prefs/module.proto (16 Bytes)
??:??:?? 0 I2C device found at address 0x34
??:??:?? 0 axp192 PMU found
??:??:?? 0 I2C device found at address 0x3c
??:??:?? 0 0x4 subtype probed in 2 tries
??:??:?? 0 ssd1306 display found
```