### PR TITLE
Add additional Epoch check for time set

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -228,6 +228,13 @@ RTCSetResult perhapsSetRTC(RTCQuality q, struct tm &t)
     tv.tv_sec = res;
     tv.tv_usec = 0; // time.centisecond() * (10 / 1000);
 
+#ifdef BUILD_EPOCH
+    if (tv->tv_sec < BUILD_EPOCH) {
+        LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+        return RTCSetResultInvalidTime;
+    }
+#endif
+
     // LOG_DEBUG("Got time from GPS month=%d, year=%d, unixtime=%ld", t.tm_mon, t.tm_year, tv.tv_sec);
     if (t.tm_year < 0 || t.tm_year >= 300) {
         // LOG_DEBUG("Ignore invalid GPS month=%d, year=%d, unixtime=%ld", t.tm_mon, t.tm_year, tv.tv_sec);


### PR DESCRIPTION
We have two perhapsSetRTC functions, which are called to set the time.

The one with 3 parameters had a helpful check to reject an invalid time, by comparing the time from the source against when the firmware was compiled. The one with 2 parameters, which is called from the GPS lookForTime did not.

As a result, certain GPS with bad time handling could set a time that was in the past.

This patch adds the same epoch check code to the other perhapsSetRTC method.

Fixes https://github.com/meshtastic/firmware/issues/7364