### PR TITLE
fix heltec v3 screen not working when VEXT is used

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -464,6 +464,10 @@ void setup()
     digitalWrite(VEXT_ENABLE, VEXT_ON_VALUE); // turn on the display power
 #endif
 
+#if defined(VEXT_ENABLE_DELAY)
+    delay(VEXT_ENABLE_DELAY); // give the LDO some time to stabilize the power
+#endif
+
 #if defined(BIAS_T_ENABLE)
     pinMode(BIAS_T_ENABLE, OUTPUT);
     digitalWrite(BIAS_T_ENABLE, BIAS_T_VALUE); // turn on 5V for GPS Antenna

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -276,7 +276,7 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false, bool skipSaveN
 #endif
 
 #if defined(VEXT_ENABLE)
-    digitalWrite(VEXT_ENABLE, !VEXT_ON_VALUE); // turn on the display power
+    digitalWrite(VEXT_ENABLE, !VEXT_ON_VALUE); // turn off the display power
 #endif
 
 #ifdef ARCH_ESP32

--- a/variants/esp32s3/heltec_v3/variant.h
+++ b/variants/esp32s3/heltec_v3/variant.h
@@ -10,7 +10,9 @@
 #define I2C_SDA1 SDA
 #define I2C_SCL1 SCL
 
-#define VEXT_ENABLE Vext // active low, powers the oled display and the lora antenna boost
+#define VEXT_ENABLE Vext    // active low, powers the oled display and the lora antenna boost
+#define VEXT_ENABLE_DELAY 2 // the LDO needs some time to stabilize the power
+
 #define BUTTON_PIN 0
 
 #define ADC_CTRL 37


### PR DESCRIPTION
This fixes the fact that the OLED screen on the heltec v3 does not work all the time.

This problem is 100% reproducebal if additional hardware is using the VEXT (3.3V) as a power src, for example a GPS module.
But I can reproduce it too by simply adding a 100µF cap to VEXT.

this change gives the VEXT 3.3V LDO regulator some time to stablize power before the OLED reset and init is perfomed.
1ms worked for my setup, but setting it too 2ms to be sure.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3.2
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
