### PR TITLE
feat(bug): cache the lines and heights to reduce the overhead

### DIFF
--- a/src/graphics/draw/MessageRenderer.cpp
+++ b/src/graphics/draw/MessageRenderer.cpp
@@ -278,7 +278,7 @@ void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
         // Cache miss - regenerate lines and heights
         cachedLines = generateLines(display, headerStr, messageBuf, textWidth);
         cachedHeights =
-            calculateLineHeights(display, cachedLines, emotes, numEmotes);
+            calculateLineHeights(cachedLines, emotes);
         cachedKey = currentKey;
     }
 
@@ -345,7 +345,9 @@ void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
 
 std::vector<std::string> generateLines(OLEDDisplay *display,
                                        const char *headerStr,
-                                       const char *messageBuf, int textWidth) {
+                                       const char *messageBuf,
+                                       int textWidth)
+{
     std::vector<std::string> lines;
     lines.push_back(std::string(headerStr)); // Header line is always first
 
@@ -390,9 +392,9 @@ std::vector<std::string> generateLines(OLEDDisplay *display,
     return lines;
 }
 
-std::vector<int> calculateLineHeights(OLEDDisplay *display,
-                                      const std::vector<std::string> &lines,
-                                      const Emote *emotes, int emoteCount) {
+std::vector<int> calculateLineHeights(const std::vector<std::string>& lines,
+                                      const Emote *emotes)
+{
     std::vector<int> rowHeights;
 
     for (const auto &_line : lines) {
@@ -421,15 +423,16 @@ std::vector<int> calculateLineHeights(OLEDDisplay *display,
 }
 
 void renderMessageContent(OLEDDisplay *display,
-                          const std::vector<std::string> &lines,
-                          const std::vector<int> &rowHeights,
+                          const std::vector<std::string>& lines,
+                          const std::vector<int>& rowHeights,
                           int x,
                           int yOffset,
                           int scrollBottom,
                           const Emote *emotes,
                           int numEmotes,
                           bool isInverted,
-                          bool isBold) {
+                          bool isBold)
+{
     for (size_t i = 0; i < lines.size(); ++i) {
         int lineY = yOffset;
         for (size_t j = 0; j < i; ++j)

--- a/src/graphics/draw/MessageRenderer.h
+++ b/src/graphics/draw/MessageRenderer.h
@@ -19,17 +19,17 @@ void drawTextMessageFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16
 // Function to generate lines with word wrapping
 std::vector<std::string> generateLines(OLEDDisplay *display,
                                        const char *headerStr,
-                                       const char *messageBuf, int textWidth);
+                                       const char *messageBuf,
+                                       int textWidth);
 
 // Function to calculate heights for each line
-std::vector<int> calculateLineHeights(OLEDDisplay *display,
-                                      const std::vector<std::string> &lines,
-                                      const Emote *emotes, int emoteCount);
+std::vector<int> calculateLineHeights(const std::vector<std::string>& lines,
+                                      const Emote *emotes);
 
 // Function to render the message content
 void renderMessageContent(OLEDDisplay *display,
-                          const std::vector<std::string> &lines,
-                          const std::vector<int> &rowHeights,
+                          const std::vector<std::string>& lines,
+                          const std::vector<int>& rowHeights,
                           int x,
                           int yOffset,
                           int scrollBottom,


### PR DESCRIPTION
# 👋Summary of Changes

This patch introduces a caching mechanism for text rendering in message display, which should reduce CPU overhead when displaying the same message multiple times. The key changes are:

1. **Fixed an issue when add `-D EXCLUDE_EMOJI` flag**
  ```bash
  src/graphics/draw/MessageRenderer.cpp: In function 'void graphics::MessageRenderer::drawTextMessageFrame(OLEDDisplay*, OLEDDisplayUiState*, int16_t, int16_t)':
  src/graphics/draw/MessageRenderer.cpp:333:20: error: 'now' was not declared in this scope
     float delta = (now - lastTime) / 400.0f;
  ```
2. **Added Text Caching**
   - Implemented a simple caching system using text hashing to avoid redundant line calculation
   - Added static cache variables to store previously rendered lines and their heights

3. **Code Restructuring**
   - Split the message rendering logic into smaller, more focused functions:
     - `generateLines`: Handles text line wrapping
     - `calculateLineHeights`: Determines proper height for each line
     - `renderMessageContent`: Draws the actual content

4. **Performance Optimization**
   - Added simple cache key to avoid regenerating the same content
   - Only recalculates line data when the message content changes
   - Reduced CPU usage during repeated rendering of the same message

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] Heltec Wireless Tracker
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

## Videos

https://github.com/user-attachments/assets/50f51a69-4958-43b7-997c-c945f847c60b