### PR TITLE
Simplify CannedMessageModule::drawHeader

### DIFF
--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -191,20 +191,17 @@ int CannedMessageModule::splitConfiguredMessages()
 
     return this->messagesCount;
 }
+
 void CannedMessageModule::drawHeader(OLEDDisplay *display, int16_t x, int16_t y, char *buffer)
 {
-    if (graphics::isHighResolution) {
-        if (this->dest == NODENUM_BROADCAST) {
-            display->drawStringf(x, y, buffer, "To: Broadcast@%s", channels.getName(this->channel));
-        } else {
-            display->drawStringf(x, y, buffer, "To: %s", getNodeName(this->dest));
+    if (this->dest == NODENUM_BROADCAST) {
+        const char *broadcastString = "To: Broadcast@%s";
+        if (!graphics::isHighResolution) {
+            broadcastString = "To: Broadc@%.5s";
         }
+        display->drawStringf(x, y, buffer, broadcastString, channels.getName(this->channel));
     } else {
-        if (this->dest == NODENUM_BROADCAST) {
-            display->drawStringf(x, y, buffer, "To: Broadc@%.5s", channels.getName(this->channel));
-        } else {
-            display->drawStringf(x, y, buffer, "To: %s", getNodeName(this->dest));
-        }
+        display->drawStringf(x, y, buffer, "To: %s", getNodeName(this->dest));
     }
 }
 


### PR DESCRIPTION
Deduplicates some of the implementation and saves ~112 bytes of flash memory. Behavior is unchanged.

It builds locally and existing tests pass but there is no coverage for this change. I don't have screen hardware necessary to test for regressions. Help here is appreciated.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
