### PR TITLE
Add LR1121 support for T-Beam SUPREME ESP32-S3

### DIFF
--- a/variants/esp32s3/tbeam-s3-core/rfswitch.h
+++ b/variants/esp32s3/tbeam-s3-core/rfswitch.h
@@ -1,0 +1,11 @@
+#include "RadioLib.h"
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode                  DIO5  DIO6
+    {LR11x0::MODE_STBY, {LOW, LOW}},  {LR11x0::MODE_RX, {HIGH, LOW}},
+    {LR11x0::MODE_TX, {LOW, HIGH}},   {LR11x0::MODE_TX_HP, {LOW, HIGH}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW}},
+    {LR11x0::MODE_WIFI, {LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/esp32s3/tbeam-s3-core/variant.h
+++ b/variants/esp32s3/tbeam-s3-core/variant.h
@@ -15,6 +15,7 @@
 // not found then probe for SX1262
 #define USE_SX1262
 #define USE_SX1268
+#define USE_LR1121
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 5
@@ -32,6 +33,19 @@
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
 // Internally the TTGO module hooks the SX1262-DIO2 in to control the TX/RX switch (which is the default for the sx1262interface
 // code)
+#endif
+
+// LR1121
+#ifdef USE_LR1121
+#define LR1121_IRQ_PIN 1
+#define LR1121_NRESET_PIN LORA_RESET
+#define LR1121_BUSY_PIN 4
+#define LR1121_SPI_NSS_PIN 10
+#define LR1121_SPI_SCK_PIN 12
+#define LR1121_SPI_MOSI_PIN 11
+#define LR1121_SPI_MISO_PIN 13
+#define LR11X0_DIO3_TCXO_VOLTAGE 3.0
+#define LR11X0_DIO_AS_RF_SWITCH
 #endif
 
 // Leave undefined to disable our PMU IRQ handler.  DO NOT ENABLE THIS because the pmuirq can cause sperious interrupts


### PR DESCRIPTION
The LR1121 LoRa chip was not supported, but I got the T-Beam SUPREME ESP32-S3 with LR1121 as a gift.
So I wrote this fix so I can actually use it with Meshtastic and everyone else can also.

This PR adds LR1121 support for the tbeam-s3-core. I tried it on my T-Beam SUPREME ESP32-S3 and it works.
I only sent a message and did not do extensive testing, but I think everything should work fine.
Pretty small fix to make it work. (Thanks Claude)

I hope I did everything right - pretty new to embedded development and Meshtastic.

If you are curious, the T-Beam SUPREME ESP32-S3 with LR1121 is from AliExpress:
https://de.aliexpress.com/item/1005005418286231.html

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (T-Beam SUPREME ESP32-S3 with LR1121)
