### PR TITLE
Reset ESP32S3 after flash using watchdog

### DIFF
--- a/arch/esp32/esp32s3.ini
+++ b/arch/esp32/esp32s3.ini
@@ -3,3 +3,4 @@ extends = esp32_base
 custom_esp32_kind = esp32s3
 
 monitor_speed = 115200
+board_upload.after_reset = watchdog_reset


### PR DESCRIPTION
ESP32S3-based devices with direct USB connections currently do not automatically reset when esptool flashing has completed. This requires users to press a physical reset button or power-cycle a device before the new firmware will run, which can pose usability or confusion issues for installations where such actions are not straightforward or expected.

**Dependency:** Once https://github.com/meshtastic/firmware/pull/7697 is merged, the newer version of esptool included will support a watchdog-based reset method. This has been confirmed to work on a Heltec WiFi LoRa 32 V4.