### PR TITLE
native: force stdout to be line buffered

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -37,6 +37,8 @@ bool yamlOnly = false;
 
 const char *argp_program_version = optstr(APP_VERSION);
 
+char stdoutBuffer[512];
+
 // FIXME - move setBluetoothEnable into a HALPlatform class
 void setBluetoothEnable(bool enable)
 {
@@ -153,6 +155,9 @@ void portduinoSetup()
     int max_GPIO = 0;
     std::string gpioChipName = "gpiochip";
     portduino_config.displayPanel = no_screen;
+
+    // Force stdout to be line buffered
+    setvbuf(stdout, stdoutBuffer, _IOLBF, sizeof(stdoutBuffer));
 
     if (portduino_config.force_simradio == true) {
         portduino_config.lora_module = use_simradio;


### PR DESCRIPTION
This makes the logs in journalctl actually show up on time, as well as not being cut off if meshtasticd crashes.
stderr is typically not buffered.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] native