### PR TITLE
'battery_gauge_fix'

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -131,7 +131,7 @@ class AnalogBatteryLevel : public HasBatteryLevel
 #endif
             // DEBUG_MSG("battery gpio %d raw val=%u scaled=%u\n", BATTERY_PIN, raw, (uint32_t)(scaled));
             last_read_value = scaled;
-            return scaled * 1000;
+            return scaled;
         } else {
             return last_read_value;
         }


### PR DESCRIPTION
Bug: getBatteryPercent() in the Power.cpp has to return -1 for "no battery" status, but it is never return -1.

Reason:
The return value is controlled by the condition "v<noBatVolt". noBatVolt is defined in mV, but in the getBattVoltage() we *1000 two times for converting from V to mV, so that  (v<noBatVolt) never comes to true.

Fix:
Remove one of the *1000