### PR TITLE
Fix Station G2 Lora Power Settings

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -123,6 +123,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TX_GAIN_LORA 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10, 9, 9, 8, 7
 #endif
 
+#ifdef STATION_G2
+#define NUM_PA_POINTS 19
+#define TX_GAIN_LORA 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 19, 19, 18, 18
+#endif
+
 // Default system gain to 0 if not defined
 #ifndef TX_GAIN_LORA
 #define TX_GAIN_LORA 0


### PR DESCRIPTION
In #8107 we introduced the ability to specify gain values for non-linear power amplifiers.

This patch adds appropriate values for the Station G2, based on the table at https://wiki.uniteng.com/en/meshtastic/station-g2#summary-for-lora-power-amplifier-conduction-test

Fixes https://github.com/meshtastic/firmware/issues/7239
