### PR TITLE
mDNS: Advertise pio_env (for OTA scripts)

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -95,10 +95,12 @@ static void onNetworkConnected()
 #ifdef ARCH_ESP32
             MDNS.addServiceTxt("meshtastic", "tcp", "shortname", String(owner.short_name));
             MDNS.addServiceTxt("meshtastic", "tcp", "id", String(nodeDB->getNodeId().c_str()));
+            MDNS.addServiceTxt("meshtastic", "tcp", "pio_env", optstr(APP_ENV));
             // ESP32 prints obtained IP address in WiFiEvent
 #elif defined(ARCH_RP2040)
             MDNS.addServiceTxt("meshtastic", "shortname", owner.short_name);
             MDNS.addServiceTxt("meshtastic", "id", nodeDB->getNodeId().c_str());
+            MDNS.addServiceTxt("meshtastic", "pio_env", optstr(APP_ENV));
             LOG_INFO("Obtained IP address: %s", WiFi.localIP().toString().c_str());
 #endif
         }


### PR DESCRIPTION
Compile tested, not run-tested.

Advertise platformio `--environment` over mDNS.

This can later be accessed by WiFi OTA scripts to ensure the correct device type is being targeted without connecting to the tcp api.