### PR TITLE
Swap GPS pins for GPS TX/RX only for T114/T-Echo

### DIFF
--- a/variants/nrf52840/heltec_mesh_node_t114/variant.h
+++ b/variants/nrf52840/heltec_mesh_node_t114/variant.h
@@ -167,8 +167,8 @@ No longer populated on PCB
 #define PIN_GPS_PPS (32 + 4)
 // Seems to be missing on this new board
 // #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 5) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 7) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 7) // This is for bits going TOWARDS the CPU
+#define GPS_RX_PIN (32 + 5) // This is for bits going TOWARDS the GPS
 
 #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/t-echo/variant.h
+++ b/variants/nrf52840/t-echo/variant.h
@@ -182,8 +182,8 @@ External serial flash WP25R1635FZUIL0
 #define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
 // Seems to be missing on this new board
 // #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 9) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 8) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 8) // This is for bits going TOWARDS the CPU
+#define GPS_RX_PIN (32 + 9) // This is for bits going TOWARDS the GPS
 
 #define GPS_THREAD_INTERVAL 50
 


### PR DESCRIPTION
Swap GPS pins for GPS TX/RX respectively - issue was identified in https://github.com/meshtastic/firmware/pull/8486