### PR TITLE
Fix typo in GNSS_MODEL defination and usages for the UC6580

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -293,7 +293,7 @@ bool GPS::setup()
             gnssModel = GNSS_MODEL_UNKNOWN;
         }
 #else
-        gnssModel = GNSS_MODEL_UC6850;
+        gnssModel = GNSS_MODEL_UC6580;
 #endif
 
         if (gnssModel == GNSS_MODEL_MTK) {
@@ -311,10 +311,10 @@ bool GPS::setup()
             // Switch to Vehicle Mode, since SoftRF enables Aviation < 2g
             _serial_gps->write("$PCAS11,3*1E\r\n");
             delay(250);
-        } else if (gnssModel == GNSS_MODEL_UC6850) {
+        } else if (gnssModel == GNSS_MODEL_UC6580) {
 
-            // use GPS + GLONASS
-            _serial_gps->write("$CFGSYS,h15\r\n");
+            // use GPS L1 & L5 + BDS B1I & B2a + GLONASS L1 + GALILEO E1 & E5a + SBAS
+            _serial_gps->write("$CFGSYS,h25155\r\n");
             delay(250);
         } else if (gnssModel == GNSS_MODEL_UBLOX) {
             // Configure GNSS system to GPS+SBAS+GLONASS (Module may restart after this command)

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -23,7 +23,7 @@ struct uBloxGnssModelInfo {
 typedef enum {
     GNSS_MODEL_MTK,
     GNSS_MODEL_UBLOX,
-    GNSS_MODEL_UC6850,
+    GNSS_MODEL_UC6580,
     GNSS_MODEL_UNKNOWN,
 } GnssModel_t;
 


### PR DESCRIPTION
Correct the $CFGSYS init string for the UC6580 to init the receiver for: GPS L1 & L5 + BDS B1I & B2a + GLONASS L1 + GALILEO E1 & E5a + SBAS

Fixes Bug #2983

The protocol spec provided on the Heltec download site is for an older version of the Firebird series. the correct protocol spec is available at:
https://en.unicorecomm.com/products/detail/34
where 1.4.2.5 CFGSYS: Configure Satellite System
describes the much expanded command for the Firebird II chips of which the UC6580 is one.