### PR TITLE
GAT562: Use PRIVATE_HW (fix build)

### DIFF
--- a/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
@@ -6,7 +6,8 @@ board = gat562_mesh_trial_tracker
 board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/nrf52840/gat562_mesh_trial_tracker
-  -D GAT562_MESH_TRIAL_TRACKER
+  ;-D GAT562_MESH_TRIAL_TRACKER
+  -D PRIVATE_HW
   -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   -DRADIOLIB_EXCLUDE_SX128X=1
   -DRADIOLIB_EXCLUDE_SX127X=1


### PR DESCRIPTION
Switch GAT562 to `PRIVATE_HW` model for now. Fixes builds since this is not included in Protobufs.