### PR TITLE
Fix hydra radio

### DIFF
--- a/variants/diy/hydra/variant.h
+++ b/variants/diy/hydra/variant.h
@@ -36,8 +36,12 @@
 #define SX126X_TXEN 13 // Schematic connects EBYTE module's TXEN pin to MCU
 #define SX126X_RXEN 14 // Schematic connects EBYTE module's RXEN pin to MCU
 
-#define LORA_CS SX126X_CS     // Compatibility with variant file configuration structure
-#define LORA_SCK SX126X_SCK   // Compatibility with variant file configuration structure
-#define LORA_MOSI SX126X_MOSI // Compatibility with variant file configuration structure
-#define LORA_MISO SX126X_MISO // Compatibility with variant file configuration structure
-#define LORA_DIO1 SX126X_DIO1 // Compatibility with variant file configuration structure
+#define LORA_CS SX126X_CS       // Compatibility with variant file configuration structure
+#define LORA_SCK SX126X_SCK     // Compatibility with variant file configuration structure
+#define LORA_MOSI SX126X_MOSI   // Compatibility with variant file configuration structure
+#define LORA_MISO SX126X_MISO   // Compatibility with variant file configuration structure
+#define LORA_DIO1 SX126X_DIO1   // Compatibility with variant file configuration structure
+#define LORA_TXEN SX126X_TXEN   // Compatibility with variant file configuration structure
+#define LORA_RXEN SX126X_RXEN   // Compatibility with variant file configuration structure
+#define LORA_RESET SX126X_RESET // Compatibility with variant file configuration structure
+#define LORA_DIO2 SX126X_BUSY   // Compatibility with variant file configuration structure


### PR DESCRIPTION
I've noticed, when using a Meshadventurer board, compatible with Hydra variant, that the receiving sensitivity was unusually low immediately after a transmission. When doing a traceroute to a node a couple blocks away, it would not be received back on the Meshadventurer, even though there were no problems receiving 0-hop on a Heltec Wireless Tracker with the same antenna in the same location. The traceroute would only be received on the Meshadventurer when another node was added to repeat the returning packet.

I suspected a problem with switching the E22-900M30S between transmit and receive, so I've added a couple defines to the variant.h file and now the problem seems to be gone, traceroutes in similar conditions seem to be working no worse than the Heltec Wireless Tracker used as reference.

✅I have tested that my proposed changes do not cause any obvious regressions on the following devices: diy/hydra.