### PR TITLE
Update platformio/espressif32 to v6.12.0

### DIFF
--- a/extra_scripts/esp32_extra.py
+++ b/extra_scripts/esp32_extra.py
@@ -10,6 +10,12 @@ Import("env")
 platform = env.PioPlatform()
 
 sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
+# IntelHex workaround, remove after fixed upstream
+# https://github.com/platformio/platform-espressif32/issues/1632
+try:
+    import intelhex
+except ImportError:
+    env.Execute("$PYTHONEXE -m pip install intelhex")
 import esptool
 
 

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -5,7 +5,7 @@ custom_esp32_kind = esp32
 custom_mtjson_part =
 platform =
   # renovate: datasource=custom.pio depName=platformio/espressif32 packageName=platformio/platform/espressif32
-  platformio/espressif32@6.11.0
+  platformio/espressif32@6.12.0
 
 extra_scripts =
   ${env.extra_scripts}


### PR DESCRIPTION
Closes #7809 

Update platformio/espressif32 to v6.12.0
https://github.com/platformio/platform-espressif32/releases/tag/v6.12.0

Also adds the `intelhex` dependency if needed to workaround a PlatformIO bug with fetching this automatically.
See: https://github.com/platformio/platform-espressif32/issues/1632