### PR TITLE
Ble reconnect prefetch bug fix, plus some speed enhancements

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -435,6 +435,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
     case STATE_SEND_OTHER_NODEINFOS: {
         LOG_DEBUG("Send known nodes");
         if (nodeInfoForPhone.num == 0 && !nodeInfoQueue.empty()) {
+            // Serve the next cached node without re-reading from the DB iterator.
             nodeInfoForPhone = nodeInfoQueue.front();
             nodeInfoQueue.pop_front();
         }
@@ -557,6 +558,7 @@ void PhoneAPI::releaseQueueStatusPhonePacket()
 void PhoneAPI::prefetchNodeInfos()
 {
     bool added = false;
+    // Keep the queue topped up so BLE reads stay responsive even if DB fetches take a moment.
     while (nodeInfoQueue.size() < kNodePrefetchDepth) {
         auto nextNode = nodeDB->readNextMeshNode(readIndex);
         if (!nextNode)

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -80,7 +80,9 @@ class PhoneAPI
 
     /// We temporarily keep the nodeInfo here between the call to available and getFromRadio
     meshtastic_NodeInfo nodeInfoForPhone = meshtastic_NodeInfo_init_default;
+    // Prefetched node info entries ready for immediate transmission to the phone.
     std::deque<meshtastic_NodeInfo> nodeInfoQueue;
+    // Tunable size of the node info cache so we can keep BLE reads non-blocking.
     static constexpr size_t kNodePrefetchDepth = 4;
 
     meshtastic_ToRadio toRadioScratch = {


### PR DESCRIPTION
- Restored the lightweight phoneWants/hasChecked flow in NimBLE so the first read after reconnect fetches data before the GATT response, preventing the “empty stream after second connection” stall that forced phones to reboot (src/nimble/NimbleBluetooth.cpp:48).
- Cleared BLE state on disconnect and restarted advertising on all NimBLE variants to guarantee clients can discover the radio again (src/nimble/NimbleBluetooth.cpp:283).
- Made the FromRadio characteristic notify-capable and immediately issue a notify when data exists, letting subscribed phones receive config packets without additional reads.
- Added a small deque-backed prefetch cache for NodeDB entries so the BLE callback serves node info from RAM while a background read keeps the queue warm; removes the 20 ms polling loop and avoids the per-node stall seen in the previous version (src/mesh/PhoneAPI.{h,cpp}).

Why it was broken

- With the prior refactor, the NimBLE read callback ran before getFromRadio() was scheduled, so the first read after a reconnect always returned empty, the state machine never progressed, and the phone saw no data until a reboot.
- Node info delivery also regressed: every read hit NodeDB synchronously, so the phone UI paused ~20 ms per entry.
How this fixes it

- The callbacks now set phoneWants, trigger the worker, and fetch once before responding; we reset the flags on disconnect to start each session clean.
- Node info is preloaded ahead of time; the read path just pops from the deque and queues the next batch asynchronously, eliminating the per-entry delays.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
Lora32 v4