### PR TITLE
Reset the calibration data back to 0 when doing a compass calibration

### DIFF
--- a/src/motion/BMX160Sensor.cpp
+++ b/src/motion/BMX160Sensor.cpp
@@ -116,6 +116,7 @@ void BMX160Sensor::calibrate(uint16_t forSeconds)
 {
 #if !defined(MESHTASTIC_EXCLUDE_SCREEN)
     LOG_DEBUG("BMX160 calibration started for %is", forSeconds);
+    highestX = 0, lowestX = 0, highestY = 0, lowestY = 0, highestZ = 0, lowestZ = 0;
 
     doCalibration = true;
     uint16_t calibrateFor = forSeconds * 1000; // calibrate for seconds provided

--- a/src/motion/ICM20948Sensor.cpp
+++ b/src/motion/ICM20948Sensor.cpp
@@ -157,6 +157,7 @@ void ICM20948Sensor::calibrate(uint16_t forSeconds)
 {
 #if !defined(MESHTASTIC_EXCLUDE_SCREEN) && HAS_SCREEN
     LOG_DEBUG("BMX160 calibration started for %is", forSeconds);
+    highestX = 0, lowestX = 0, highestY = 0, lowestY = 0, highestZ = 0, lowestZ = 0;
 
     doCalibration = true;
     uint16_t calibrateFor = forSeconds * 1000; // calibrate for seconds provided


### PR DESCRIPTION
Realized that our compass calibration routine can only ever increase the values, not reduce them. Was leading to compass inaccuracy. 