### PR TITLE
fix portduino native builds

### DIFF
--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -17,6 +17,7 @@ extends = native_base
 build_flags = ${native_base.build_flags}
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
+  !pkg-config --cflags --libs sdl2 --silence-errors || :
 
 [env:native-tft]
 extends = native_base


### PR DESCRIPTION
fix linux native build by handling the sdl2 libraries

`pio run -e native` would not build unless I added sdl2

You only run into this if you have the libsdl2-dev package installed

```
apt install libsdl2-dev
```

<img width="1670" height="1006" alt="image" src="https://github.com/user-attachments/assets/359cc1cb-78e1-428b-a646-11685e92ff79" />



This change fixes the build errors introduced by 9ded6a52153d894880a98298ee4896d4316a2c46

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Portduino on RPI