### PR TITLE
Refactor RadioLibInterface to support multiple instances

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1034,7 +1034,7 @@ void Screen::setFrames(FrameFocus focus)
         indicatorIcons.push_back(icon_compass);
     }
 #endif
-    if (RadioLibInterface::instance && !hiddenFrames.lora) {
+    if (!RadioLibInterface::instances.empty() && !hiddenFrames.lora) {
         fsi.positions.lora = numframes;
         normalFrames[numframes++] = graphics::DebugRenderer::drawLoRaFocused;
         indicatorIcons.push_back(icon_radio);

--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -422,7 +422,7 @@ void drawLoRaFocused(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x,
     // === Fourth Row: Frequency / ChanNum ===
     char frequencyslot[35];
     char freqStr[16];
-    float freq = RadioLibInterface::instance->getFreq();
+    float freq = RadioLibInterface::instances.front()->getFreq();
     snprintf(freqStr, sizeof(freqStr), "%.3f", freq);
     if (config.lora.channel_num == 0) {
 #if defined(M5STACK_UNITC6L)

--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -189,7 +189,7 @@ int32_t ButtonThread::runOnce()
         case BUTTON_EVENT_LONG_PRESSED: {
             // Ignore if: TX in progress
             // Uncommon T-Echo hardware bug, LoRa TX triggers touch button
-            if (_touchQuirk && RadioLibInterface::instance && RadioLibInterface::instance->isSending())
+            if (_touchQuirk && !RadioLibInterface::instances.empty() && RadioLibInterface::instances.front()->isSending())
                 break;
 
             // Check if this is part of a short-press + long-press combination

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -100,7 +100,7 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
   public:
     /** Our ISR code currently needs this to find our active instance
      */
-    static RadioLibInterface *instance;
+    static std::vector<RadioLibInterface*> instances;
 
     /**
      * Glue functions called from ISR land

--- a/src/mesh/http/ContentHandler.cpp
+++ b/src/mesh/http/ContentHandler.cpp
@@ -694,8 +694,10 @@ void handleReport(HTTPRequest *req, HTTPResponse *res)
 
     // data->radio
     JSONObject jsonObjRadio;
-    jsonObjRadio["frequency"] = new JSONValue(RadioLibInterface::instance->getFreq());
-    jsonObjRadio["lora_channel"] = new JSONValue((int)RadioLibInterface::instance->getChannelNum() + 1);
+    if(!RadioLibInterface::instances.empty()) {
+        jsonObjRadio["frequency"] = new JSONValue(RadioLibInterface::instances.front()->getFreq());
+        jsonObjRadio["lora_channel"] = new JSONValue((int)RadioLibInterface::instances.front()->getChannelNum() + 1);
+    }
 
     // collect data to inner data object
     JSONObject jsonObjInner;

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -117,12 +117,12 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
     telemetry.variant.local_stats.air_util_tx = airTime->utilizationTXPercent();
     telemetry.variant.local_stats.num_online_nodes = numOnlineNodes;
     telemetry.variant.local_stats.num_total_nodes = nodeDB->getNumMeshNodes();
-    if (RadioLibInterface::instance) {
-        telemetry.variant.local_stats.num_packets_tx = RadioLibInterface::instance->txGood;
-        telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instance->rxGood + RadioLibInterface::instance->rxBad;
-        telemetry.variant.local_stats.num_packets_rx_bad = RadioLibInterface::instance->rxBad;
-        telemetry.variant.local_stats.num_tx_relay = RadioLibInterface::instance->txRelay;
-        telemetry.variant.local_stats.num_tx_dropped = RadioLibInterface::instance->txDrop;
+    if (!RadioLibInterface::instances.empty()) {
+        telemetry.variant.local_stats.num_packets_tx = RadioLibInterface::instances.front()->txGood;
+        telemetry.variant.local_stats.num_packets_rx = RadioLibInterface::instances.front()->rxGood + RadioLibInterface::instances.front()->rxBad;
+        telemetry.variant.local_stats.num_packets_rx_bad = RadioLibInterface::instances.front()->rxBad;
+        telemetry.variant.local_stats.num_tx_relay = RadioLibInterface::instances.front()->txRelay;
+        telemetry.variant.local_stats.num_tx_dropped = RadioLibInterface::instances.front()->txDrop;
     }
 #ifdef ARCH_PORTDUINO
     if (SimRadio::instance) {

--- a/variants/nrf52840/t-echo/nicheGraphics.h
+++ b/variants/nrf52840/t-echo/nicheGraphics.h
@@ -105,7 +105,7 @@ void setupNicheGraphics()
     buttons->setHandlerDown(1, [inkhud, backlight]() {
         // Discard the button press if radio is active
         // Rare hardware fault: LoRa activity triggers touch button
-        if (!RadioLibInterface::instance || RadioLibInterface::instance->isSending())
+        if (RadioLibInterface::instances.empty() || RadioLibInterface::instances.front()->isSending())
             return;
 
         // Backlight on (while held)


### PR DESCRIPTION
These changes make it possible to determine which LoRa module triggered the interrupt by reading the GPIO state.
This allows for creating multiple instances of RadioLibInterface.

https://github.com/meshtastic/firmware/discussions/3831

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V4
  - [x] Seeed Studio T-1000E tracker card
