### PR TITLE
fix #1713

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -1,6 +1,7 @@
 #include "configuration.h"
 #include "RedirectablePrint.h"
 #include "RTC.h"
+#include "NodeDB.h"
 #include "concurrency/OSThread.h"
 // #include "wifi/WiFiServerAPI.h"
 #include <assert.h>
@@ -30,7 +31,9 @@ size_t RedirectablePrint::write(uint8_t c)
     // optionally send chars to TCP also
     //WiFiServerPort::debugOut(c);
 
-    dest->write(c);
+    if (!config.has_lora || config.device.serial_enabled)
+        dest->write(c);
+
     return 1; // We always claim one was written, rather than trusting what the
               // serial port said (which could be zero)
 }

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -60,10 +60,15 @@ bool SerialConsole::checkIsConnected()
  */
 bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
 {
-    // Turn off debug serial printing once the API is activated, because other threads could print and corrupt packets
-    if (!config.device.debug_log_enabled)
-        setDestination(&noopPrint);
-    canWrite = true;
+    // only talk to the API once the configuration has been loaded and we're sure the serial port is not disabled.
+    if (config.has_lora && config.device.serial_enabled) {
+        // Turn off debug serial printing once the API is activated, because other threads could print and corrupt packets
+        if (!config.device.debug_log_enabled)
+            setDestination(&noopPrint);
+        canWrite = true;
 
-    return StreamAPI::handleToRadio(buf, len);
+        return StreamAPI::handleToRadio(buf, len);
+    }else{
+        return false;
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,9 +157,7 @@ void setup()
 #endif
 
 #ifdef DEBUG_PORT
-    if (!config.has_device || config.device.serial_enabled) {
         consoleInit(); // Set serial baud rate and init our mesh console
-    }
 #endif
 
     serialSinceMsec = millis();


### PR DESCRIPTION
stop output to serial debug after config has been loaded (if serial is disabled), and only accept protobuf packets from that point on.


