### PR TITLE
Force coverage tests to run in simulation mode

### DIFF
--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -107,3 +107,7 @@ build_src_filter = ${env:native-tft.build_src_filter}
 [env:coverage]
 extends = env:native
 build_flags = -lgcov --coverage -fprofile-abs-path -fsanitize=address ${env:native.build_flags}
+; https://docs.platformio.org/en/latest/projectconf/sections/env/options/test/test_testing_command.html
+test_testing_command =
+  ${platformio.build_dir}/${this.__env__}/program
+  -s


### PR DESCRIPTION
Re-submit of #8249 

Force meshtastic native tests to run with `-s`

https://docs.platformio.org/en/latest/projectconf/sections/env/options/test/test_testing_command.html