### PR TITLE
Fixe battery voltage to show missing decimals

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -709,7 +709,7 @@ void InkHUD::MenuApplet::drawSystemInfoPanel(int16_t left, int16_t top, uint16_t
     // Voltage
     float voltage = powerStatus->getBatteryVoltageMv() / 1000.0;
     char voltageStr[6]; // "XX.XV"
-    sprintf(voltageStr, "%.1fV", voltage);
+    sprintf(voltageStr, "%.2fV", voltage);
     printAt(colC[0], labelT, "Bat", CENTER, TOP);
     printAt(colC[0], valT, voltageStr, CENTER, TOP);
 


### PR DESCRIPTION
InkHUD had the issue that it did not show the 2 decimals for the voltage so it would round up or down 4.1V or  4.2V instead of 4.15V. This adds the missing decimal