### PR TITLE
Packaging: Add libbsd where needed

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # trunk-ignore-all(terrascan/AC_DOCKER_0002): Known terrascan issue
 # trunk-ignore-all(hadolint/DL3008): Do not pin apt package versions
 # trunk-ignore-all(hadolint/DL3013): Do not pin pip package versions
-FROM mcr.microsoft.com/devcontainers/cpp:2-debian-12
+FROM mcr.microsoft.com/devcontainers/cpp:2-debian-13
 
 USER root
 

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -8,7 +8,8 @@ ARG PIO_ENV=native
 ENV PIP_ROOT_USER_ACTION=ignore
 
 RUN apk --no-cache add \
-        bash g++ libstdc++-dev linux-headers zip git ca-certificates libgpiod-dev yaml-cpp-dev bluez-dev \
+        bash g++ libstdc++-dev linux-headers zip git ca-certificates libbsd-dev \
+        libgpiod-dev yaml-cpp-dev bluez-dev \
         libusb-dev i2c-tools-dev libuv-dev openssl-dev pkgconf argp-standalone \
         libx11-dev libinput-dev libxkbcommon-dev \
     && rm -rf /var/cache/apk/* \
@@ -40,8 +41,8 @@ LABEL org.opencontainers.image.title="Meshtastic" \
 USER root
 
 RUN apk --no-cache add \
-        shadow libstdc++ libgpiod yaml-cpp libusb i2c-tools libuv \
-        libx11 libinput libxkbcommon \
+        shadow libstdc++ libbsd libgpiod yaml-cpp libusb \
+        i2c-tools libuv libx11 libinput libxkbcommon \
     && rm -rf /var/cache/apk/* \
     && mkdir -p /var/lib/meshtasticd \
     && mkdir -p /etc/meshtasticd/config.d \

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Austin Lane <vidplace7@gmail.com>
 Build-Depends: debhelper-compat (= 13),
+               libc6-dev (>= 2.38) | libbsd-dev,
                lsb-release,
                tar,
                gzip,

--- a/meshtasticd.spec.rpkg
+++ b/meshtasticd.spec.rpkg
@@ -33,6 +33,7 @@ BuildRequires: python3dist(grpcio[protobuf])
 BuildRequires: python3dist(grpcio-tools)
 BuildRequires: git-core
 BuildRequires: gcc-c++
+BuildRequires: (glibc-devel >= 2.38) or pkgconfig(libbsd-overlay)
 BuildRequires: pkgconfig(yaml-cpp)
 BuildRequires: pkgconfig(libgpiod)
 BuildRequires: pkgconfig(bluez)


### PR DESCRIPTION
Related to #8520 (merge together)

Add `libbsd` to Linux packaging when glibc version is less than 2.38 (when `strlcpy` was added).
Also always add libbsd on Alpine container (glibc isn't a thing at all)
Switch devcontainer to debian:13 base now that it's available, where glibc is up to date.