### PR TITLE
Fix build for Pico2 RP2350 platform.

### DIFF
--- a/arch/rp2xx0/rp2350.ini
+++ b/arch/rp2xx0/rp2350.ini
@@ -7,12 +7,12 @@ platform_packages = framework-arduinopico@https://github.com/earlephilhower/ardu
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m
 build_flags = 
-  ${arduino_base.build_flags} -Wno-unused-variable 
+  ${arduino_base.build_flags} -Wno-unused-variable -Wcast-align
   -Isrc/platform/rp2xx0
-  -D__PLAT_RP2040__
+  -D__PLAT_RP2350__
 #  -D _POSIX_THREADS
 build_src_filter = 
-  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<modules/esp32> -<platform/nrf52/> -<platform/stm32wl> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp>
+  ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<modules/esp32> -<platform/nrf52/> -<platform/stm32wl> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp> -<platform/rp2xx0/pico_sleep> -<platform/rp2xx0/hardware_rosc>
 
 lib_ignore =
   BluetoothOTA

--- a/src/platform/rp2xx0/main-rp2xx0.cpp
+++ b/src/platform/rp2xx0/main-rp2xx0.cpp
@@ -2,14 +2,11 @@
 #include "hardware/xosc.h"
 #include <hardware/clocks.h>
 #include <hardware/pll.h>
-#include <pico/sleep.h>
 #include <pico/stdlib.h>
 #include <pico/unique_id.h>
 
-void setBluetoothEnable(bool enable)
-{
-    // not needed
-}
+#ifdef __PLAT_RP2040__
+#include <pico/sleep.h>
 
 static bool awake;
 
@@ -66,7 +63,20 @@ void cpuDeepSleep(uint32_t msecs)
     rp2040.reboot();
 
     /* Set RP2040 in dormant mode. Will not wake up. */
-    //  xosc_dormant();
+    // xosc_dormant();
+}
+
+#else
+void cpuDeepSleep(uint32_t msecs)
+{
+    /* Set RP2040 in dormant mode. Will not wake up. */
+    xosc_dormant();
+}
+#endif
+
+void setBluetoothEnable(bool enable)
+{
+    // not needed
 }
 
 void updateBatteryLevel(uint8_t level)


### PR DESCRIPTION
The RP2350 does not include an RTC. So the current sleep code on RP2xx0 platforms is only applicable for RP2040 and needs to be excluded on RP2350.
