### PR TITLE
RP2040: Reverse dmac assignment

### DIFF
--- a/src/platform/rp2040/main-rp2040.cpp
+++ b/src/platform/rp2040/main-rp2040.cpp
@@ -21,10 +21,10 @@ void getMacAddr(uint8_t *dmac)
 {
     pico_unique_board_id_t src;
     pico_get_unique_board_id(&src);
-    dmac[5] = src.id[0];
-    dmac[4] = src.id[1];
-    dmac[3] = src.id[2];
-    dmac[2] = src.id[3];
-    dmac[1] = src.id[4];
-    dmac[0] = src.id[5];
+    dmac[5] = src.id[7];
+    dmac[4] = src.id[6];
+    dmac[3] = src.id[5];
+    dmac[2] = src.id[4];
+    dmac[1] = src.id[3];
+    dmac[0] = src.id[2];
 }


### PR DESCRIPTION
src.id[0] and src.id[1] seem not unique. Since dmac[5] and dmac[4] are used for the Bluetooth name, I think it's better to reverse this.
