### PR TITLE
More quickly hide "Shutting Down" to prevent it showing on Eink sleep screen

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -759,6 +759,8 @@ void Power::shutdown()
     if (screen) {
 #ifdef T_DECK_PRO
         screen->showSimpleBanner("Device is powered off.\nConnect USB to start!", 0); // T-Deck Pro has no power button
+#elif USE_EINK
+        screen->showSimpleBanner("Shutting Down...", 2250); // dismiss after 3 seconds to avoid the banner on the sleep screen
 #else
         screen->showSimpleBanner("Shutting Down...", 0); // stays on screen
 #endif


### PR DESCRIPTION
- Set timeout of 2.25 seconds to prevent "Shutting Down" from showing on Eink sleep screen