### PR TITLE
Send network ping on triple-click

### DIFF
--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -166,6 +166,7 @@ class ButtonThread : public concurrency::OSThread
 
     static void userButtonMultiPressed()
     {
+        service.refreshMyNodeInfo();
         service.sendNetworkPing(NODENUM_BROADCAST, true);
     }
 

--- a/src/ButtonThread.h
+++ b/src/ButtonThread.h
@@ -166,12 +166,7 @@ class ButtonThread : public concurrency::OSThread
 
     static void userButtonMultiPressed()
     {
-#ifdef ARCH_ESP32
-        clearNVS();
-#endif
-#ifdef ARCH_NRF52
-        clearBonds();
-#endif
+        service.sendNetworkPing(NODENUM_BROADCAST, true);
     }
 
     static void userButtonPressedLongStart()


### PR DESCRIPTION
This change will remove the erase nvs / bluetooth bonds function on triple click which is no longer relavent in the new bluetooth stack. 
It would be replaced with sendNetworkPing which sends either a position packet if we have valid coordinates or a nodeinfo packet otherwise.