### PR TITLE
Fix excluded modules configuration handling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1515,6 +1515,9 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
     deviceMetadata.hw_model = HW_VENDOR;
     deviceMetadata.hasRemoteHardware = moduleConfig.remote_hardware.enabled;
     deviceMetadata.excluded_modules = meshtastic_ExcludedModules_EXCLUDED_NONE;
+#if MESHTASTIC_EXCLUDE_MQTT
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_MQTT_CONFIG;
+#endif
 #if MESHTASTIC_EXCLUDE_REMOTEHARDWARE
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_REMOTEHARDWARE_CONFIG;
 #endif
@@ -1537,8 +1540,17 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #if NO_EXT_GPIO && NO_GPS || MESHTASTIC_EXCLUDE_SERIAL
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_SERIAL_CONFIG;
 #endif
-#ifndef ARCH_ESP32
+#if MESHTASTIC_EXCLUDE_PAXCOUNTER
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_PAXCOUNTER_CONFIG;
+#endif
+#if MESHTASTIC_EXCLUDE_STOREFORWARD
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_STOREFORWARD_CONFIG;
+#endif
+#if MESHTASTIC_EXCLUDE_RANGETEST
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_RANGETEST_CONFIG;
+#endif
+#if MESHTASTIC_EXCLUDE_NEIGHBORINFO
+    deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_NEIGHBORINFO_CONFIG;
 #endif
 #if !defined(HAS_RGB_LED) && !RAK_4631
     deviceMetadata.excluded_modules |= meshtastic_ExcludedModules_AMBIENTLIGHTING_CONFIG;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -775,7 +775,9 @@ void NodeDB::installDefaultModuleConfig()
 
     moduleConfig.version = DEVICESTATE_CUR_VER;
     moduleConfig.has_mqtt = true;
+#if !MESHTASTIC_EXCLUDE_RANGETEST
     moduleConfig.has_range_test = true;
+#endif
     moduleConfig.has_serial = true;
     moduleConfig.has_store_forward = true;
     moduleConfig.has_telemetry = true;
@@ -841,6 +843,12 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.canned_message.inputbroker_event_press = meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_SELECT;
 #endif
     moduleConfig.has_canned_message = true;
+#if !MESHTASTIC_EXCLUDE_AUDIO
+    moduleConfig.has_audio = true;
+#endif
+#if !MESHTASTIC_EXCLUDE_PAXCOUNTER
+    moduleConfig.has_paxcounter = true;
+#endif
 #if USERPREFS_MQTT_ENABLED && !MESHTASTIC_EXCLUDE_MQTT
     moduleConfig.mqtt.enabled = true;
 #endif
@@ -1428,15 +1436,21 @@ bool NodeDB::saveToDiskNoRetry(int saveWhat)
         moduleConfig.has_canned_message = true;
         moduleConfig.has_external_notification = true;
         moduleConfig.has_mqtt = true;
+#if !MESHTASTIC_EXCLUDE_RANGETEST
         moduleConfig.has_range_test = true;
+#endif
         moduleConfig.has_serial = true;
         moduleConfig.has_store_forward = true;
         moduleConfig.has_telemetry = true;
         moduleConfig.has_neighbor_info = true;
         moduleConfig.has_detection_sensor = true;
         moduleConfig.has_ambient_lighting = true;
+#if !MESHTASTIC_EXCLUDE_AUDIO
         moduleConfig.has_audio = true;
+#endif
+#if !MESHTASTIC_EXCLUDE_PAXCOUNTER
         moduleConfig.has_paxcounter = true;
+#endif
 
         success &=
             saveProto(moduleConfigFileName, meshtastic_LocalModuleConfig_size, &meshtastic_LocalModuleConfig_msg, &moduleConfig);

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -354,20 +354,63 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             fromRadioScratch.moduleConfig.payload_variant.serial = moduleConfig.serial;
             break;
         case meshtastic_ModuleConfig_external_notification_tag:
+#if !(NO_EXT_GPIO || MESHTASTIC_EXCLUDE_EXTERNALNOTIFICATION)
             LOG_DEBUG("Send module config: ext notification");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_external_notification_tag;
             fromRadioScratch.moduleConfig.payload_variant.external_notification = moduleConfig.external_notification;
             break;
+#else
+            LOG_DEBUG("External Notification module excluded from build, skipping");
+            config_state++;
+            if (config_state > (_meshtastic_AdminMessage_ModuleConfigType_MAX + 1)) {
+                if (config_nonce == SPECIAL_NONCE_ONLY_CONFIG) {
+                    state = STATE_SEND_FILEMANIFEST;
+                } else {
+                    state = STATE_SEND_OTHER_NODEINFOS;
+                }
+                config_state = 0;
+            }
+            return getFromRadio(buf);
+#endif
         case meshtastic_ModuleConfig_store_forward_tag:
