### PR TITLE
[rak4630] enable 3.3v periphery before scan for i2c devices

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,6 +242,12 @@ void setup()
     delay(1);
 #endif
 
+#ifdef RAK4630
+    // We need to enable 3.3V periphery in order to scan it
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, 1);
+#endif
+
     // We need to scan here to decide if we have a screen for nodeDB.init()
     scanI2Cdevice();
 #ifdef RAK4630

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -185,6 +185,9 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define SX126X_RXEN (37)
 #define SX126X_E22 // DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
 
+// enables 3.3V periphery like GPS or IO Module
+#define PIN_3V3_EN (34)
+
 // RAK1910 GPS module
 // If using the wisblock GPS module and pluged into Port A on WisBlock base
 // IO1 is hooked to PPS (pin 12 on header) = gpio 17
@@ -192,7 +195,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // Therefore must be 1 to keep peripherals powered
 // Power is on the controllable 3V3_S rail
 // #define PIN_GPS_RESET (34)
-#define PIN_GPS_EN (34)
+#define PIN_GPS_EN PIN_3V3_EN
 #define PIN_GPS_PPS (17) // Pulse per second input from the GPS
 
 #define GPS_RX_PIN PIN_SERIAL1_RX

--- a/variants/rak4631_epaper/variant.h
+++ b/variants/rak4631_epaper/variant.h
@@ -185,6 +185,9 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define SX126X_RXEN (37)
 #define SX126X_E22 // DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
 
+// enables 3.3V periphery like GPS or IO Module
+#define PIN_3V3_EN (34)
+
 // RAK1910 GPS module
 // If using the wisblock GPS module and pluged into Port A on WisBlock base
 // IO1 is hooked to PPS (pin 12 on header) = gpio 17
@@ -192,7 +195,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // Therefore must be 1 to keep peripherals powered
 // Power is on the controllable 3V3_S rail
 // #define PIN_GPS_RESET (34)
-#define PIN_GPS_EN (34)
+#define PIN_GPS_EN PIN_3V3_EN
 #define PIN_GPS_PPS (17) // Pulse per second input from the GPS
 
 #define GPS_RX_PIN PIN_SERIAL1_RX


### PR DESCRIPTION
3.3 Enable pin in RAK4631 not only enables GPS but any other 3.3V periphery including I2c.
This PR is intended to enable 3.3V periphery from the start.
fixes #1846 