### PR TITLE
Store hop/mqtt/transport mechanism info in S&F

### DIFF
--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -204,6 +204,10 @@ void StoreForwardModule::historyAdd(const meshtastic_MeshPacket &mp)
     this->packetHistory[this->packetHistoryTotalCount].payload_size = p.payload.size;
     this->packetHistory[this->packetHistoryTotalCount].rx_rssi = mp.rx_rssi;
     this->packetHistory[this->packetHistoryTotalCount].rx_snr = mp.rx_snr;
+    this->packetHistory[this->packetHistoryTotalCount].hop_start = mp.hop_start;
+    this->packetHistory[this->packetHistoryTotalCount].hop_limit = mp.hop_limit;
+    this->packetHistory[this->packetHistoryTotalCount].via_mqtt = mp.via_mqtt;
+    this->packetHistory[this->packetHistoryTotalCount].transport_mechanism = mp.transport_mechanism;
     memcpy(this->packetHistory[this->packetHistoryTotalCount].payload, p.payload.bytes, meshtastic_Constants_DATA_PAYLOAD_LEN);
 
     this->packetHistoryTotalCount++;
@@ -256,6 +260,10 @@ meshtastic_MeshPacket *StoreForwardModule::preparePayload(NodeNum dest, uint32_t
                 p->decoded.emoji = (uint32_t)this->packetHistory[i].emoji;
                 p->rx_rssi = this->packetHistory[i].rx_rssi;
                 p->rx_snr = this->packetHistory[i].rx_snr;
+                p->hop_start = this->packetHistory[i].hop_start;
+                p->hop_limit = this->packetHistory[i].hop_limit;
+                p->via_mqtt = this->packetHistory[i].via_mqtt;
+                p->transport_mechanism = (meshtastic_MeshPacket_TransportMechanism)this->packetHistory[i].transport_mechanism;
 
                 // Let's assume that if the server received the S&F request that the client is in range.
                 //   TODO: Make this configurable.

--- a/src/modules/StoreForwardModule.h
+++ b/src/modules/StoreForwardModule.h
@@ -21,6 +21,10 @@ struct PacketHistoryStruct {
     pb_size_t payload_size;
     int32_t rx_rssi;
     float rx_snr;
+    uint8_t hop_start;
+    uint8_t hop_limit;
+    bool via_mqtt;
+    uint8_t transport_mechanism;
 };
 
 class StoreForwardModule : private concurrency::OSThread, public ProtobufModule<meshtastic_StoreAndForward>


### PR DESCRIPTION
Before this, all messages received when enabling S&F server would return:

`Hops away: -1`

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [x] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Heltec wireless tracker v1.2
