### PR TITLE
Fix for using short and long names starting with char "0" from userPrefs.jsonc

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1060,12 +1060,14 @@ void NodeDB::installDefaultDeviceState()
     // Set default owner name
     pickNewNodeNum(); // based on macaddr now
 #ifdef USERPREFS_CONFIG_OWNER_LONG_NAME
-    snprintf(owner.long_name, sizeof(owner.long_name), (const char *)USERPREFS_CONFIG_OWNER_LONG_NAME);
+    #define STR(x) #x
+    snprintf(owner.long_name, sizeof(owner.long_name), "%s", STR(USERPREFS_CONFIG_OWNER_LONG_NAME));
 #else
     snprintf(owner.long_name, sizeof(owner.long_name), "Meshtastic %04x", getNodeNum() & 0x0ffff);
 #endif
-#ifdef USERPREFS_CONFIG_OWNER_SHORT_NAME
-    snprintf(owner.short_name, sizeof(owner.short_name), (const char *)USERPREFS_CONFIG_OWNER_SHORT_NAME);
+    #ifdef USERPREFS_CONFIG_OWNER_SHORT_NAME
+    #define STR(x) #x
+    snprintf(owner.short_name, sizeof(owner.short_name), "%s", STR(USERPREFS_CONFIG_OWNER_SHORT_NAME));
 #else
     snprintf(owner.short_name, sizeof(owner.short_name), "%04x", getNodeNum() & 0x0ffff);
 #endif


### PR DESCRIPTION
The behaviour before this commit was causing an error when using a string starting with character '0' in userPrefs.jsonc as node long or short name.

This was because all strings not quoted starting with 0 are interpreted as octal values so we couldn't use any number above 7 and also no alphabetic characters at all

```
<command-line>: error: invalid digit "8" in octal constant
src/mesh/NodeDB.cpp:1054:70: note: in expansion of macro 'USERPREFS_CONFIG_OWNER_LONG_NAME'
     snprintf(owner.long_name, sizeof(owner.long_name), (const char *)USERPREFS_CONFIG_OWNER_LONG_NAME);
                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: error: invalid digit "8" in octal constant
src/mesh/NodeDB.cpp:1059:72: note: in expansion of macro 'USERPREFS_CONFIG_OWNER_SHORT_NAME'
     snprintf(owner.short_name, sizeof(owner.short_name), (const char *)USERPREFS_CONFIG_OWNER_SHORT_NAME);
```

when using for example:
```
   "USERPREFS_CONFIG_OWNER_LONG_NAME": "08715",
   "USERPREFS_CONFIG_OWNER_SHORT_NAME": "0871",
```
in `userprefs.jsonc` file.

This should fix it, probably it would be nice to check if similar problems are caused by similar declarations in userPrefs.jsonc file