### PR TITLE
Revert "nrf52: add watchdog"

### DIFF
--- a/arch/nrf52/nrf52.ini
+++ b/arch/nrf52/nrf52.ini
@@ -7,7 +7,7 @@ extends = arduino_base
 platform_packages =
   ; our custom Git version until they merge our PR
   # TODO renovate
-  platformio/framework-arduinoadafruitnrf52 @ https://github.com/meshtastic/Adafruit_nRF52_Arduino#c770c8a16a351b55b86e347a3d9d7b74ad0bbf39
+  platformio/framework-arduinoadafruitnrf52 @ https://github.com/meshtastic/Adafruit_nRF52_Arduino#e13f5820002a4fb2a5e6754b42ace185277e5adf
   ; Don't renovate toolchain-gccarmnoneeabi
   platformio/toolchain-gccarmnoneeabi@~1.90301.0
 

--- a/src/platform/nrf52/main-nrf52.cpp
+++ b/src/platform/nrf52/main-nrf52.cpp
@@ -4,13 +4,6 @@
 #include <InternalFileSystem.h>
 #include <SPI.h>
 #include <Wire.h>
-
-#define NRFX_WDT_ENABLED 1
-#define NRFX_WDT0_ENABLED 1
-#define NRFX_WDT_CONFIG_NO_IRQ 1
-#include <nrfx_wdt.c>
-#include <nrfx_wdt.h>
-
 #include <assert.h>
 #include <ble_gap.h>
 #include <memory.h>
@@ -25,9 +18,6 @@
 #ifdef BQ25703A_ADDR
 #include "BQ25713.h"
 #endif
-
-static nrfx_wdt_t nrfx_wdt = NRFX_WDT_INSTANCE(0);
-static nrfx_wdt_channel_id nrfx_wdt_channel_id_nrf52_main;
 
 static inline void debugger_break(void)
 {
@@ -212,15 +202,6 @@ void checkSDEvents()
 
 void nrf52Loop()
 {
-    {
-        static bool watchdog_running = false;
-        if (!watchdog_running) {
-            nrfx_wdt_enable(&nrfx_wdt);
-            watchdog_running = true;
-        }
-    }
-    nrfx_wdt_channel_feed(&nrfx_wdt, nrfx_wdt_channel_id_nrf52_main);
-
     checkSDEvents();
     reportLittleFSCorruptionOnce();
 }
@@ -288,20 +269,6 @@ void nrf52Setup()
     LOG_DEBUG("Set random seed %u", seed.seed32);
     randomSeed(seed.seed32);
     nRFCrypto.end();
-
-    // Set up nrfx watchdog. Do not enable the watchdog yet (we do that
-    // the first time through the main loop), so that other threads can
-    // allocate their own wdt channel to protect themselves from hangs.
-    nrfx_wdt_config_t wdt0_config = {
-        .behaviour = NRF_WDT_BEHAVIOUR_RUN_SLEEP, .reload_value = 2000,
-        // Note: Not using wdt interrupts.
-        // .interrupt_priority = NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-    };
-    nrfx_err_t r = nrfx_wdt_init(&nrfx_wdt, &wdt0_config,
-                                 nullptr // Watchdog event handler, not used, we just reset.
-    );
-
-    r = nrfx_wdt_channel_alloc(&nrfx_wdt, &nrfx_wdt_channel_id_nrf52_main);
 }
 
 void cpuDeepSleep(uint32_t msecToWake)


### PR DESCRIPTION
Reverts meshtastic/firmware#8485

Reverting this based upon discussions in Contributor Lounge and having three known good nRF52 radios (two T114, one Wio Tracker L1) suddenly start showing Critical Error 12 and 13 errors.

Examples:
https://discord.com/channels/867578229534359593/931765413350613052/1435481221420552293
https://discord.com/channels/867578229534359593/931765413350613052/1435487335340048416