### PR TITLE
fix: Move `#include "variant.h"` to top of file (fixes #8276)

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -33,6 +33,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "pcf8563.h"
 #endif
 
+/* Offer chance for variant-specific defines */
+#include "variant.h"
+
 // -----------------------------------------------------------------------------
 // Version
 // -----------------------------------------------------------------------------
@@ -259,9 +262,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // convert 24-bit color to 16-bit (56K)
 #define COLOR565(r, g, b) (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xF8) >> 3))
-
-/* Step #1: offer chance for variant-specific defines */
-#include "variant.h"
 
 #if defined(VEXT_ENABLE) && !defined(VEXT_ON_VALUE)
 // Older variant.h files might not be defining this value, so stay with the old default


### PR DESCRIPTION
The original line being further down the file causes any #ifdef/defined() checks for definitions in variant.h to silently skip.

This was noticed when `USE_GC1109_PA` in Heltec v4 and Heltec Wireless Tracker failed to correct program TX_GAIN_LORA, but will also affect any variant.h-dependent configurations in this file, if they would have been defined above where the `#include` previously was.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec V4