### PR TITLE
Gating off BaseUI code for Screenless nodes and InkHUD

### DIFF
--- a/src/graphics/SharedUIDisplay.cpp
+++ b/src/graphics/SharedUIDisplay.cpp
@@ -1,6 +1,8 @@
-#include "graphics/SharedUIDisplay.h"
+#include "configuration.h"
+#if HAS_SCREEN
 #include "RTC.h"
 #include "graphics/ScreenFonts.h"
+#include "graphics/SharedUIDisplay.h"
 #include "graphics/draw/UIRenderer.h"
 #include "main.h"
 #include "meshtastic/config.pb.h"
@@ -423,3 +425,4 @@ std::string sanitizeString(const std::string &input)
 }
 
 } // namespace graphics
+#endif

--- a/src/graphics/VirtualKeyboard.cpp
+++ b/src/graphics/VirtualKeyboard.cpp
@@ -1,5 +1,6 @@
-#include "VirtualKeyboard.h"
 #include "configuration.h"
+#if HAS_SCREEN
+#include "VirtualKeyboard.h"
 #include "graphics/Screen.h"
 #include "graphics/ScreenFonts.h"
 #include "graphics/SharedUIDisplay.h"
@@ -736,3 +737,4 @@ bool VirtualKeyboard::isTimedOut() const
 }
 
 } // namespace graphics
+#endif

--- a/src/graphics/draw/CompassRenderer.cpp
+++ b/src/graphics/draw/CompassRenderer.cpp
@@ -1,3 +1,5 @@
+#include "configuration.h"
+#if HAS_SCREEN
 #include "CompassRenderer.h"
 #include "NodeDB.h"
 #include "UIRenderer.h"
@@ -135,3 +137,4 @@ uint16_t getCompassDiam(uint32_t displayWidth, uint32_t displayHeight)
 
 } // namespace CompassRenderer
 } // namespace graphics
+#endif

--- a/src/graphics/emotes.cpp
+++ b/src/graphics/emotes.cpp
@@ -1,3 +1,5 @@
+#include "configuration.h"
+#if HAS_SCREEN
 #include "emotes.h"
 
 namespace graphics
@@ -275,3 +277,4 @@ const unsigned char bell_icon[] PROGMEM = {
 #endif
 
 } // namespace graphics
+#endif

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -361,6 +361,7 @@ bool EnvironmentTelemetryModule::wantUIFrame()
     return moduleConfig.telemetry.environment_screen_enabled;
 }
 
+#if HAS_SCREEN
 void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
     // === Setup display ===
@@ -510,6 +511,7 @@ void EnvironmentTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiSt
         currentY += rowHeight;
     }
 }
+#endif
 
 bool EnvironmentTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *t)
 {

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -108,6 +108,7 @@ bool PowerTelemetryModule::wantUIFrame()
     return moduleConfig.telemetry.power_screen_enabled;
 }
 
+#if HAS_SCREEN
 void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
     display->clear();
@@ -165,6 +166,7 @@ void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *s
         drawLine("Ch3", m.ch3_voltage, m.ch3_current);
     }
 }
+#endif
 
 bool PowerTelemetryModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Telemetry *t)
 {


### PR DESCRIPTION
Just housekeeping to prevent BaseUI functions to be built on nodes without screens or on InkHUD builds since none need them.