### PR TITLE
GPS.cpp refactor - move Ublox and CASIC to separate files.

### DIFF
--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -200,10 +200,6 @@ class GPS : private concurrency::OSThread
     static HardwareSerial *_serial_gps;
 #endif
 
-    // Create a ublox packet for editing in memory
-    uint8_t makeUBXPacket(uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg);
-    uint8_t makeCASPacket(uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg);
-
     // scratch space for creating ublox packets
     uint8_t UBXscratch[250] = {0};
 

--- a/src/gps/cas.cpp
+++ b/src/gps/cas.cpp
@@ -1,0 +1,58 @@
+#include "cas.h"
+
+// Calculate the checksum for a CAS packet
+void CASChecksum(uint8_t *message, size_t length)
+{
+    uint32_t cksum = ((uint32_t)message[5] << 24); // Message ID
+    cksum += ((uint32_t)message[4]) << 16;         // Class
+    cksum += message[2];                           // Payload Len
+
+    // Iterate over the payload as a series of uint32_t's and
+    // accumulate the cksum
+    for (size_t i = 0; i < (length - 10) / 4; i++) {
+        uint32_t pl = 0;
+        memcpy(&pl, (message + 6) + (i * sizeof(uint32_t)), sizeof(uint32_t)); // avoid pointer dereference
+        cksum += pl;
+    }
+
+    // Place the checksum values in the message
+    message[length - 4] = (cksum & 0xFF);
+    message[length - 3] = (cksum & (0xFF << 8)) >> 8;
+    message[length - 2] = (cksum & (0xFF << 16)) >> 16;
+    message[length - 1] = (cksum & (0xFF << 24)) >> 24;
+}
+
+// Function to create a CAS packet for editing in memory
+uint8_t makeCASPacket(uint8_t *out, uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg)
+{
+    // General CAS structure
+    //        | H1   | H2   | payload_len | cls  | msg  | Payload       ...   | Checksum                  |
+    // Size:  | 1    | 1    | 2           | 1    | 1    | payload_len         | 4                         |
+    // Pos:   | 0    | 1    | 2    | 3    | 4    | 5    | 6    | 7      ...   | 6 + payload_len ...       |
+    //        |------|------|-------------|------|------|------|--------------|---------------------------|
+    //        | 0xBA | 0xCE | 0xXX | 0xXX | 0xXX | 0xXX | 0xXX | 0xXX   ...   | 0xXX | 0xXX | 0xXX | 0xXX |
+
+    // Construct the CAS packet
+    out[0] = 0xBA;         // header 1 (0xBA)
+    out[1] = 0xCE;         // header 2 (0xCE)
+    out[2] = payload_size; // length 1
+    out[3] = 0;            // length 2
+    out[4] = class_id;     // class
+    out[5] = msg_id;       // id
+
+    out[6 + payload_size] = 0x00; // Checksum
+    out[7 + payload_size] = 0x00;
+    out[8 + payload_size] = 0x00;
+    out[9 + payload_size] = 0x00;
+
+    for (int i = 0; i < payload_size; i++) {
+        out[6 + i] = pgm_read_byte(&msg[i]);
+    }
+    CASChecksum(out, (payload_size + 10));
+
+#if defined(GPS_DEBUG) && defined(DEBUG_PORT)
+    LOG_DEBUG("CAS packet: ");
+    DEBUG_PORT.hexDump(MESHTASTIC_LOG_LEVEL_DEBUG, out, payload_size + 10);
+#endif
+    return (payload_size + 10);
+}

--- a/src/gps/cas.h
+++ b/src/gps/cas.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Arduino.h>
 
 // CASIC binary message definitions
 // Reference: https://www.icofchina.com/d/file/xiazai/2020-09-22/20f1b42b3a11ac52089caf3603b43fb5.pdf
@@ -61,3 +62,9 @@ static const uint8_t _message_CAS_CFG_NAVX_CONF[] = {
     0x00, 0x00, 0x00, 0x00, // Time Accuracy Max
     0x00, 0x00, 0x00, 0x00  // Static Hold Threshold
 };
+
+// CASIC checksum calculation
+void CASChecksum(uint8_t *message, size_t length);
+
+// Create a CAS packet for editing in memory
+uint8_t makeCASPacket(uint8_t *out, uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg);

--- a/src/gps/ubx.cpp
+++ b/src/gps/ubx.cpp
@@ -1,0 +1,35 @@
+#include "ubx.h"
+
+void UBXChecksum(uint8_t *message, size_t length)
+{
+    uint8_t CK_A = 0, CK_B = 0;
+    for (size_t i = 2; i < length - 2; i++) {
+        CK_A = (CK_A + message[i]) & 0xFF;
+        CK_B = (CK_B + CK_A) & 0xFF;
+    }
+    message[length - 2] = CK_A;
+    message[length - 1] = CK_B;
+}
+
+uint8_t makeUBXPacket(uint8_t *out, uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg)
+{
+    // UBX header
+    out[0] = 0xB5;
+    out[1] = 0x62;
+    out[2] = class_id;
+    out[3] = msg_id;
+    out[4] = payload_size; // length LSB
+    out[5] = 0x00;         // length MSB
+
+    // Payload
+    for (int i = 0; i < payload_size; i++) {
+        out[6 + i] = pgm_read_byte(&msg[i]);
+    }
+
+    // Reserve space for checksum and compute it
+    out[6 + payload_size] = 0x00;
+    out[7 + payload_size] = 0x00;
+    UBXChecksum(out, payload_size + 8);
+
+    return payload_size + 8;
+}

--- a/src/gps/ubx.h
+++ b/src/gps/ubx.h
@@ -1,8 +1,11 @@
+#pragma once
+#include <Arduino.h>
+
 static const char *failMessage = "Unable to %s";
 
 #define SEND_UBX_PACKET(TYPE, ID, DATA, ERRMSG, TIMEOUT)                                                                         \
     do {                                                                                                                         \
-        msglen = makeUBXPacket(TYPE, ID, sizeof(DATA), DATA);                                                                    \
+        msglen = makeUBXPacket(UBXscratch, TYPE, ID, sizeof(DATA), DATA);                                                        \
         _serial_gps->write(UBXscratch, msglen);                                                                                  \
         if (getACK(TYPE, ID, TIMEOUT) != GNSS_RESPONSE_OK) {                                                                     \
             LOG_WARN(failMessage, #ERRMSG);                                                                                      \
@@ -10,7 +13,6 @@ static const char *failMessage = "Unable to %s";
     } while (0)
 
 // Power Management
-
 static uint8_t _message_PMREQ[] PROGMEM = {
     0x00, 0x00, 0x00, 0x00, // 4 bytes duration of request task (milliseconds)
     0x02, 0x00, 0x00, 0x00  // Bitfield, set backup = 1
@@ -478,3 +480,6 @@ b5 62 06 8a 0e 00 00 01 00 00 20 00 31 10 00 05 00 31 10 00 46 87
 BBR layer config message:
 b5 62 06 8a 0e 00 00 02 00 00 20 00 31 10 00 05 00 31 10 00 47 94
 */
+
+void UBXChecksum(uint8_t *message, size_t length);
+uint8_t makeUBXPacket(uint8_t *out, uint8_t class_id, uint8_t msg_id, uint8_t payload_size, const uint8_t *msg);


### PR DESCRIPTION
GPS.cpp is 1800 lines long. This is an attempt to shorten it slightly by moving functions specific to certain families of GPS into their own files.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
