### PR TITLE
Fix 'buildroot' compiles (OpenWRT)

### DIFF
--- a/arch/portduino/portduino.ini
+++ b/arch/portduino/portduino.ini
@@ -17,7 +17,6 @@ build_src_filter =
   +<mesh/raspihttp/>
   -<mesh/eth/>
   -<modules/esp32>
-  +<../variants/portduino>
 
 lib_deps =
   ${env.lib_deps}
@@ -35,6 +34,7 @@ lib_deps =
 
 build_flags =
   ${arduino_base.build_flags}
+  -D ARCH_PORTDUINO
   -fPIC
   -Isrc/platform/portduino
   -DRADIOLIB_EEPROM_UNSUPPORTED

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -1,7 +1,6 @@
 [native_base]
 extends = portduino_base
 build_flags = ${portduino_base.build_flags} -I variants/native/portduino
-  -D ARCH_PORTDUINO
   -I /usr/include
 board = cross_platform
 lib_deps = ${portduino_base.lib_deps}


### PR DESCRIPTION
`ARCH_PORTDUINO` should be defined in the shared portduino base. Buildroot (OpenWRT) compiles are currently broken :'(