### PR TITLE
Linux: Fix silly EPEL9 mistake

### DIFF
--- a/meshtasticd.spec.rpkg
+++ b/meshtasticd.spec.rpkg
@@ -50,7 +50,7 @@ BuildRequires: pkgconfig(libinput)
 BuildRequires: pkgconfig(xkbcommon-x11)
 
 # libbsd is needed on older Fedora/RHEL to provide 'strlcpy'
-%if 0%{?fedora} >= 41 || 0%{?rhel} >= 9
+%if 0%{?fedora} >= 39 || 0%{?rhel} >= 10
 BuildRequires: glibc-devel >= 2.38
 %else
 BuildRequires: pkgconfig(libbsd-overlay)


### PR DESCRIPTION
Addendum to #8659
Embarrassing! EPEL9 does not have `glibc >= 2.38`! And it was added in Fedora `39` not `41` (not that it matters much). Should be all good now.