### PR TITLE
Ignore MQTT Client Proxy messages while not in sendpackets state

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -159,6 +159,10 @@ bool PhoneAPI::handleToRadio(const uint8_t *buf, size_t bufLength)
 #if !MESHTASTIC_EXCLUDE_MQTT
         case meshtastic_ToRadio_mqttClientProxyMessage_tag:
             LOG_DEBUG("Got MqttClientProxy message");
+            if (state != STATE_SEND_PACKETS) {
+                LOG_WARN("Ignore MqttClientProxy message while completing config handshake");
+                break;
+            }
             if (mqtt && moduleConfig.mqtt.proxy_to_client_enabled && moduleConfig.mqtt.enabled &&
                 (channels.anyMqttEnabled() || moduleConfig.mqtt.map_reporting_enabled)) {
                 mqtt->onClientProxyReceive(toRadioScratch.mqttClientProxyMessage);


### PR DESCRIPTION
Noticed while paired and debugging some bluetooth issues. The want_config flow can get tremendously throttled by getting hammered with MQTTClientProxy messages during the process. I even witnessed a timeout a couple of times. The simplest solution is to just ignore these packets while we are not in a sendpackets state and not ready to process them yet.