### PR TITLE
M6 leds

### DIFF
--- a/variants/nrf52840/ELECROW-ThinkNode-M6/variant.cpp
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/variant.cpp
@@ -32,11 +32,11 @@ const uint32_t g_ADigitalPinMap[] = {
 
 void initVariant()
 {
-    pinMode(PIN_LED1, OUTPUT);
-    ledOff(PIN_LED1);
+    pinMode(LED_CHARGE, OUTPUT);
+    ledOff(LED_CHARGE);
 
-    pinMode(PIN_LED2, OUTPUT);
-    ledOff(PIN_LED2);
+    pinMode(LED_PAIRING, OUTPUT);
+    ledOff(LED_PAIRING);
 
     pinMode(VDD_FLASH_EN, OUTPUT);
     digitalWrite(VDD_FLASH_EN, HIGH);

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
@@ -40,10 +40,11 @@ extern "C" {
 #define NUM_ANALOG_OUTPUTS (0)
 
 // LEDs
-#define PIN_LED1 (12)
-#define PIN_LED2 (7)
-#define LED_BUILTIN PIN_LED1
-#define LED_BLUE PIN_LED2
+#define LED_BUILTIN -1
+#define LED_BLUE -1
+#define LED_CHARGE (12)
+#define LED_PAIRING (7)
+
 #define LED_STATE_ON 1
 
 // USB power detection


### PR DESCRIPTION
Use the new StatusLEDModule for the Thinknode m6. This assumes the red LED is to indicate the charging state, and the Blue LED is to indicate BLE state