### PR TITLE
Update device-install.sh to support heltec-v4

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -47,6 +47,7 @@ BIGDB_16MB=(
 S3_VARIANTS=(
     "s3"
     "-v3"
+    "-v4"
     "t-deck"
     "wireless-paper"
     "wireless-tracker"


### PR DESCRIPTION
This adds support for the heltec-v4 devices for the device-install.sh and fixes issues such as this [one here](https://github.com/meshtastic/firmware/issues/8487)


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V4
