### PR TITLE
Congestion: Always Ignore MQTT by default

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -141,9 +141,6 @@ void menuHandler::LoraRegionPicker(uint32_t duration)
             }
             config.lora.tx_enabled = true;
             initRegion();
-            if (myRegion->dutyCycle < 100) {
-                config.lora.ignore_mqtt = true; // Ignore MQTT by default if region has a duty cycle limit
-            }
 
             if (strncmp(moduleConfig.mqtt.root, default_mqtt_root, strlen(default_mqtt_root)) == 0) {
                 //  Default broker is in use, so subscribe to the appropriate MQTT root topic for this region

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -582,7 +582,7 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 #ifdef USERPREFS_CONFIG_LORA_IGNORE_MQTT
     config.lora.ignore_mqtt = USERPREFS_CONFIG_LORA_IGNORE_MQTT;
 #else
-    config.lora.ignore_mqtt = false;
+    config.lora.ignore_mqtt = true;
 #endif
     // Initialize admin_key_count to zero
     byte numAdminKeys = 0;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -793,9 +793,6 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
             }
             config.lora.tx_enabled = true;
             initRegion();
-            if (myRegion->dutyCycle < 100) {
-                config.lora.ignore_mqtt = true; // Ignore MQTT by default if region has a duty cycle limit
-            }
             //  Compare the entire string, we are sure of the length as a topic has never been set
             if (strcmp(moduleConfig.mqtt.root, default_mqtt_root) == 0) {
                 sprintf(moduleConfig.mqtt.root, "%s/%s", default_mqtt_root, myRegion->name);


### PR DESCRIPTION
It's no secret that one poorly configured MQTT Downlink can send a mesh into a tailspin.

We currently Ignore MQTT in regions with *any* duty cycle imposed, I propose we simply extend this to be globally ignored as a more sensible default. Effectively this prevents MQTT messages from propagating through an RF network without explicitly opting in.