+#if !MESHTASTIC_EXCLUDE_STOREFORWARD
             LOG_DEBUG("Send module config: store forward");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_store_forward_tag;
             fromRadioScratch.moduleConfig.payload_variant.store_forward = moduleConfig.store_forward;
             break;
+#else
+            LOG_DEBUG("Store & Forward module excluded from build, skipping");
+            config_state++;
+            if (config_state > (_meshtastic_AdminMessage_ModuleConfigType_MAX + 1)) {
+                if (config_nonce == SPECIAL_NONCE_ONLY_CONFIG) {
+                    state = STATE_SEND_FILEMANIFEST;
+                } else {
+                    state = STATE_SEND_OTHER_NODEINFOS;
+                }
+                config_state = 0;
+            }
+            return getFromRadio(buf);
+#endif
         case meshtastic_ModuleConfig_range_test_tag:
+#if !MESHTASTIC_EXCLUDE_RANGETEST
             LOG_DEBUG("Send module config: range test");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_range_test_tag;
             fromRadioScratch.moduleConfig.payload_variant.range_test = moduleConfig.range_test;
             break;
+#else
+            LOG_DEBUG("Range Test module excluded from build, skipping");
+            // Skip this config completely - advance to next without sending
+            config_state++;
+            if (config_state > (_meshtastic_AdminMessage_ModuleConfigType_MAX + 1)) {
+                if (config_nonce == SPECIAL_NONCE_ONLY_CONFIG) {
+                    state = STATE_SEND_FILEMANIFEST;
+                } else {
+                    state = STATE_SEND_OTHER_NODEINFOS;
+                }
+                config_state = 0;
+            }
+            return getFromRadio(buf);
+#endif
         case meshtastic_ModuleConfig_telemetry_tag:
             LOG_DEBUG("Send module config: telemetry");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_telemetry_tag;
@@ -379,10 +422,25 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             fromRadioScratch.moduleConfig.payload_variant.canned_message = moduleConfig.canned_message;
             break;
         case meshtastic_ModuleConfig_audio_tag:
+#if !MESHTASTIC_EXCLUDE_AUDIO
             LOG_DEBUG("Send module config: audio");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_audio_tag;
             fromRadioScratch.moduleConfig.payload_variant.audio = moduleConfig.audio;
             break;
+#else
+            LOG_DEBUG("Audio module excluded from build, skipping");
+            // Skip this config completely - advance to next without sending
+            config_state++;
+            if (config_state > (_meshtastic_AdminMessage_ModuleConfigType_MAX + 1)) {
+                if (config_nonce == SPECIAL_NONCE_ONLY_CONFIG) {
+                    state = STATE_SEND_FILEMANIFEST;
+                } else {
+                    state = STATE_SEND_OTHER_NODEINFOS;
+                }
+                config_state = 0;
+            }
+            return getFromRadio(buf);
+#endif
         case meshtastic_ModuleConfig_remote_hardware_tag:
             LOG_DEBUG("Send module config: remote hardware");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_remote_hardware_tag;
@@ -404,10 +462,25 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             fromRadioScratch.moduleConfig.payload_variant.ambient_lighting = moduleConfig.ambient_lighting;
             break;
         case meshtastic_ModuleConfig_paxcounter_tag:
+#if !MESHTASTIC_EXCLUDE_PAXCOUNTER
             LOG_DEBUG("Send module config: paxcounter");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_paxcounter_tag;
             fromRadioScratch.moduleConfig.payload_variant.paxcounter = moduleConfig.paxcounter;
             break;
