### PR TITLE
Registers GPIO3 and GPIO4 for secondary I2C bus

### DIFF
--- a/variants/esp32s3/heltec_v4/variant.h
+++ b/variants/esp32s3/heltec_v4/variant.h
@@ -6,6 +6,10 @@
 #define I2C_SDA 17 // I2C pins for this board
 #define I2C_SCL 18
 
+// Enable secondary bus for external periherals
+#define I2C_SDA1 SDA
+#define I2C_SCL1 SCL
+
 #define VEXT_ENABLE 36 // active low, powers the oled display and the lora antenna boost
 #define BUTTON_PIN 0
 


### PR DESCRIPTION
Resolves meshtastic/firmware#8417

Given pins 41 and 42 are used for GPS on this version it would seem using those pins, though drop in compatible with the V3 board, would render the GNSS socket unusable unless one used the inconvenient OLED pins on the forward edge of the board.

I will test this on a Heltec v3, RAK 4631, and a T-Beam as I have those, but a regression seems quite unlikely given this is a simple `variant.h` update.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
