### PR TITLE
Fix: set SD card CS pin low before deep sleep on RAK WISMESH TAP V2

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -244,6 +244,10 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false, bool skipSaveN
     // pinMode(PIN_POWER_EN1, INPUT_PULLDOWN);
 #endif
 
+#ifdef RAK_WISMESH_TAP_V2
+    digitalWrite(SDCARD_CS, LOW);
+#endif
+
 #ifdef TRACKER_T1000_E
 #ifdef GNSS_AIROHA
     digitalWrite(GPS_VRTC_EN, LOW);


### PR DESCRIPTION
This pull request introduces a minor hardware-specific change for the RAK WISMESH TAP V2 platform in the `src/sleep.cpp` file. The update ensures the SD card chip select pin is set to LOW before entering deep sleep.

* Hardware support:
  * For the RAK WISMESH TAP V2 platform, added a line to set `SDCARD_CS` LOW before sleep to properly manage SD card power state.