### PR TITLE
Thinknode M5 ADC_MULTIPLIER to actually hit 100% charge

### DIFF
--- a/variants/esp32s3/ELECROW-ThinkNode-M5/variant.h
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/variant.h
@@ -14,6 +14,8 @@
 #define BATTERY_PIN 8
 #define ADC_CHANNEL ADC1_GPIO8_CHANNEL
 
+#define ADC_MULTIPLIER 2.11 // 2.0 + 10% for correction of display undervoltage.
+
 #define PIN_BUZZER 9
 
 // Buttons


### PR DESCRIPTION
Thinknode M5 was showing 95% when battery was fully charged. This tweak corrects the battery at the high end, and it still shows 0% when discharged.