### PR TITLE
Renovate: Always use `master` as the base.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "replacements:all",
     "workarounds:all"
   ],
+  "baseBranchPatterns": ["master"],
   "forkProcessing": "enabled",
   "ignoreDeps": [
     "protobufs"


### PR DESCRIPTION
We still want renovate updating master, even though `develop` is now the default branch.