### PR TITLE
Refactor num uint16

### DIFF
--- a/src/NodeStatus.h
+++ b/src/NodeStatus.h
@@ -14,16 +14,16 @@ class NodeStatus : public Status
     CallbackObserver<NodeStatus, const NodeStatus *> statusObserver =
         CallbackObserver<NodeStatus, const NodeStatus *>(this, &NodeStatus::updateStatus);
 
-    uint8_t numOnline = 0;
-    uint8_t numTotal = 0;
+    uint16_t numOnline = 0;
+    uint16_t numTotal = 0;
 
-    uint8_t lastNumTotal = 0;
+    uint16_t lastNumTotal = 0;
 
   public:
     bool forceUpdate = false;
 
     NodeStatus() { statusType = STATUS_TYPE_NODE; }
-    NodeStatus(uint8_t numOnline, uint8_t numTotal, bool forceUpdate = false) : Status()
+    NodeStatus(uint16_t numOnline, uint16_t numTotal, bool forceUpdate = false) : Status()
     {
         this->forceUpdate = forceUpdate;
         this->numOnline = numOnline;
@@ -34,11 +34,11 @@ class NodeStatus : public Status
 
     void observe(Observable<const NodeStatus *> *source) { statusObserver.observe(source); }
 
-    uint8_t getNumOnline() const { return numOnline; }
+    uint16_t getNumOnline() const { return numOnline; }
 
-    uint8_t getNumTotal() const { return numTotal; }
+    uint16_t getNumTotal() const { return numTotal; }
 
-    uint8_t getLastNumTotal() const { return lastNumTotal; }
+    uint16_t getLastNumTotal() const { return lastNumTotal; }
 
     bool matches(const NodeStatus *newStatus) const
     {
@@ -56,7 +56,7 @@ class NodeStatus : public Status
             numTotal = newStatus->getNumTotal();
         }
         if (isDirty || newStatus->forceUpdate) {
-            LOG_DEBUG("Node status update: %d online, %d total", numOnline, numTotal);
+            LOG_DEBUG("Node status update: %u online, %u total", numOnline, numTotal);
             onNewStatus.notifyObservers(this);
         }
         return 0;

--- a/src/graphics/niche/InkHUD/Applets/Bases/Map/MapApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/Bases/Map/MapApplet.cpp
@@ -287,7 +287,7 @@ void InkHUD::MapApplet::getMapCenter(float *lat, float *lng)
     float easternmost = lngCenter;
     float westernmost = lngCenter;
 
-    for (uint8_t i = 0; i < nodeDB->getNumMeshNodes(); i++) {
+    for (size_t i = 0; i < nodeDB->getNumMeshNodes(); i++) {
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
 
         // Skip if no position
@@ -474,8 +474,8 @@ void InkHUD::MapApplet::drawLabeledMarker(meshtastic_NodeInfoLite *node)
 // Need at least two, to draw a sensible map
 bool InkHUD::MapApplet::enoughMarkers()
 {
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < nodeDB->getNumMeshNodes(); i++) {
+    size_t count = 0;
+    for (size_t i = 0; i < nodeDB->getNumMeshNodes(); i++) {
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
 
         // Count nodes

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -46,12 +46,15 @@ class Default
     static uint32_t getConfiguredOrDefaultMs(uint32_t configuredInterval);
     static uint32_t getConfiguredOrDefaultMs(uint32_t configuredInterval, uint32_t defaultInterval);
     static uint32_t getConfiguredOrDefault(uint32_t configured, uint32_t defaultValue);
+    // Note: numOnlineNodes uses uint32_t to match the public API and allow flexibility,
+    // even though internal node counts use uint16_t (max 65535 nodes)
     static uint32_t getConfiguredOrDefaultMsScaled(uint32_t configured, uint32_t defaultValue, uint32_t numOnlineNodes);
     static uint8_t getConfiguredOrDefaultHopLimit(uint8_t configured);
     static uint32_t getConfiguredOrMinimumValue(uint32_t configured, uint32_t minValue);
 
   private:
-    static float congestionScalingCoefficient(int numOnlineNodes)
+    // Note: Kept as uint32_t to match the public API parameter type
+    static float congestionScalingCoefficient(uint32_t numOnlineNodes)
     {
         // Increase frequency of broadcasts for small networks regardless of preset
         if (numOnlineNodes <= 10) {

--- a/src/mesh/ProtobufModule.h
+++ b/src/mesh/ProtobufModule.h
@@ -13,7 +13,7 @@ template <class T> class ProtobufModule : protected SinglePortModule
     const pb_msgdesc_t *fields;
 
   public:
-    uint8_t numOnlineNodes = 0;
+    uint16_t numOnlineNodes = 0;
     /** Constructor
      * name is for debugging output
      */


### PR DESCRIPTION

## What changed
- Bigger node counts: NodeStatus and ProtobufModule::numOnlineNodes now use uint16_t (was uint8_t).
- Map/UI fixes: Iteration/counting in the map applet uses wider types to avoid overflow.

## Motivation
- To support #8097 when adding more nodes to the DB

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
Heltec (Lora32) V4