### PR TITLE
Revert "Fix Station G2 Lora Power Settings"

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -126,11 +126,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TX_GAIN_LORA 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10, 9, 9, 8, 7
 #endif
 
-#ifdef STATION_G2
-#define NUM_PA_POINTS 19
-#define TX_GAIN_LORA 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 19, 19, 18, 18
-#endif
-
 // Default system gain to 0 if not defined
 #ifndef TX_GAIN_LORA
 #define TX_GAIN_LORA 0


### PR DESCRIPTION
Reverts meshtastic/firmware#8273 until we have an additional lora param to handle line loss gain compensation