### PR TITLE
fix build with HAS_TELEMETRY 0

### DIFF
--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -237,7 +237,7 @@ void setupModules()
 #if HAS_TELEMETRY
         new DeviceTelemetryModule();
 #endif
-#if HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+#if HAS_TELEMETRY && HAS_SENSOR && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
         if (moduleConfig.has_telemetry &&
             (moduleConfig.telemetry.environment_measurement_enabled || moduleConfig.telemetry.environment_screen_enabled)) {
             new EnvironmentTelemetryModule();


### PR DESCRIPTION
fix build with HAS_TELEMETRY 0

did need this to get develop working on a ESP32 since I did run out of space.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] Heltec (Lora32) V2
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

