### PR TITLE
Actions: Re-Add nrf52 hex release (rak4631)

### DIFF
--- a/.github/workflows/build_nrf52.yml
+++ b/.github/workflows/build_nrf52.yml
@@ -36,4 +36,5 @@ jobs:
           path: |
             release/*.uf2
             release/*.elf
+            release/*.hex
             release/*-ota.zip


### PR DESCRIPTION
RAK4631 previously released .hex files as well. Re-add it

See [build-nrf52.sh](https://github.com/meshtastic/firmware/blob/master/bin/build-nrf52.sh#L50-L53)