### PR TITLE
Make telemetry packets minimum priority

### DIFF
--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -69,6 +69,7 @@ bool DeviceTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
     MeshPacket *p = allocDataProtobuf(t);
     p->to = dest;
     p->decoded.want_response = false;
+    p->priority = MeshPacket_Priority_MIN;
 
     lastMeasurementPacket = packetPool.allocCopy(*p);
     nodeDB.updateTelemetry(nodeDB.getNodeNum(), t, RX_SRC_LOCAL);

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -241,6 +241,7 @@ bool EnvironmentTelemetryModule::sendTelemetry(NodeNum dest, bool phoneOnly)
     MeshPacket *p = allocDataProtobuf(m);
     p->to = dest;
     p->decoded.want_response = false;
+    p->priority = MeshPacket_Priority_MIN;
 
     lastMeasurementPacket = packetPool.allocCopy(*p);
     if (phoneOnly) {


### PR DESCRIPTION
In _most_ networks, telemetry should be the minumum priority.