### PR TITLE
Only request node info when we see a text message

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -86,12 +86,9 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
 
     nodeDB->updateFrom(*mp); // update our DB state based off sniffing every RX packet from the radio
     bool isPreferredRebroadcaster = config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER;
-    if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
-        mp->decoded.portnum == meshtastic_PortNum_TELEMETRY_APP && mp->decoded.request_id > 0) {
-        LOG_DEBUG("Received telemetry response. Skip sending our NodeInfo");
-        //  ignore our request for its NodeInfo
-    } else if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !nodeDB->getMeshNode(mp->from)->has_user &&
-               nodeInfoModule && !isPreferredRebroadcaster && !nodeDB->isFull()) {
+    if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag && !nodeDB->getMeshNode(mp->from)->has_user &&
+        nodeInfoModule && !isPreferredRebroadcaster && !nodeDB->isFull() &&
+        mp->decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP) {
         if (airTime->isTxAllowedChannelUtil(true)) {
             // Hops used by the request. If somebody in between running modified firmware modified it, ignore it
             auto hopStart = mp->hop_start;


### PR DESCRIPTION
We will only request node info from a unknown node only if we saw a text message packet from it. A large portion of traffic on the mesh is node info packets.
Node info is primarily used for messaging, so we should ignore nodes who do not message and only request info from nodes who send a message (like a dm or channel message).

In conjunction with this we should encourage the use of manually exchanging node qr codes or sending manually exchange node info requests to unknown nodes you are interested in.