### PR TITLE
Workaround Webserver needing to stay up while Wifi is being turned off

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -236,6 +236,11 @@ bool isWifiAvailable()
     } else if (config.network.eth_enabled) {
         return true;
 #endif
+#ifndef ARCH_PORTDUINO
+    } else if (WiFi.status() == WL_CONNECTED) {
+        // it's likely we have wifi now, but user intends to turn it off in config!
+        return true;
+#endif
     } else {
         return false;
     }


### PR DESCRIPTION
Expertly triaged by @philon- , turning off wifi using the HTTP API did not work. That was because we only served the HTTP API if Wifi was deemed to be available, but mid-way through turning it off Wifi was still available, but the configuration we were checking said it wasn't.

This patch introduces an additional way the system can determine if Wifi is available, by referring to the WiFi.status(). This means that in that limbo state where Wifi has been set to be turned off, but the configuration has not been saved and it is still up, the HTTP API will stay up long enough to save the configuration.

Fixes https://github.com/meshtastic/firmware/issues/6965

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
