### PR TITLE
PIN_PWR_DELAY_MS --> PERIPHERAL_WARMUP_MS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1186,11 +1186,6 @@ void setup()
 #endif
 #endif
 
-#ifdef PIN_PWR_DELAY_MS
-    // This may be required to give the peripherals time to power up.
-    delay(PIN_PWR_DELAY_MS);
-#endif
-
 #ifdef ARCH_PORTDUINO
     // as one can't use a function pointer to the class constructor:
     auto loraModuleInterface = [](LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,

--- a/variants/nrf52840/canaryone/variant.h
+++ b/variants/nrf52840/canaryone/variant.h
@@ -103,7 +103,7 @@ static const uint8_t A0 = PIN_A0;
 #define EXTERNAL_FLASH_USE_QSPI
 
 // Add a delay on startup to allow LoRa and GPS to power up
-#define PIN_PWR_DELAY_MS 100
+#define PERIPHERAL_WARMUP_MS 100
 
 /*
  * Lora radio


### PR DESCRIPTION
It turns out we had two methods for delaying startup while peripherals warmed up. They were invented within months of each other and just missed the chance to merge.

Let's delete PIN_PWR_DELAY_MS and use PERIPHERAL_WARMUP_MS, since it's most common and earlier in the sequence.
