### PR TITLE
Fix MenuHandler when MESHTASTIC_EXCLUDE_PKI is defined

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -119,6 +119,7 @@ void menuHandler::LoraRegionPicker(uint32_t duration)
             auto changes = SEGMENT_CONFIG;
 
             // This is needed as we wait til picking the LoRa region to generate keys for the first time.
+#if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
             if (!owner.is_licensed) {
                 bool keygenSuccess = false;
                 if (config.security.private_key.size == 32) {
@@ -139,6 +140,7 @@ void menuHandler::LoraRegionPicker(uint32_t duration)
                     memcpy(owner.public_key.bytes, config.security.public_key.bytes, 32);
                 }
             }
+#endif
             config.lora.tx_enabled = true;
             initRegion();
             if (myRegion->dutyCycle < 100) {


### PR DESCRIPTION
The build is broken if MESHTASTIC_EXCLUDE_PKI is set.

This was missed in #8698 since the t1000e variant doesn't build MenuHandler. Rak4631 does.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
