### PR TITLE
Renovate: fix BH1750_WE

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -182,8 +182,8 @@ lib_deps =
 	dfrobot/DFRobot_BMM150@1.0.0
 	# renovate: datasource=custom.pio depName=Adafruit_TSL2561 packageName=adafruit/library/Adafruit TSL2561
 	adafruit/Adafruit TSL2561@1.1.2
-	# renovate: datasource=custom.pio depName=BH1750_WE packageName=wollewald/BH1750_WE@^1.1.10
-	wollewald/BH1750_WE@^1.1.10
+	# renovate: datasource=custom.pio depName=BH1750_WE packageName=wollewald/library/BH1750_WE
+	wollewald/BH1750_WE@1.1.10
 
 ; (not included in native / portduino)
 [environmental_extra]


### PR DESCRIPTION
Fix dependency lookup warnings in Renovate for `wollewald/BH1750_WE`