### PR TITLE
Fixing a number of T-Beam poweroff display issues

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -233,14 +233,14 @@ bool Power::setup()
 
 void Power::shutdown()
 {
-
+    screen->setOn(false);
 #if defined(USE_EINK) && defined(PIN_EINK_EN)
     digitalWrite(PIN_EINK_EN, LOW); //power off backlight first
 #endif
 
 #ifdef HAS_PMU
     DEBUG_MSG("Shutting down\n");
-    if(PMU){
+    if(PMU) {
         PMU->setChargingLedMode(XPOWERS_CHG_LED_OFF);
         PMU->shutdown();
     }
@@ -315,7 +315,7 @@ int32_t Power::runOnce()
 #ifdef HAS_PMU
     // WE no longer use the IRQ line to wake the CPU (due to false wakes from sleep), but we do poll
     // the IRQ status by reading the registers over I2C
-    if(PMU){
+    if(PMU) {
 
         PMU->getIrqStatus();
 
@@ -344,10 +344,11 @@ int32_t Power::runOnce()
         if (PMU->isBatRemoveIrq()) {
             DEBUG_MSG("Battery removed\n");
         }
-        if (PMU->isPekeyShortPressIrq()) {
-            DEBUG_MSG("PEK short button press\n");
-        }
         */
+        if (PMU->isPekeyLongPressIrq()) {
+            DEBUG_MSG("PEK long button press\n");
+            screen->setOn(false);
+        }
 
         PMU->clearIrqStatus();
     }
@@ -454,7 +455,6 @@ bool Power::axpChipInit()
         // Set constant current charging current
         PMU->setChargerConstantCurr(XPOWERS_AXP192_CHG_CUR_450MA);
 
-    
     } else if (PMU->getChipModel() == XPOWERS_AXP2101) {
 
         // t-beam s3 core 

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -131,8 +131,7 @@ class Screen : public concurrency::OSThread
     void setOn(bool on)
     {
         if (!on)
-            handleSetOn(
-                false); // We handle off commands immediately, because they might be called because the CPU is shutting down
+            handleSetOn(false); // We handle off commands immediately, because they might be called because the CPU is shutting down
         else
             enqueueCmd(ScreenCmd{.cmd = on ? Cmd::SET_ON : Cmd::SET_OFF});
     }

--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -17,7 +17,7 @@ void powerCommandsCheck()
 #endif
     }
 
-#if defined(ARCH_NRF52)
+#if defined(ARCH_NRF52) || defined(HAS_PMU)
     if (shutdownAtMsec) {
         screen->startShutdownScreen();
         playBeep();


### PR DESCRIPTION
This fixes some of the issues with the 1.3" OLED T-Beam add on screen:
1) Not turning off the screen during shutdown both PWR button long-press
2) Not turning off the screen during soft shutdown 
3) Not displaying the Shutting down screen upon receiving the shutdown admin message from an app
