### PR TITLE
Fix multitude of warnings during builds on MeshTiny

### DIFF
--- a/variants/nrf52840/meshtiny/variant.h
+++ b/variants/nrf52840/meshtiny/variant.h
@@ -19,7 +19,9 @@
 #ifndef _VARIANT_MESHTINY_
 #define _VARIANT_MESHTINY_
 
+#ifndef MESHTINY
 #define MESHTINY
+#endif
 
 /** Master clock frequency */
 #define VARIANT_MCK (64000000ul)


### PR DESCRIPTION
- Fix multitude of warnings during builds due to redefine without verifying existence