### PR TITLE
Skip GPS baud rate probing if disabled, reduce the stucking duration

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -492,6 +492,10 @@ static const int rareSerialSpeeds[3] = {4800, 57600, GPS_BAUDRATE};
  */
 bool GPS::setup()
 {
+    // skip baud rate probing if disabled
+    if (isDisabled())
+        return true;
+
     if (!didSerialInit) {
         int msglen = 0;
         if (tx_gpio && gnssModel == GNSS_MODEL_UNKNOWN) {
@@ -1726,6 +1730,15 @@ bool GPS::hasLock()
 bool GPS::hasFlow()
 {
     return reader.passedChecksum() > 0;
+}
+
+bool GPS::isDisabled() const
+{
+    if (config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_DISABLED ||
+        config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_NOT_PRESENT)
+        return true;
+
+    return powerState == GPS_OFF;
 }
 
 bool GPS::whileActive()

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -99,6 +99,9 @@ class GPS : private concurrency::OSThread
     /// Returns true if there's valid data flow with the chip.
     virtual bool hasFlow();
 
+    // Return true if GPS state is disabled
+    bool isDisabled() const;
+
     /// Return true if we are connected to a GPS
     bool isConnected() const { return hasGPS; }
 


### PR DESCRIPTION
If the GPS module is not available at startup, the baud rate cycle will take more than 30 seconds, causing the interface to freeze. If GPS is not enabled, this check can be skipped.

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec T114
  - [x] Wio Tracker L1
  - [x] Meshtiny
  - [x] GAT562