### PR TITLE
Don't cancel rebroadcast if we hear a rebroadcast with bad snr

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -66,7 +66,8 @@ bool FloodingRouter::roleAllowsCancelingDupe(const meshtastic_MeshPacket *p)
 
 void FloodingRouter::perhapsCancelDupe(const meshtastic_MeshPacket *p)
 {
-    if (p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && roleAllowsCancelingDupe(p)) {
+    if (p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && roleAllowsCancelingDupe(p) &&
+        p->rx_snr >= -4) {
         // cancel rebroadcast of this message *if* there was already one, unless we're a router/repeater!
         // But only LoRa packets should be able to trigger this.
         if (Router::cancelSending(p->from, p->id))


### PR DESCRIPTION
Currently, nodes that receive a packet with bad SNR are prioritized for retransmission, but they might not be the best transmitters, and their retransmissions might cancel out better clients. Therefore, I propose that we do not cancel a rebroadcast if we hear a bad SNR signal (for now, I chose worse than -4). Also, this change will help prevent bad routers from stopping retransmission, as a router with a bad transmitter will not be able to cancel the rebroadcast of a client. Based on preliminary simulator tests, this does create a higher delivery rate at the slight cost of more packets. The -4 number may need to be tuned in the future, and I am considering basing it on the current spreading factor.
Here is a scenario where this change could be useful (Also a testing scenario if anyone wants to try this change IRL)
<img width="1444" height="1280" alt="image" src="https://github.com/user-attachments/assets/5fb6fedc-15fa-4586-b0c1-6b1249503dda" />
In this scenario, the client can reach the recipient, but it will not retransmit the sender's packet because it heard another node go first. With my change, this will not happen, as the client will tell that the router has a bad SNR, either meaning it's far or it has a bad transmitter, so it rebroadcasts and delivers the packet to the recipient.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ x ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
