### PR TITLE
Add constant time compare to AES-CCM

### DIFF
--- a/src/mesh/aes-ccm.cpp
+++ b/src/mesh/aes-ccm.cpp
@@ -16,22 +16,23 @@
  * @param a First byte array to compare
  * @param b Second byte array to compare
  * @param len Number of bytes to compare
- * @return 0 if arrays are equal, 1 if different or if inputs are invalid
+ * @return 0 if arrays are equal, -1 if different or if inputs are invalid
  */
 static int constant_time_compare(const void *a_, const void *b_, size_t len)
 {
-    // Cast to volatile to prevent the compiler from optimizing out their comparison.
+    /* Cast to volatile to prevent the compiler from optimizing out their comparison. */
     const volatile uint8_t *volatile a = (const volatile uint8_t *volatile) a_;
     const volatile uint8_t *volatile b = (const volatile uint8_t *volatile) b_;
     if (len == 0)
         return 0;
     if (a == NULL || b == NULL)
-        return 1;
+        return -1;
     size_t i;
     volatile uint8_t d = 0U;
     for (i = 0U; i < len; i++) {
         d |= (a[i] ^ b[i]);
     }
+    /* Constant time bit arithmetic to convert d > 0 to -1 and d = 0 to 0. */
     return (1 & ((d - 1) >> 8)) - 1;
 }
 


### PR DESCRIPTION
I noticed that there was a `#FIXME` within `firmware/src/mesh/aes-ccm.cpp` with respect to replacing a `memcmp` with a constant time comparison.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [X] LilyGo T-Beam
  - [X] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
