### PR TITLE
Linux: Adjust udev rules for gpio

### DIFF
--- a/bin/99-meshtasticd-udev.rules
+++ b/bin/99-meshtasticd-udev.rules
@@ -1,4 +1,7 @@
-# Set spidev ownership to 'spi' group.
+# Set spidev ownership to 'spi' group
 SUBSYSTEM=="spidev", KERNEL=="spidev*", GROUP="spi", MODE="0660"
 # Allow access to USB CH341 devices
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5512", MODE="0666"
+# Set gpio ownership to 'gpio' group
+SUBSYSTEM=="*gpiomem*", GROUP="gpio", MODE="0660"
+SUBSYSTEM=="gpio", GROUP="gpio", MODE="0660"

--- a/debian/meshtasticd.postinst
+++ b/debian/meshtasticd.postinst
@@ -20,16 +20,17 @@ set -e
 
 case "$1" in
     configure|reconfigure)
-    # create spi group (for udev rules)
-    # this group already exists on Raspberry Pi OS
+    # create spi, gpio groups (for udev rules)
+    # these groups already exist on Raspberry Pi OS
         getent group spi >/dev/null 2>/dev/null || addgroup --system spi
+        getent group gpio >/dev/null 2>/dev/null || addgroup --system gpio
     # create a meshtasticd group and user
         getent passwd meshtasticd >/dev/null 2>/dev/null || adduser --system --home /var/lib/meshtasticd --no-create-home meshtasticd
         getent group meshtasticd >/dev/null 2>/dev/null || addgroup --system meshtasticd
         adduser meshtasticd meshtasticd >/dev/null 2>/dev/null
         adduser meshtasticd spi >/dev/null 2>/dev/null
+        adduser meshtasticd gpio >/dev/null 2>/dev/null
     # add meshtasticd user to appropriate groups (if they exist)
-        getent group gpio >/dev/null 2>/dev/null && adduser meshtasticd gpio >/dev/null 2>/dev/null
         getent group plugdev >/dev/null 2>/dev/null && adduser meshtasticd plugdev >/dev/null 2>/dev/null
         getent group dialout >/dev/null 2>/dev/null && adduser meshtasticd dialout >/dev/null 2>/dev/null
         getent group i2c >/dev/null 2>/dev/null && adduser meshtasticd i2c >/dev/null 2>/dev/null

--- a/debian/meshtasticd.udev
+++ b/debian/meshtasticd.udev
@@ -1,4 +1,7 @@
-# Set spidev ownership to 'spi' group.
+# Set spidev ownership to 'spi' group
 SUBSYSTEM=="spidev", KERNEL=="spidev*", GROUP="spi", MODE="0660"
 # Allow access to USB CH341 devices
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5512", MODE="0666"
+# Set gpio ownership to 'gpio' group
+SUBSYSTEM=="*gpiomem*", GROUP="gpio", MODE="0660"
+SUBSYSTEM=="gpio", GROUP="gpio", MODE="0660"


### PR DESCRIPTION
Fix gpio permissions on distros that don't set them up automatically (Ubuntu).