### PR TITLE
Add build support for TenStar Esp32-C3 SuperMini

### DIFF
--- a/variants/esp32c3/diy/esp32c3_super_mini_tenstar/pins_arduino.h
+++ b/variants/esp32c3/diy/esp32c3_super_mini_tenstar/pins_arduino.h
@@ -1,0 +1,24 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t TX = 21;
+static const uint8_t RX = 20;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+static const uint8_t SS = 7;
+static const uint8_t MOSI = 6;
+static const uint8_t MISO = 5;
+static const uint8_t SCK = 4;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32c3/diy/esp32c3_super_mini_tenstar/platformio.ini
+++ b/variants/esp32c3/diy/esp32c3_super_mini_tenstar/platformio.ini
@@ -1,0 +1,16 @@
+; TenStar ESP32 C3 Super Mini Development Board
+; https://forum.arduino.cc/t/esp32-c3-supermini-pinout/1189850
+; Note: Pinout is different than Espressif ESP32-C3 Super Mini
+
+[env:esp32c3_super_mini_tenstar]
+extends = esp32c3_base
+board = esp32-c3-devkitm-1
+board_build.mcu = esp32c3
+board_build.f_cpu = 160000000L
+build_flags =
+  ${esp32_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/esp32c3/diy/esp32c3_super_mini_tenstar
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+board_level = extra

--- a/variants/esp32c3/diy/esp32c3_super_mini_tenstar/variant.h
+++ b/variants/esp32c3/diy/esp32c3_super_mini_tenstar/variant.h
@@ -1,0 +1,63 @@
+#ifndef _VARIANT_ESP32C3_SUPER_MINI_TENSTAR_
+#define _VARIANT_ESP32C3_SUPER_MINI_TENSTAR_
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// I2C (Wire) & OLED
+#define WIRE_INTERFACES_COUNT (1)
+#define I2C_SDA (8)
+#define I2C_SCL (9)
+
+#define USE_SSD1306
+
+// GPS
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+#define GPS_RX_PIN (20)
+#define GPS_TX_PIN (21)
+
+// Button, active LOW
+#define BUTTON_PIN (10)
+
+// LoRa
+#define USE_LLCC68
+// TODO: why enable SX126x if not used ?
+// Note: without these, LoRa will not work correctly
+#define USE_SX1262
+// #define USE_RF95
+#define USE_SX1268
+
+#define LORA_DIO0 RADIOLIB_NC
+#define LORA_RESET (0)
+#define LORA_DIO1 (1)
+#define LORA_RXEN (2)
+#define LORA_BUSY (3)
+#define LORA_SCK (4)
+#define LORA_MISO (5)
+#define LORA_MOSI (6)
+#define LORA_CS (7)
+
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_BUSY
+#define SX126X_RESET LORA_RESET
+#define SX126X_RXEN LORA_RXEN
+
+#define SX126X_DIO3_TCXO_VOLTAGE (1.8)
+#define TCXO_OPTIONAL // make it so that the firmware can try both TCXO and XTAL
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
Tried to build the **esp32c3_super_mini** platform for my ESP32C3-SuperMini. The defined pinout was not compatible with my version.
Added new variant, with the correct pinout.
Tested with my own ESP32C3-SuperMini, LLCC68 LoRa, SSD1306, works correctly.
