### PR TITLE
mqtt: obey own ok2mqtt flag

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -746,10 +746,16 @@ void MQTT::onSend(const meshtastic_MeshPacket &mp_encrypted, const meshtastic_Me
         // For uplinking other's packets, check if it's not OK to MQTT or if it's an older packet without the bitfield
         bool dontUplink = !mp_decoded.decoded.has_bitfield || !(mp_decoded.decoded.bitfield & BITFIELD_OK_TO_MQTT_MASK);
         // check for the lowest bit of the data bitfield set false, and the use of one of the default keys.
-        if (!isFromUs(&mp_decoded) && !isMqttServerAddressPrivate && dontUplink &&
+        if (!isFromUs(&mp_decoded)) {
+            if (!isMqttServerAddressPrivate && dontUplink &&
             (ch.settings.psk.size < 2 || (ch.settings.psk.size == 16 && memcmp(ch.settings.psk.bytes, defaultpsk, 16)) ||
              (ch.settings.psk.size == 32 && memcmp(ch.settings.psk.bytes, eventpsk, 32)))) {
-            LOG_INFO("MQTT onSend - Not forwarding packet due to DontMqttMeBro flag");
+                LOG_INFO("MQTT onSend - Not forwarding packet due to DontMqttMeBro flag");
+                return;
+             }
+        }
+        else if (!config.lora.config_ok_to_mqtt) {
+            LOG_INFO("MQTT onSend - this is our packet and we are not OK to send it to MQTT");
             return;
         }
 


### PR DESCRIPTION
When the MQTT module is enabled and the channel has an MQTT uplink enabled, all packets from this node are sent to the MQTT topic, regardless of whether the ok_to_mqtt flag is set.
This change is intended to correct this behavior and ensure that the ok_to_mqtt flag is respected for packets sent from the node.
This behavior is useful when you want to act as an MQTT gateway for other nodes but don't want to send your own packets to the internet.

- [X ] I have tested that my proposed changes behave as described.
- [ X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V4
