### PR TITLE
stm32wl: claw back slightly more flash space

### DIFF
--- a/arch/stm32/stm32.ini
+++ b/arch/stm32/stm32.ini
@@ -37,6 +37,9 @@ build_flags =
   -DRADIOLIB_EXCLUDE_LR11X0=1
   -DHAL_DAC_MODULE_ONLY
   -DHAL_RNG_MODULE_ENABLED
+  -Wl,--wrap=__assert_func
+  -Wl,--wrap=strerror
+  -Wl,--wrap=_tzset_unlocked_r
 
 build_src_filter =
   ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<mesh/api/> -<mesh/wifi/> -<mesh/http/> -<modules/esp32> -<mesh/eth/> -<input> -<buzz> -<modules/RemoteHardwareModule.cpp> -<platform/nrf52> -<platform/portduino> -<platform/rp2xx0> -<mesh/raspihttp>

--- a/src/platform/stm32wl/main-stm32wl.cpp
+++ b/src/platform/stm32wl/main-stm32wl.cpp
@@ -26,3 +26,31 @@ void getMacAddr(uint8_t *dmac)
 }
 
 void cpuDeepSleep(uint32_t msecToWake) {}
+
+// Hacks to force more code and data out.
+
+// By default __assert_func uses fiprintf which pulls in stdio.
+extern "C" void __wrap___assert_func(const char *, int, const char *, const char *)
+{
+    while (true)
+        ;
+    return;
+}
+
+// By default strerror has a lot of strings we probably don't use. Make it return an empty string instead.
+char empty = 0;
+extern "C" char *__wrap_strerror(int)
+{
+    return &empty;
+}
+
+#ifdef MESHTASTIC_EXCLUDE_TZ
+struct _reent;
+
+// Even if you don't use timezones, mktime will try to set the timezone anyway with _tzset_unlocked(), which pulls in scanf and
+// friends. The timezone is initialized to UTC by default.
+extern "C" void __wrap__tzset_unlocked_r(struct _reent *reent_ptr)
+{
+    return;
+}
+#endif


### PR DESCRIPTION
Before PR: doesn't fit - region `FLASH' overflowed by 220 bytes
After wrapping __assert_func: 2492 bytes free
After wrapping strerror: 5156 bytes free
After wrapping tzset: 8472 bytes free

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] wio-e5