### PR TITLE
Save devicestate (nodedb) on position config change - Fixes fixed position bug

### DIFF
--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -219,6 +219,8 @@ void AdminModule::handleSetConfig(const Config &c)
             DEBUG_MSG("Setting config: Position\n");
             config.has_position = true;
             config.position = c.payload_variant.position;
+            // Save nodedb as well in case we got a fixed position packet
+            nodeDB.saveToDisk(SEGMENT_DEVICESTATE);
             break;
         case Config_power_tag:
             DEBUG_MSG("Setting config: Power\n");


### PR DESCRIPTION
Fixes #1811 (I think)
I believe what was happening is that only the position config changes were being saved to disk and then we trigger a reboot. So unless a NodeDB save for device state occured within that time, the position packet stored in the NodeDB wouldn't be persisted to the filesystem.