### PR TITLE
Disaster.radio dev board support update

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -33,6 +33,7 @@ jobs:
           - board: heltec-v2.1
           - board: tbeam0.7
           - board: meshtastic-diy-v1
+          - board: meshtastic-dr-dev
           - board: rak4631
           - board: rak4631_eink
           - board: t-echo
@@ -96,6 +97,7 @@ jobs:
           - board: heltec-v2.1
           - board: tbeam0.7
           - board: meshtastic-diy-v1
+          - board: meshtastic-dr-dev
           - board: nano-g1
           - board: station-g1
           - board: m5stack-core

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@
 ;default_envs = pca10059_diy_eink
 ;default_envs = meshtastic-diy-v1
 ;default_envs = meshtastic-diy-v1.1
+;default_envs = meshtastic-dr-dev
 ;default_envs = m5stack-coreink
 ;default_envs = rak4631
 

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -80,6 +80,8 @@
     #define HW_VENDOR HardwareModel_M5STACK
 #elif defined(STATION_G1)
     #define HW_VENDOR HardwareModel_STATION_G1
+#elif defined(DR_DEV)
+    #define HW_VENDOR HardwareModel_DR_DEV
 #endif
 
 //

--- a/variants/diy/dr-dev/variant.h
+++ b/variants/diy/dr-dev/variant.h
@@ -1,0 +1,69 @@
+// For OLED LCD
+#define I2C_SDA 21
+#define I2C_SCL 22
+
+// GPS
+#undef GPS_RX_PIN
+#define GPS_RX_PIN NOT_A_PIN
+#undef WANT_GPS
+
+#define BUTTON_PIN 2 // The middle button GPIO on the T-Beam
+#define BUTTON_NEED_PULLUP
+#define EXT_NOTIFY_OUT 12 // Overridden default pin to use for Ext Notify Module (#975).
+
+#define LORA_DIO0 -1  // a No connect on the SX1262/SX1268 module
+#define LORA_RESET -1 // RST for SX1276, and for SX1262/SX1268
+#define LORA_DIO1 27  // IRQ for SX1262/SX1268 (IO26 FOR 22S)
+#define LORA_DIO2 NOT_A_PIN  // BUSY for SX1262/SX1268
+#define LORA_DIO3     // Not connected on PCB, but internally on the SX1262/SX1268, if DIO3 is high the TXCO is enabled
+
+// In transmitting, set TXEN as high communication level，RXEN pin is low level;
+// In receiving, set RXEN as high communication level, TXEN is lowlevel;
+// Before powering off, set TXEN、RXEN as low level.
+#define LORA_RXEN 17  // Input - RF switch RX control, connecting external MCU IO, valid in high level
+#define LORA_TXEN -1 // Input - RF switch TX control, connecting external MCU IO or DIO2, valid in high level
+/*  --PINS FOR THE 900M22S
+#undef RF95_SCK
+#define RF95_SCK 18
+#undef RF95_MISO
+#define RF95_MISO 19
+#undef RF95_MOSI
+#define RF95_MOSI 23
+#undef RF95_NSS
+#define RF95_NSS 16
+*/
+
+// PINS FOR THE 900M30S
+#undef RF95_SCK
+#define RF95_SCK 18
+#undef RF95_MISO
+#define RF95_MISO 19
+#undef RF95_MOSI
+#define RF95_MOSI 23
+#undef RF95_NSS
+#define RF95_NSS 33
+
+// RX/TX for RFM95/SX127x
+#define RF95_RXEN LORA_RXEN
+#define RF95_TXEN LORA_TXEN
+// #define RF95_TCXO <GPIO#>
+
+// common pinouts for SX126X modules
+#define SX126X_CS 33
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY 35
+#define SX126X_RESET LORA_RESET
+#define SX126X_RXEN LORA_RXEN
+#define SX126X_TXEN LORA_TXEN
+
+// supported modules list
+#define USE_RF95 // RFM95/SX127x
+#define USE_SX1262
+#define USE_SX1268
+#define USE_LLCC68
+
+#ifdef EBYTE_E22
+// Internally the TTGO module hooks the SX126x-DIO2 in to control the TX/RX switch
+// (which is the default for the sx1262interface code)
+#define SX126X_E22
+#endif


### PR DESCRIPTION
Since the structure of the project has changed, some files lost the definitions for this board and were only living in the 1.2-legacy branch.
Edit: Nevermind, it does compile when I remove the spurious NimBLE-Arduino@1.3.6 from my .pio/libdeps dir.
