### PR TITLE
Switch to 5.4.0 using latest fix (170ce9) to error check after calibr…

### DIFF
--- a/arch/stm32/stm32wl5e.ini
+++ b/arch/stm32/stm32wl5e.ini
@@ -13,7 +13,6 @@ build_src_filter =
   ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mqtt/> -<graphics> -<input> -<buzz> -<modules/Telemetry> -<platform/nrf52> -<platform/portduino> -<platform/rp2040>
 lib_deps =
   ${env.lib_deps}
-  jgromes/RadioLib@5.3.0
   https://github.com/kokke/tiny-AES-c.git#f06ac37fc31dfdaca2e0d9bec83f90d5663c319b
 lib_ignore = 
   mathertel/OneButton@^2.0.3

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,10 +62,10 @@ framework = arduino
 lib_deps =
   ${env.lib_deps}
   ; Portduino is using meshtastic fork for now
-  ;jgromes/RadioLib@5.3.0
-  https://github.com/jgromes/RadioLib.git#170ce9752bf7ccf78713d60fb1a0b93f9ba3e3d2
+  jgromes/RadioLib@5.4.1
 
 build_flags = ${env.build_flags} -Os 
+  -DRADIOLIB_SPI_PARANOID=0
 # -DRADIOLIB_GODMODE
 build_src_filter = ${env.build_src_filter} -<platform/portduino/>
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,8 @@ framework = arduino
 lib_deps =
   ${env.lib_deps}
   ; Portduino is using meshtastic fork for now
-  jgromes/RadioLib@5.3.0
+  ;jgromes/RadioLib@5.3.0
+  https://github.com/jgromes/RadioLib.git#170ce9752bf7ccf78713d60fb1a0b93f9ba3e3d2
 
 build_flags = ${env.build_flags} -Os 
 # -DRADIOLIB_GODMODE


### PR DESCRIPTION
Per [jgromes/RadioLib] RadioLib 5.4.0 fails initialization for CubeCell (Issue #583)

It looks like it's caused by performing command verification during an ongoing calibration. In the latest commit ([170ce97](https://github.com/jgromes/RadioLib/commit/170ce9752bf7ccf78713d60fb1a0b93f9ba3e3d2)), I changed this to skip verification in this one case.
