### PR TITLE
modules: fix broadcasting neighbor info

### DIFF
--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -34,7 +34,7 @@ void NeighborInfoModule::printNodeDBNeighbors()
     }
 }
 
-/* Send our initial owner announcement 35 seconds after we start (to give network time to setup) */
+/* Neighbor info broadcasts start after the configured interval so we honor user pacing */
 NeighborInfoModule::NeighborInfoModule()
     : ProtobufModule("neighborinfo", meshtastic_PortNum_NEIGHBORINFO_APP, &meshtastic_NeighborInfo_msg),
       concurrency::OSThread("NeighborInfo")
@@ -44,7 +44,8 @@ NeighborInfoModule::NeighborInfoModule()
 
     if (moduleConfig.neighbor_info.enabled) {
         isPromiscuous = true; // Update neighbors from all packets
-        setIntervalFromNow(35 * 1000); // Send our initial broadcast roughly 35 seconds after boot
+        setIntervalFromNow(Default::getConfiguredOrDefaultMs(moduleConfig.neighbor_info.update_interval,
+                                                             default_telemetry_broadcast_interval_secs));
     } else {
         LOG_DEBUG("NeighborInfoModule is disabled");
         disable();


### PR DESCRIPTION
- ~~NeighborInfoModule now schedules its first run 35 s after boot as documented, instead of waiting for the full configured interval.~~ Scratched that.
- Neighbor broadcasts are emitted every cycle regardless of the currently known neighbor count, with an inline comment explaining why we keep sending empty payloads to bootstrap future discovery. This reverts #7493
- Neighbor cleanup is more forgiving: entries fall back to min_node_info_broadcast_secs when no interval is known and are only purged after 4× that duration, preventing premature eviction when RX is spotty.
- getOrCreateNeighbor() now normalizes zero-interval updates to min_node_info_broadcast_secs, ensuring we never store a 0 s interval that would trigger immediate cleanup, while still honoring explicit intervals from peers.
- attempt to fix #8581 

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)

~~These changes are untested as I want to gather feedback on the proposed changes first.~~ I'm currently testing this on my hardware. :hourglass_flowing_sand: 