### PR TITLE
Add a banner on startup when DEBUG_MUTE is enabled

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,6 +436,12 @@ void setup()
 
     LOG_INFO("\n\n//\\ E S H T /\\ S T / C\n");
 
+#if defined(DEBUG_MUTE) && defined(DEBUG_PORT)
+    DEBUG_PORT.printf("\r\n\r\n//\\ E S H T /\\ S T / C\r\n");
+    DEBUG_PORT.printf("Version %s for %s from %s\r\n", optstr(APP_VERSION), optstr(APP_ENV), optstr(APP_REPO));
+    DEBUG_PORT.printf("Debug mute is enabled, there will be no serial output.\r\n");
+#endif
+
     initDeepSleep();
 
 #if defined(MODEM_POWER_EN)


### PR DESCRIPTION
On STM32 we have to turn off debug printing for flash space reasons, but it's confusing if there's absolutely no serial output.
Add a banner that gets printed directly, which adds minimal flash usage.

On wio-e5:
Before:
Flash: [==========]  99.5% (used 232372 bytes from 233472 bytes)
After:
Flash: [==========]  99.6% (used 232444 bytes from 233472 bytes)

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Wio E5
