### PR TITLE
InkHUD crash fix when nodes get deleted from NodeDB

### DIFF
--- a/src/graphics/niche/InkHUD/Applets/Bases/NodeList/NodeListApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/Bases/NodeList/NodeListApplet.cpp
@@ -129,10 +129,7 @@ void InkHUD::NodeListApplet::onRender()
 
     // Clean up deleted nodes before drawing
     cards.erase(
-        std::remove_if(cards.begin(), cards.end(),
-                       [](const CardInfo &c) { 
-                           return nodeDB->getMeshNode(c.nodeNum) == nullptr; 
-                       }),
+        std::remove_if(cards.begin(), cards.end(), [](const CardInfo &c) { return nodeDB->getMeshNode(c.nodeNum) == nullptr; }),
         cards.end());
 
     // -- Each node in list --
@@ -201,7 +198,7 @@ void InkHUD::NodeListApplet::onRender()
             drawSignalIndicator(signalX, signalY, signalW, signalH, signal);
         }
         // Otherwise, print "hops away" info, if available
-        else if (hopsAway != CardInfo::HOPS_UNKNOWN && node) { 
+        else if (hopsAway != CardInfo::HOPS_UNKNOWN && node) {
             std::string hopString = to_string(node->hops_away);
             hopString += " Hop";
             if (node->hops_away != 1)


### PR DESCRIPTION
This fix resolves a crash that could happen when the NodeDB reached its limit and automatically purged older nodes. When that happened, the Node List screen was still trying to draw information for a node that no longer existed, leading to a reboot. The applet now safely skips any deleted or missing nodes, preventing crashes during automatic purges. This crash could also be seen if a node was deleted while on the nodelist applet.

Should fix issue https://github.com/meshtastic/firmware/issues/8082