### PR TITLE
Add a reset pulse signal to the OLED.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -479,9 +479,8 @@ void setup()
     digitalWrite(RESET_OLED, 1);
     delay(2);
     digitalWrite(RESET_OLED, 0);
-    delay(2);
+    delay(10);
     digitalWrite(RESET_OLED, 1);
-    delay(2);
 #endif
 
 #ifdef SENSOR_POWER_CTRL_PIN


### PR DESCRIPTION
For some OLED screens, a clear reset signal is required before they can function properly.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] Heltec (Lora32) V4

