### PR TITLE
Init default intervals

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -209,7 +209,7 @@ void NodeDB::installDefaultModuleConfig()
 void NodeDB::initModuleConfigIntervals() 
 {
     moduleConfig.telemetry.device_update_interval = default_broadcast_interval_secs;
-    moduleConfig.telemetry.environment_screen_enabled = default_broadcast_interval_secs;
+    moduleConfig.telemetry.environment_update_interval = default_broadcast_interval_secs;
 }
 
 void NodeDB::installDefaultChannels()

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -173,6 +173,20 @@ void NodeDB::installDefaultConfig()
     config.bluetooth.mode = hasScreen ? Config_BluetoothConfig_PairingMode_RANDOM_PIN : Config_BluetoothConfig_PairingMode_FIXED_PIN;
     // for backward compat, default position flags are ALT+MSL
     config.position.position_flags = (Config_PositionConfig_PositionFlags_ALTITUDE | Config_PositionConfig_PositionFlags_ALTITUDE_MSL);
+    initConfigIntervals();
+}
+
+void NodeDB::initConfigIntervals() 
+{
+    config.position.position_broadcast_secs = default_broadcast_interval_secs;
+
+    config.power.ls_secs = default_ls_secs;
+    config.power.mesh_sds_timeout_secs = default_mesh_sds_timeout_secs;
+    config.power.min_wake_secs = default_min_wake_secs;
+    config.power.sds_secs = default_sds_secs;
+    config.power.wait_bluetooth_secs = default_wait_bluetooth_secs;
+    
+    config.display.screen_on_secs = default_screen_on_secs;
 }
 
 void NodeDB::installDefaultModuleConfig()
@@ -187,6 +201,14 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.has_telemetry = true;
     moduleConfig.has_external_notification = true;
     moduleConfig.has_canned_message = true;
+    
+    initModuleConfigIntervals();
+}
+
+void NodeDB::initModuleConfigIntervals() 
+{
+    moduleConfig.telemetry.device_update_interval = default_broadcast_interval_secs;
+    moduleConfig.telemetry.environment_screen_enabled = default_broadcast_interval_secs;
 }
 
 void NodeDB::installDefaultChannels()

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -173,6 +173,7 @@ void NodeDB::installDefaultConfig()
     config.bluetooth.mode = hasScreen ? Config_BluetoothConfig_PairingMode_RANDOM_PIN : Config_BluetoothConfig_PairingMode_FIXED_PIN;
     // for backward compat, default position flags are ALT+MSL
     config.position.position_flags = (Config_PositionConfig_PositionFlags_ALTITUDE | Config_PositionConfig_PositionFlags_ALTITUDE_MSL);
+    
     initConfigIntervals();
 }
 
@@ -201,7 +202,7 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.has_telemetry = true;
     moduleConfig.has_external_notification = true;
     moduleConfig.has_canned_message = true;
-    
+
     initModuleConfigIntervals();
 }
 

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -115,6 +115,8 @@ class NodeDB
     /// Return the number of nodes we've heard from recently (within the last 2 hrs?)
     size_t getNumOnlineNodes();
 
+    void initConfigIntervals(), initModuleConfigIntervals();
+
   private:
     /// Find a node in our DB, create an empty NodeInfo if missing
     NodeInfo *getOrCreateNode(NodeNum n);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -175,7 +175,15 @@ void AdminModule::handleSetConfig(const Config &c)
         case Config_device_tag:
             DEBUG_MSG("Setting config: Device\n");
             config.has_device = true;
+            auto previousDeviceRole = config.device.role;
             config.device = c.payload_variant.device;
+            // If we're setting router role for the first time, install its intervals
+            if (previousDeviceRole != Config_DeviceConfig_Role_ROUTER &&
+                c.payload_variant.device.role == Config_DeviceConfig_Role_ROUTER) {
+                nodeDB.initConfigIntervals();
+                nodeDB.initModuleConfigIntervals();
+            }
+            requiresReboot = true;
             break;
         case Config_position_tag:
             DEBUG_MSG("Setting config: Position\n");

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -171,14 +171,15 @@ void AdminModule::handleSetOwner(const User &o)
 void AdminModule::handleSetConfig(const Config &c)
 {
     bool requiresReboot = false;
+    bool isRouter = (config.device.role == Config_DeviceConfig_Role_ROUTER);
+
     switch (c.which_payload_variant) {
         case Config_device_tag:
             DEBUG_MSG("Setting config: Device\n");
             config.has_device = true;
-            auto previousDeviceRole = config.device.role;
             config.device = c.payload_variant.device;
             // If we're setting router role for the first time, install its intervals
-            if (previousDeviceRole != Config_DeviceConfig_Role_ROUTER &&
+            if (!isRouter &&
                 c.payload_variant.device.role == Config_DeviceConfig_Role_ROUTER) {
                 nodeDB.initConfigIntervals();
                 nodeDB.initModuleConfigIntervals();

--- a/variants/tbeam/platformio.ini
+++ b/variants/tbeam/platformio.ini
@@ -2,7 +2,9 @@
 [env:tbeam]
 extends = esp32_base
 board = ttgo-t-beam
+platform_packages = framework-arduinoespressif32@https://github.com/meshtastic/arduino-esp32.git#4cde0f5d412d2695184f32e8a47e9bea57b45276
 lib_deps =
   ${esp32_base.lib_deps}
 build_flags = 
   ${esp32_base.build_flags} -D TBEAM_V10  -I variants/tbeam
+upload_speed = 921600


### PR DESCRIPTION
This PR causes the default device intervals to be set in the initial device and again when device role is set to router.