### PR TITLE
Renovate: Use github-tags for XPowersLib updates

### DIFF
--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -54,8 +54,8 @@ lib_deps =
   h2zero/NimBLE-Arduino@^1.4.3
   # renovate: datasource=git-refs depName=libpax packageName=https://github.com/dbinfrago/libpax gitBranch=master
   https://github.com/dbinfrago/libpax/archive/3cdc0371c375676a97967547f4065607d4c53fd1.zip
-  # renovate: datasource=git-refs depName=XPowersLib packageName=https://github.com/lewisxhe/XPowersLib gitBranch=master
-  https://github.com/lewisxhe/XPowersLib/archive/refs/tags/v0.3.0.zip
+  # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib
+  https://github.com/lewisxhe/XPowersLib/archive/v0.3.0.zip
   # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto


### PR DESCRIPTION
Addendum to #6936

Use `github-tags` renovate datasource for XPowersLib, since we're using tagged builds now.

Closes #7409 