### PR TITLE
Refactor Data bitfield into an enum

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -417,8 +417,9 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
     if (decrypted) {
         // parsing was successful
         p->channel = chIndex; // change to store the index instead of the hash
-        if (p->decoded.has_bitfield)
-            p->decoded.want_response |= p->decoded.bitfield & BITFIELD_WANT_RESPONSE_MASK;
+        if (p->decoded.has_bitfield) {
+            p->decoded.want_response |= p->decoded.bitfield & DataBitfield::WANT_RESPONSE;
+        }
 
         /* Not actually ever used.
         // Decompress if needed. jm
@@ -467,8 +468,8 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         if (isFromUs(p)) {
             p->decoded.has_bitfield = true;
-            p->decoded.bitfield |= (config.lora.config_ok_to_mqtt << BITFIELD_OK_TO_MQTT_SHIFT);
-            p->decoded.bitfield |= (p->decoded.want_response << BITFIELD_WANT_RESPONSE_SHIFT);
+            p->decoded.bitfield |= (config.lora.config_ok_to_mqtt * DataBitfield::OK_TO_MQTT);
+            p->decoded.bitfield |= (p->decoded.want_response * DataBitfield::WANT_RESPONSE);
         }
 
         size_t numbytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_Data_msg, &p->decoded);

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -159,7 +159,8 @@ extern Router *router;
 // FIXME, move this someplace better
 PacketId generatePacketId();
 
-#define BITFIELD_WANT_RESPONSE_SHIFT 1
-#define BITFIELD_OK_TO_MQTT_SHIFT 0
-#define BITFIELD_WANT_RESPONSE_MASK (1 << BITFIELD_WANT_RESPONSE_SHIFT)
-#define BITFIELD_OK_TO_MQTT_MASK (1 << BITFIELD_OK_TO_MQTT_SHIFT)
+enum DataBitfield : uint32_t {
+    EMPTY = 0,
+    OK_TO_MQTT = (1 << 0),
+    WANT_RESPONSE = (1 << 1),
+};

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -689,7 +689,7 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
     // mp_decoded will not be decoded when it's PKI encrypted and not directed to us
     if (mp_decoded.which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         // For uplinking other's packets, check if it's not OK to MQTT or if it's an older packet without the bitfield
-        bool dontUplink = !mp_decoded.decoded.has_bitfield || !(mp_decoded.decoded.bitfield & BITFIELD_OK_TO_MQTT_MASK);
+        bool dontUplink = !mp_decoded.decoded.has_bitfield || !(mp_decoded.decoded.bitfield & DataBitfield::OK_TO_MQTT);
         // check for the lowest bit of the data bitfield set false, and the use of one of the default keys.
         if (!isFromUs(&mp_decoded) && !isMqttServerAddressPrivate && dontUplink &&
             (ch.settings.psk.size < 2 || (ch.settings.psk.size == 16 && memcmp(ch.settings.psk.bytes, defaultpsk, 16)) ||

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -293,7 +293,7 @@ const meshtastic_MeshPacket decoded = {
     .from = 1,
     .to = 2,
     .which_payload_variant = meshtastic_MeshPacket_decoded_tag,
-    .decoded = {.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP, .has_bitfield = true, .bitfield = BITFIELD_OK_TO_MQTT_MASK},
+    .decoded = {.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP, .has_bitfield = true, .bitfield = DataBitfield::OK_TO_MQTT},
     .id = 4,
 };
 const meshtastic_MeshPacket encrypted = {


### PR DESCRIPTION
This is a little easier to read and will serve as a good example for use with other (larger) bitfields in the future. Another baby step towards #6427

A longer range benefit of using a enum is that the valid values for a field are typed. It's not really relevant for this change, but becomes relevant if/when you type the flags explicitly. This helps avoid mismatching flags and their associated bitfields.

I have not tested this on devices yet, but it does build. There should be no change in behavior.