### PR TITLE
Rv3028 rtc fix

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -184,8 +184,13 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 type = RTC_RV3028;
                 logFoundDevice("RV3028", (uint8_t)addr.address);
                 rtc.initI2C(*i2cBus);
-                rtc.writeToRegister(0x35, 0x07); // no Clkout
-                rtc.writeToRegister(0x37, 0xB4);
+                // Update RTC EEPROM settings, if necessary
+                if (rtc.readEEPROMRegister(0x35) != 0x07) {
+                    rtc.writeEEPROMRegister(0x35, 0x07); // no Clkout
+                }
+                if (rtc.readEEPROMRegister(0x37) != 0xB4) {
+                    rtc.writeEEPROMRegister(0x37, 0xB4);
+                }
                 break;
 #endif
 


### PR DESCRIPTION
Hello,

this commit fixes an issue where the RAK12002 RTC Module (Melopero RV3028) looses its configuration every day at midnight (UTC) and causes the RAK4631 to crash/shutdown when installed in Slot D.

According to the [documentation](https://www.microcrystal.com/fileadmin/Media/Products/RTC/App.Manual/RV-3028-C7_App-Manual.pdf) of the RV3028, it automatically refreshes its RAM configuration from EEPROM at "date increment (at the beginning of the last second before midnight)" if the EERD bit is not set. The previously used function `rtc.writeToRegister` seems to only write configuration in RAM, not in EEPROM.

On my device, CLKOUT on the RTC module seemed to get enabled at midnight when the default configuration was loaded from EEPROM. CLKOUT is connected to PIN 12, which is IO5 on the RAK4631 when installed in Slot D. As IO5 (= GPIO9) is assigned as default user button, the RAK4631 seemed to interpret the CLKOUT signal as "long user button press" and triggered a shutdown.

`rtc.writeEEPROMRegister` writes the configuration to disable CLKOUT to the EEPROM, so it survives the automatic refresh at midnight. Additionally, it is checked whether the value has already been set in order to prevent EEPROM wear out.

On my board, this change prevented the board from triggering the shutdown and becoming unresponsive each night (tested with firmware 2.6.11.60ec05e Beta).

The [meshtastic documentation](https://meshtastic.org/de/docs/hardware/devices/rak-wireless/wisblock/peripherals/?rakmodules=RTC) also mentions problems with the RTC module when installed in Slot D, maybe this is related.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [X] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
