### PR TITLE
Remove gating for Display Options

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -581,11 +581,8 @@ void menuHandler::systemBaseMenu()
 
     optionsArray[options] = "Notifications";
     optionsEnumArray[options++] = Notifications;
-#if defined(ST7789_CS) || defined(ST7796_CS) || defined(USE_OLED) || defined(USE_SSD1306) || defined(USE_SH1106) ||              \
-    defined(USE_SH1107) || defined(HELTEC_MESH_NODE_T114) || defined(HELTEC_VISION_MASTER_T190) || HAS_TFT
     optionsArray[options] = "Display Options";
     optionsEnumArray[options++] = ScreenOptions;
-#endif
 
 #if defined(M5STACK_UNITC6L)
     optionsArray[options] = "Bluetooth";


### PR DESCRIPTION
- Remove gating for Display Options
- Allow for all devices to enter the Display Options menu