### PR TITLE
MeshAdv-Mini: Correct autoconf settings

### DIFF
--- a/bin/config.d/lora-MeshAdv-Mini-900M22S.yaml
+++ b/bin/config.d/lora-MeshAdv-Mini-900M22S.yaml
@@ -6,6 +6,6 @@ Lora:
   IRQ: 16
   Busy: 20
   Reset: 24
-  TXen: 13
+  RXen: 12
   DIO2_AS_RF_SWITCH: true
   DIO3_TCXO_VOLTAGE: true

--- a/src/platform/portduino/PortduinoGlue.h
+++ b/src/platform/portduino/PortduinoGlue.h
@@ -11,7 +11,7 @@
 inline const std::unordered_map<std::string, std::string> configProducts = {{"MESHTOAD", "lora-usb-meshtoad-e22.yaml"},
                                                                             {"MESHSTICK", "lora-meshstick-1262.yaml"},
                                                                             {"MESHADV-PI", "lora-MeshAdv-900M30S.yaml"},
-                                                                            {"MESHADV-MINI", "lora-MeshAdv-Mini-900M22S.yaml"},
+                                                                            {"MeshAdv Mini", "lora-MeshAdv-Mini-900M22S.yaml"},
                                                                             {"POWERPI", "lora-MeshAdv-900M30S.yaml"}};
 
 enum configNames {


### PR DESCRIPTION
Correct the pinout for MeshAdv Mini to define RXen, working per @chrismyers2000

Also correct autoconf string. Products are being flashed with the Product `MeshAdv Mini`, not the current value `MESHADV-MINI`.