### PR TITLE
fix strlcpy compile error in Ubuntu 22.04

### DIFF
--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -18,6 +18,7 @@ build_flags = ${native_base.build_flags}
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
   !pkg-config --cflags --libs sdl2 --silence-errors || :
+  !pkg-config --cflags --libs libbsd-overlay --silence-errors || :
 
 [env:native-tft]
 extends = native_base


### PR DESCRIPTION
The portduino _native-xxx_ targets do not compile on Ubuntu 22.04 (arm64), I get the following compile error:

```c++
src/mqtt/MQTT.cpp: In member function ‘bool MQTT::publish(const char*, const uint8_t*, size_t, bool)’:
src/mqtt/MQTT.cpp:476:9: error: ‘strlcpy’ was not declared in this scope; did you mean ‘strncpy’?
  476 |         strlcpy(msg->topic, topic, sizeof(msg->topic));
      |         ^~~~~~~
      |         strncpy

```      
This is due to strlcpy (introduced in PR https://github.com/meshtastic/firmware/pull/8320) is not a POSIX function and not part of glibc.

However, it is contained in libbsd so this PR modifies the build command line to optionally include this library if it is installed:

`!pkg-config --cflags --libs libbsd-overlay --silence-errors`

Install _strlcpy_ with `sudo apt install libbsd-dev` on Ubuntu if affected by this same error.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
    - [x] native
    - [x] native-tft
    - [x] native-fb
    - [x] native-tft-debug
