### PR TITLE
Fix for nodeInfo change to inform phone

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -689,11 +689,11 @@ void NodeDB::updateTelemetry(uint32_t nodeId, const meshtastic_Telemetry &t, RxS
 
 /** Update user info for this node based on received user data
  */
-void NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
+bool NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
 {
     meshtastic_NodeInfo *info = getOrCreateNode(nodeId);
     if (!info) {
-        return;
+        return false;
     }
 
     LOG_DEBUG("old user %s/%s/%s\n", info->user.id, info->user.long_name, info->user.short_name);
@@ -713,6 +713,8 @@ void NodeDB::updateUser(uint32_t nodeId, const meshtastic_User &p)
         // We just changed something important about the user, store our DB
         saveToDisk(SEGMENT_DEVICESTATE);
     }
+
+    return changed;
 }
 
 /// given a subpacket sniffed from the network, update our DB state

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -86,7 +86,7 @@ class NodeDB
 
     /** Update user info for this node based on received user data
      */
-    void updateUser(uint32_t nodeId, const meshtastic_User &p);
+    bool updateUser(uint32_t nodeId, const meshtastic_User &p);
 
     /// @return our node number
     NodeNum getNodeNum() { return myNodeInfo.my_node_num; }

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -12,7 +12,7 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
 {
     auto p = *pptr;
 
-    nodeDB.updateUser(getFrom(&mp), p);
+    bool hasChanged = nodeDB.updateUser(getFrom(&mp), p);
 
     bool wasBroadcast = mp.to == NODENUM_BROADCAST;
 
@@ -22,6 +22,10 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
         if (screen)
             screen->print(lcd.c_str());
     }
+
+    // if user has changed while packet was not for us, inform phone
+    if (hasChanged && !wasBroadcast && mp.to != nodeDB.getNodeNum())
+        service.sendToPhone(packetPool.allocCopy(mp));
 
     // LOG_DEBUG("did handleReceived\n");
     return false; // Let others look at this message also if they want


### PR DESCRIPTION
This is a fix for "new NodeInfo is not sent to phone" #2421.

In case a nodeInfo is received the information is stored in nodeDB, nevertheless if the packet was either broadcasted or even not for us. This leads to discrepancies between the shown information in nodeDB and on phone.

With this fix the packet with changed user info is sent to phone, in case it is not already sent to phone through other paths (i.e. broadcast or destined to us).  

Test result OK:

```
DEBUG | 11:09:48 139 [RadioIf] (bw=250, sf=11, cr=4/8) packet symLen=8 ms, payloadSize=63, time 985 ms
DEBUG | 11:09:48 139 [RadioIf] Lora RX (id=0x4e70e90e fr=0x20 to=0xdc, WantAck=0, HopLim=3 Ch=0x63 encrypted rxSNR=6 rxRSSI=-61)
DEBUG | 11:09:48 139 [RadioIf] AirTime - Packet received : 985ms
DEBUG | 11:09:48 139 [Router] Add packet record (id=0x4e70e90e fr=0x20 to=0xdc, WantAck=0, HopLim=3 Ch=0x63 encrypted rxSNR=6 rxRSSI=-61)
DEBUG | 11:09:48 139 [Router] Using channel 0 (hash 0x63)
DEBUG | 11:09:48 139 [Router] Using AES256 key!
DEBUG | 11:09:48 139 [Router] ESP32 crypt fr=fa5a0620, num=4e70e90e, numBytes=47!
DEBUG | 11:09:48 139 [Router] decoded message (id=0x4e70e90e fr=0x20 to=0xdc, WantAck=0, HopLim=3 Ch=0x0 Portnum=4 requestId=6460339a rxtime=1681211388 rxSNR=6 rxRSSI=-61)
DEBUG | 11:09:48 139 [Router] handleReceived(REMOTE) (id=0x4e70e90e fr=0x20 to=0xdc, WantAck=0, HopLim=3 Ch=0x0 Portnum=4 requestId=6460339a rxtime=1681211388 rxSNR=6 rxRSSI=-61)
DEBUG | 11:09:48 139 [Router] Module 'nodeinfo' wantsPacket=1
INFO  | 11:09:48 140 [Router] Received nodeinfo from=0xfa5a0620, id=0x4e70e90e, portnum=4, payloadlen=38
DEBUG | 11:09:48 140 [Router] old user //
DEBUG | 11:09:48 140 [Router] updating changed=1 user !fa5a0620/WEST-0620/WEST
DEBUG | 11:09:48 140 [Router] Node status update: 1 online, 5 total
DEBUG | 11:09:48 140 [Router] showing standard frames
DEBUG | 11:09:48 140 [Router] Showing 0 module frames
DEBUG | 11:09:48 140 [Router] Total frame count: 83
DEBUG | 11:09:48 140 [Router] Added modules.  numframes: 0
DEBUG | 11:09:48 140 [Router] Finished building frames. numframes: 6
INFO  | 11:09:48 140 [Router] Saving /prefs/db.proto
DEBUG | 11:09:49 140 [Router] Module 'nodeinfo' considered
DEBUG | 11:09:49 140 [Router] Module 'routing' wantsPacket=1
INFO  | 11:09:49 140 [Router] Received routing from=0xfa5a0620, id=0x4e70e90e, portnum=4, payloadlen=38
DEBUG | 11:09:49 140 [Router] Routing sniffing (id=0x4e70e90e fr=0x20 to=0xdc, WantAck=0, HopLim=3 Ch=0x0 Portnum=4 requestId=6460339a rxtime=1681211388 rxSNR=6 rxRSSI=-61)
INFO  | 11:09:49 140 [Router] Rebroadcasting received floodmsg to neighbors
DEBUG | 11:09:49 140 [Router] Using AES256 key!
DEBUG | 11:09:49 140 [Router] ESP32 crypt fr=fa5a0620, num=4e70e90e, numBytes=47!
DEBUG | 11:09:49 140 [Router] enqueuing for send (id=0x4e70e90e fr=0x20 to=0xdc, WantAck=0, HopLim=2 Ch=0x63 encrypted rxtime=1681211388 rxSNR=6 rxRSSI=-61)
DEBUG | 11:09:49 140 [Router] txGood=6,rxGood=13,rxBad=0
DEBUG | 11:09:49 140 [Router] rx_snr found. hop_limit:2 rx_snr:6.000000
DEBUG | 11:09:49 140 [Router] rx_snr found in packet. Setting tx delay:168
DEBUG | 11:09:49 140 [Router] Module 'routing' considered
INFO  | 11:09:49 140 Telling client we have new packets 12
INFO  | 11:09:49 140 BLE notify fromNum
WARN  | 11:09:49 140 [RadioIf] Can not send yet, busyRx
DEBUG | 11:09:49 140 [RadioIf] rx_snr found. hop_limit:2 rx_snr:6.000000
DEBUG | 11:09:49 140 [RadioIf] rx_snr found in packet. Setting tx delay:672
INFO  | 11:09:49 140 From Radio onread
INFO  | 11:09:49 140 getFromRadio=STATE_SEND_PACKETS
DEBUG | 11:09:49 140 phone downloaded packet (id=0x4e70e90e fr=0x20 to=0xdc, WantAck=0, HopLim=3 Ch=0x0 Portnum=4 requestId=6460339a rxtime=1681211388 rxSNR=6 rxRSSI=-61)
```
