### PR TITLE
Fix type to ensure correct alignment; saves 4B per entry

### DIFF
--- a/src/mesh/PacketCache.h
+++ b/src/mesh/PacketCache.h
@@ -17,7 +17,7 @@ typedef struct PacketCacheEntry {
             uint8_t encrypted : 1;    // Payload is encrypted
             uint8_t has_metadata : 1; // Payload includes PacketCacheMetadata
             uint8_t : 6;              // Reserved for future use
-            uint16_t : 8;             // Reserved for future use
+            uint8_t : 8;              // Reserved for future use
         };
     };
 } PacketCacheEntry;


### PR DESCRIPTION
Fix the type of the second reserved byte. This results in properly packed alignment, thus saving 4B per entry.

The original uint16_t was a typo; this should always have been a uint8_t.