### PR TITLE
Fix SHT4x temperature and humidity sensor detection by reading unique serial nubmer

### DIFF
--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -106,6 +106,7 @@ uint16_t ScanI2CTwoWire::getRegisterValue(const ScanI2CTwoWire::RegisterLocation
         if (i2cBus->available())
             i2cBus->read();
     }
+    LOG_DEBUG("Register value: 0x%x", value);
     return value;
 }
 
@@ -377,14 +378,13 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
                 }
             case SHT31_4x_ADDR:     // same as OPT3001_ADDR_ALT
             case SHT31_4x_ADDR_ALT: // same as OPT3001_ADDR
-                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x89), 2);
-                if (registerValue == 0x11a2 || registerValue == 0x11da || registerValue == 0x11f3 || registerValue == 0xe9c ||
-                    registerValue == 0xc8d) {
-                    type = SHT4X;
-                    logFoundDevice("SHT4X", (uint8_t)addr.address);
-                } else if (getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x7E), 2) == 0x5449) {
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x7E), 2);
+                if (registerValue == 0x5449) {
                     type = OPT3001;
                     logFoundDevice("OPT3001", (uint8_t)addr.address);
+                } else if (getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x89), 2) != 0) { // unique SHT4x serial number
+                    type = SHT4X;
+                    logFoundDevice("SHT4X", (uint8_t)addr.address);
                 } else {
                     type = SHT31;
                     logFoundDevice("SHT31", (uint8_t)addr.address);


### PR DESCRIPTION
fixes #7522 
fixes #6835

## Problem

The current SHT4x and SHT3x environment sensors distinguishing algorithm is wrong. It writes `0x89` and accepts only certain values returned.
```
registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x89), 2);
if (registerValue == 0x11a2 || registerValue == 0x11da || registerValue == 0x11f3 || registerValue == 0xe9c ||
    registerValue == 0xc8d) {
    type = SHT4X;
    logFoundDevice("SHT4X", (uint8_t)addr.address);
}
```

Actually, `0x89`'s answer from SHT4x is the *unique* serial number, according to the [datasheet](https://sensirion.com/media/documents/33FD6951/6555C40E/Sensirion_Datasheet_SHT4x.pdf) (p. 4.7).

## Fix

The fixed code firstly checks for OPT3001, then uses `0x89` and considers any non-zero value as SHT4x. Otherwise, it's SHT3x. Also note that SHT3x will not respond to the `0x89`, since its commands have 2-byte length, according to the [datasheet](https://sensirion.com/media/documents/213E6A3B/63A5A569/Datasheet_SHT3x_DIS.pdf).

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] SHT41 sensor
  - [x] Heltec (Lora32) V3
  - [x] Heltec MeshNode T114
