### PR TITLE
Add NP_865 and BR_902 to region picker

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -51,12 +51,14 @@ void menuHandler::LoraRegionPicker(uint32_t duration)
                                          "PH_915",
                                          "ANZ_433",
                                          "KZ_433",
-                                         "KZ_863"};
+                                         "KZ_863",
+                                         "NP_865",
+                                         "BR_902"};
     BannerOverlayOptions bannerOptions;
     bannerOptions.message = "Set the LoRa region";
     bannerOptions.durationMs = duration;
     bannerOptions.optionsArrayPtr = optionsArray;
-    bannerOptions.optionsCount = 25;
+    bannerOptions.optionsCount = 27;
     bannerOptions.InitialSelected = 0;
     bannerOptions.bannerCallback = [](int selected) -> void {
         if (selected != 0 && config.lora.region != _meshtastic_Config_LoRaConfig_RegionCode(selected)) {


### PR DESCRIPTION
This pull request updates the LoRa region picker functionality by adding support for new regions and adjusting the corresponding options count.

### Updates to LoRa region picker:

* [`src/graphics/draw/MenuHandler.cpp`] Added the two new LoRa regions (`NP_865`, `BR_902`) to the `optionsArray` and updated the `optionsCount` from 25 to 27 to reflect the additional regions.
* https://github.com/meshtastic/firmware/pull/7380
* https://github.com/meshtastic/firmware/pull/7399


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  
  
![img2](https://github.com/user-attachments/assets/61cc69d5-8ae0-4904-afce-cf76536d3cdb)
![img1](https://github.com/user-attachments/assets/ecd5f5ac-9d76-4acb-b0e6-ca9f5e728a3b)

