### PR TITLE
CI: Submit Bump Version PR against master

### DIFF
--- a/.github/workflows/release_channels.yml
+++ b/.github/workflows/release_channels.yml
@@ -61,6 +61,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Always use master branch for version bumps
+          ref: master
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Simple change requested by @thebentern -- use `master` as the base for version bump PRs.
The PR is automatically submitted against the branch it was checked-out from :+1: 