### PR TITLE
updated shebang to use a more standard path for bash in flashing scripts.

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PYTHON=${PYTHON:-$(which python3 python | head -n 1)}
 BPS_RESET=false

--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PYTHON=${PYTHON:-$(which python3 python|head -n 1)}
 CHANGE_MODE=false


### PR DESCRIPTION
Hey Meshtastic team!

This is a minor and maybe a bit annoying fix. I run my main system as NixOS which doesn't follow the LFH persay and doesn't have the path `/bin/bash` and while most systems including macOS do have this path. It's not quite as universal as /usr/bin/env so I updated the "shebang" to use that path instead.

This only impacts the device-install and device-update scripts and is still using "bash" to execute the shell script so there is no change in how it is run.

This stackoverflow thread I think does a great job at providing farther reasoning:
https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash

This does not effect any of the code for the devices themselves.

This PR simply is to make my life easier as a NixOS user :)
Without this PR I will continue to update the scripts on every download.

## 🤝 Attestations

- [ x] I have tested that my proposed changes behave as described.
- [ x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ x] Heltec (Lora32) V3
  - [ x] LilyGo T-Deck
  - [ x] LilyGo T-Beam
  - [ x] RAK WisBlock 4631
  - [ x] Seeed Studio T-1000E tracker card
  - [ x] Other (please specify below)
