### PR TITLE
Feat/6704 neighbor info on demand

### DIFF
--- a/bin/org.meshtastic.meshtasticd.metainfo.xml
+++ b/bin/org.meshtastic.meshtasticd.metainfo.xml
@@ -87,6 +87,9 @@
   </screenshots>
 
   <releases>
+    <release version="2.7.15" date="2025-11-13">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.15</url>
+    </release>
     <release version="2.7.14" date="2025-11-03">
       <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.7.14</url>
     </release>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+meshtasticd (2.7.15.0) unstable; urgency=medium
+
+  * Version 2.7.15
+
+ -- GitHub Actions <github-actions[bot]@users.noreply.github.com>  Thu, 13 Nov 2025 12:31:57 +0000
+
 meshtasticd (2.7.14.0) unstable; urgency=medium
 
   * Version 2.7.14

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 [VERSION]  
 major = 2
 minor = 7
-build = 14
+build = 15


### PR DESCRIPTION
Closes #6704 
Allows you to requestneighbours from a node. 

 - Uses the 'want response' field 
- Node needs to have neighbourInfo turned on, but can have the interval set to 0. 
- Does not need to have sendViaLora == true. 

Added limits to reduce retriggers: 
- Limit responses to one every 3 minutes. 
- added ignore for a dummy neighbour used solely for triggering this feature : 
```
DEBUG | ??:??:?? 464 [Router] Packet contains 1 neighbors
DEBUG | ??:??:?? 464 [Router] Neighbor 0: node_id=0x0, snr=0.00
DEBUG | ??:??:?? 464 [Router] Ignoring dummy neighbor info packet (single neighbor with nodeId 0, snr 0)
INFO  | ??:??:?? 464 [Router] NeighborInfoRequested.
```
