### PR TITLE
Add support for RAK_WISMESH_TAP_V2 and RAK3401 hardware models

### DIFF
--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -191,6 +191,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_CROWPANEL
 #elif defined(RAK3312)
 #define HW_VENDOR meshtastic_HardwareModel_RAK3312
+#elif defined(RAK_WISMESH_TAP_V2)
+#define HW_VENDOR meshtastic_HardwareModel_WISMESH_TAP_V2
 #elif defined(LINK_32)
 #define HW_VENDOR meshtastic_HardwareModel_LINK_32
 #elif defined(T_DECK_PRO)

--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -60,6 +60,8 @@
 // MAke sure all custom RAK4630 boards are defined before the generic RAK4630
 #elif defined(RAK4630)
 #define HW_VENDOR meshtastic_HardwareModel_RAK4631
+#elif defined(RAK3401)
+#define HW_VENDOR meshtastic_HardwareModel_RAK3401
 #elif defined(TTGO_T_ECHO)
 #define HW_VENDOR meshtastic_HardwareModel_T_ECHO
 #elif defined(T_ECHO_LITE)


### PR DESCRIPTION
This pull request adds support for two new hardware models by updating architecture header files for the ESP32 and nRF52 platforms. These changes ensure the firmware can correctly identify and work with these additional boards.

**Hardware model support:**

* Added support for the `RAK_WISMESH_TAP_V2` hardware model in the `src/platform/esp32/architecture.h` file.
* Added support for the `RAK3401` hardware model in the `src/platform/nrf52/architecture.h` file.