+#else
+            LOG_DEBUG("Paxcounter module excluded from build, skipping");
+            // Skip this config completely - advance to next without sending
+            config_state++;
+            if (config_state > (_meshtastic_AdminMessage_ModuleConfigType_MAX + 1)) {
+                if (config_nonce == SPECIAL_NONCE_ONLY_CONFIG) {
+                    state = STATE_SEND_FILEMANIFEST;
+                } else {
+                    state = STATE_SEND_OTHER_NODEINFOS;
+                }
+                config_state = 0;
+            }
+            return getFromRadio(buf);
+#endif
         default:
             LOG_ERROR("Unknown module config type %d", config_state);
         }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -1040,19 +1040,32 @@ void AdminModule::handleGetModuleConfig(const meshtastic_MeshPacket &req, const 
             res.get_module_config_response.payload_variant.serial = moduleConfig.serial;
             break;
         case meshtastic_AdminMessage_ModuleConfigType_EXTNOTIF_CONFIG:
+#if !MESHTASTIC_EXCLUDE_EXTERNALNOTIFICATION
             LOG_INFO("Get module config: External Notification");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_external_notification_tag;
             res.get_module_config_response.payload_variant.external_notification = moduleConfig.external_notification;
+#else
+            LOG_DEBUG("External Notification module excluded from build, skipping config");
+#endif
             break;
         case meshtastic_AdminMessage_ModuleConfigType_STOREFORWARD_CONFIG:
+#if !MESHTASTIC_EXCLUDE_STOREFORWARD
             LOG_INFO("Get module config: Store & Forward");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_store_forward_tag;
             res.get_module_config_response.payload_variant.store_forward = moduleConfig.store_forward;
+#else
+            LOG_DEBUG("Store & Forward module excluded from build, skipping config");
+#endif
             break;
         case meshtastic_AdminMessage_ModuleConfigType_RANGETEST_CONFIG:
+#if !MESHTASTIC_EXCLUDE_RANGETEST
             LOG_INFO("Get module config: Range Test");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_range_test_tag;
             res.get_module_config_response.payload_variant.range_test = moduleConfig.range_test;
+#else
+            LOG_DEBUG("Range Test module excluded from build, skipping config");
+            // Don't set payload variant - will result in empty response
+#endif
             break;
         case meshtastic_AdminMessage_ModuleConfigType_TELEMETRY_CONFIG:
             LOG_INFO("Get module config: Telemetry");
@@ -1065,9 +1078,13 @@ void AdminModule::handleGetModuleConfig(const meshtastic_MeshPacket &req, const 
             res.get_module_config_response.payload_variant.canned_message = moduleConfig.canned_message;
             break;
         case meshtastic_AdminMessage_ModuleConfigType_AUDIO_CONFIG:
+#if !MESHTASTIC_EXCLUDE_AUDIO
             LOG_INFO("Get module config: Audio");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_audio_tag;
             res.get_module_config_response.payload_variant.audio = moduleConfig.audio;
+#else
+            LOG_DEBUG("Audio module excluded from build, skipping config");
+#endif
             break;
         case meshtastic_AdminMessage_ModuleConfigType_REMOTEHARDWARE_CONFIG:
             LOG_INFO("Get module config: Remote Hardware");
@@ -1080,19 +1097,31 @@ void AdminModule::handleGetModuleConfig(const meshtastic_MeshPacket &req, const 
             res.get_module_config_response.payload_variant.neighbor_info = moduleConfig.neighbor_info;
             break;
         case meshtastic_AdminMessage_ModuleConfigType_DETECTIONSENSOR_CONFIG:
+#if !(NO_EXT_GPIO || MESHTASTIC_EXCLUDE_DETECTIONSENSOR)
             LOG_INFO("Get module config: Detection Sensor");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_detection_sensor_tag;
             res.get_module_config_response.payload_variant.detection_sensor = moduleConfig.detection_sensor;
+#else
+            LOG_DEBUG("Detection Sensor module excluded from build, skipping config");
+#endif
             break;
         case meshtastic_AdminMessage_ModuleConfigType_AMBIENTLIGHTING_CONFIG:
+#if !defined(HAS_RGB_LED) && !RAK_4631
+            LOG_DEBUG("Ambient Lighting module excluded from build, skipping config");
+#else
             LOG_INFO("Get module config: Ambient Lighting");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_ambient_lighting_tag;
             res.get_module_config_response.payload_variant.ambient_lighting = moduleConfig.ambient_lighting;
+#endif
             break;
         case meshtastic_AdminMessage_ModuleConfigType_PAXCOUNTER_CONFIG:
+#if !MESHTASTIC_EXCLUDE_PAXCOUNTER
             LOG_INFO("Get module config: Paxcounter");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_paxcounter_tag;
             res.get_module_config_response.payload_variant.paxcounter = moduleConfig.paxcounter;
+#else
+            LOG_DEBUG("Paxcounter module excluded from build, skipping config");
+#endif
             break;
         }
 


### PR DESCRIPTION
## Fix excluded modules appearing in client applications

### 🐛 Problem
When modules are excluded via `MESHTASTIC_EXCLUDE_*` flags during compilation, two issues occurred:

- Excluded modules still appeared in client application menus
- These excluded modules sometimes caused `PAYLOADVARIANT_NOT_SET` errors

### 💡 Solution

Added comprehensive conditional compilation guards to prevent excluded modules from:

- Being flagged as available in device metadata `getDeviceMetadata()`
- Responding to admin config requests `handleGetModuleConfig()`
- Being enumerated in phone API `getFromRadio()`
- Having default configs installed `installDefaultModuleConfig()`

### 🎯 Changes
- `src/main.cpp`: Added excluded_modules flags for `MQTT`, `PAXCOUNTER`, `STOREFORWARD`, `RANGETEST`, `NEIGHBORINFO`
- `src/modules/AdminModule.cpp`: Added conditional guards for `RANGETEST`, `AUDIO`, `PAXCOUNTER`, `STOREFORWARD`, `EXTNOTIF`, `DETECTIONSENSOR`, `AMBIENTLIGHTING`
- `src/mesh/PhoneAPI.cpp`: Added skip logic for excluded modules during config enumeration
- `src/mesh/NodeDB.cpp`: Added conditional has_* flags only for included modules

### Testing
Tested with various `MESHTASTIC_EXCLUDE_*` combinations to verify excluded modules no longer appear in client apps and don't generate payload variant errors.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
- [x] Heltec Wireless Paper