### PR TITLE
Bind python version to 3.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
       "installTools": true,
-      "version": "latest"
+      "version": "3.13"
     }
   },
   "customizations": {


### PR DESCRIPTION
PR fixes #8327 

The PR binds the python version to 3.13. 
There is no signature file for 3.14 and starting the devcontainer fails because of it.

- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
