### PR TITLE
mqtt: do not try to send packets when it disconnected

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -51,6 +51,7 @@ constexpr int reconnectMax = 5;
 static uint8_t bytes[meshtastic_MqttClientProxyMessage_size + 30]; // 12 for channel name and 16 for nodeid
 
 static bool isMqttServerAddressPrivate = false;
+static bool isConnected = false;
 
 inline void onReceiveProto(char *topic, byte *payload, size_t length)
 {
@@ -320,8 +321,10 @@ bool connectPubSub(const PubSubConfig &config, PubSubClient &pubSub, Client &cli
     std::string nodeId = nodeDB->getNodeId();
     const bool connected = pubSub.connect(nodeId.c_str(), config.mqttUsername, config.mqttPassword);
     if (connected) {
+        isConnected = true;
         LOG_INFO("MQTT connected");
     } else {
+        isConnected = false;
         LOG_WARN("Failed to connect to MQTT server");
     }
     return connected;
@@ -507,6 +510,7 @@ bool MQTT::publish(const char *topic, const uint8_t *payload, size_t length, boo
 
 void MQTT::reconnect()
 {
+    isConnected = false;
     if (wantsLink()) {
         if (moduleConfig.mqtt.proxy_to_client_enabled) {
             LOG_INFO("MQTT connect via client proxy instead");
@@ -534,7 +538,7 @@ void MQTT::reconnect()
             runASAP = true;
             reconnectCount = 0;
             isMqttServerAddressPrivate = isPrivateIpAddress(clientConnection->remoteIP());
-
+            isConnected = true;
             publishNodeInfo();
             sendSubscriptions();
         } else {
@@ -688,7 +692,7 @@ void MQTT::publishNodeInfo()
 }
 void MQTT::publishQueuedMessages()
 {
-    if (mqttQueue.isEmpty())
+    if (mqttQueue.isEmpty() || !isConnected)
         return;
 
     LOG_DEBUG("Publish enqueued MQTT message");


### PR DESCRIPTION
While testing our network's performance during internet outages, we encountered some strange behavior. When the connection to the mqtt server is temporary unstable or completely disconnected, messages are either lost or delayed in their transmission over the air. These changes eliminate situations where attempts are made to send messages while the connection to the mqtt server is down.

To reproduce such behavior you can enable the mqtt module and enable uplink/downlink on the primary channel, then block mqtt traffic for the node on the internet gateway via iptables or something like that.

- [X ] I have tested that my proposed changes behave as described.
- [ X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ X] Heltec (Lora32) V3
  - [ X] Heltec (Lora32) V4
