### PR TITLE
Make GPS_TX_PIN the serial TX and GPS_RX_PIN the serial RX for all NRF variants

### DIFF
--- a/variants/nrf52840/ELECROW-ThinkNode-M1/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/variant.h
@@ -157,15 +157,15 @@ External serial flash WP25R1635FZUIL0
 #define PIN_GPS_STANDBY (32 + 2) // An output to wake GPS, low means allow sleep, high means force wake
 // Seems to be missing on this new board
 // #define PIN_GPS_PPS (32 + 4)  // Pulse per second input from the GPS
-#define GPS_TX_PIN (32 + 9) // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (32 + 8) // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (32 + 8) // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (32 + 9) // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 
 #define PIN_GPS_SWITCH (32 + 1) // GPS开关判断
 
-#define PIN_SERIAL1_RX GPS_TX_PIN
-#define PIN_SERIAL1_TX GPS_RX_PIN
+#define PIN_SERIAL1_TX GPS_TX_PIN
+#define PIN_SERIAL1_RX GPS_RX_PIN
 
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/variant.h
@@ -78,11 +78,11 @@ extern "C" {
 #define GPS_BAUDRATE 9600
 #define PIN_GPS_RESET 25
 #define PIN_GPS_STANDBY 21
-#define GPS_TX_PIN 20
-#define GPS_RX_PIN 22
+#define GPS_TX_PIN 22
+#define GPS_RX_PIN 20
 #define GPS_THREAD_INTERVAL 50
-#define PIN_SERIAL1_RX GPS_TX_PIN
-#define PIN_SERIAL1_TX GPS_RX_PIN
+#define PIN_SERIAL1_TX GPS_TX_PIN
+#define PIN_SERIAL1_RX GPS_RX_PIN
 // Button
 #define BUTTON_PIN 12
 #define BUTTON_PIN_ALT (0 + 12)

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
@@ -107,12 +107,12 @@ static const uint8_t A0 = PIN_A0;
 #define PIN_GPS_REINIT (29)
 #define PIN_GPS_STANDBY (30)
 #define PIN_GPS_PPS (31)
-#define GPS_TX_PIN (3)
-#define GPS_RX_PIN (2)
+#define GPS_TX_PIN (2)
+#define GPS_RX_PIN (3)
 #define GPS_THREAD_INTERVAL 50
 
-#define PIN_SERIAL1_RX GPS_TX_PIN
-#define PIN_SERIAL1_TX GPS_RX_PIN
+#define PIN_SERIAL1_TX GPS_TX_PIN
+#define PIN_SERIAL1_RX GPS_RX_PIN
 
 // Secondary UART
 #define PIN_SERIAL2_RX (22)

--- a/variants/nrf52840/canaryone/variant.h
+++ b/variants/nrf52840/canaryone/variant.h
@@ -128,13 +128,13 @@ static const uint8_t A0 = PIN_A0;
 // #define PIN_GPS_WAKE (GPIO_PORT1 + 2) // An output to wake GPS, low means allow sleep, high means force wake
 // Seems to be missing on this new board
 #define PIN_GPS_PPS (GPIO_PORT1 + 4) // Pulse per second input from the GPS
-#define GPS_TX_PIN (GPIO_PORT1 + 9)  // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN (GPIO_PORT1 + 8)  // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN (GPIO_PORT1 + 8)  // This is for bits going TOWARDS the GPS
+#define GPS_RX_PIN (GPIO_PORT1 + 9)  // This is for bits going TOWARDS the CPU
 
 #define GPS_THREAD_INTERVAL 50
 
-#define PIN_SERIAL1_RX GPS_TX_PIN
-#define PIN_SERIAL1_TX GPS_RX_PIN
+#define PIN_SERIAL1_RX GPS_RX_PIN
+#define PIN_SERIAL1_TX GPS_TX_PIN
 
 #define GPS_RESET_PIN (GPIO_PORT1 + 5) // GPS reset pin
 

--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/variant.h
@@ -90,16 +90,16 @@ NRF52 PRO MICRO PIN ASSIGNMENT
 #define BUTTON_PIN (32 + 0) // P1.00
 
 // GPS
-#define PIN_GPS_TX (0 + 22) // P0.22
-#define PIN_GPS_RX (0 + 20) // P0.20
+#define PIN_GPS_TX (0 + 20) // P0.20
+#define PIN_GPS_RX (0 + 22) // P0.22
 
 #define PIN_GPS_EN (0 + 24) // P0.24
 #define GPS_UBLOX
 // define GPS_DEBUG
 
 // UART interfaces
-#define PIN_SERIAL1_RX PIN_GPS_TX
-#define PIN_SERIAL1_TX PIN_GPS_RX
+#define PIN_SERIAL1_TX PIN_GPS_TX
+#define PIN_SERIAL1_RX PIN_GPS_RX
 
 #define PIN_SERIAL2_RX (0 + 6) // P0.06
 #define PIN_SERIAL2_TX (0 + 8) // P0.08

--- a/variants/nrf52840/meshlink/variant.h
+++ b/variants/nrf52840/meshlink/variant.h
@@ -121,8 +121,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 #define PIN_GPS_PPS (26) // Pulse per second input from the GPS
 
-#define GPS_TX_PIN PIN_SERIAL1_RX // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN PIN_SERIAL1_TX // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN PIN_SERIAL1_TX // This is for bits going TOWARDS the CPU
+#define GPS_RX_PIN PIN_SERIAL1_RX // This is for bits going TOWARDS the GPS
 
 // #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/meshlink_eink/variant.h
+++ b/variants/nrf52840/meshlink_eink/variant.h
@@ -121,8 +121,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 
 #define PIN_GPS_PPS (26) // Pulse per second input from the GPS
 
-#define GPS_TX_PIN PIN_SERIAL1_RX // This is for bits going TOWARDS the CPU
-#define GPS_RX_PIN PIN_SERIAL1_TX // This is for bits going TOWARDS the GPS
+#define GPS_TX_PIN PIN_SERIAL1_TX // This is for bits going TOWARDS the CPU
+#define GPS_RX_PIN PIN_SERIAL1_RX // This is for bits going TOWARDS the GPS
 
 // #define GPS_THREAD_INTERVAL 50
 

--- a/variants/nrf52840/nano-g2-ultra/variant.h
+++ b/variants/nrf52840/nano-g2-ultra/variant.h
@@ -132,13 +132,13 @@ External serial flash W25Q16JV_IQ
 #define GPS_L76K
 
 #define PIN_GPS_STANDBY (0 + 13) // An output to wake GPS, low means allow sleep, high means force wake STANDBY
-#define PIN_GPS_TX (0 + 9)       // This is for bits going TOWARDS the CPU
-#define PIN_GPS_RX (0 + 10)      // This is for bits going TOWARDS the GPS
+#define PIN_GPS_TX (0 + 10)      // This is for bits going TOWARDS the CPU
+#define PIN_GPS_RX (0 + 9)       // This is for bits going TOWARDS the GPS
 
 // #define GPS_THREAD_INTERVAL 50
 
-#define PIN_SERIAL1_RX PIN_GPS_TX
-#define PIN_SERIAL1_TX PIN_GPS_RX
+#define PIN_SERIAL1_TX PIN_GPS_TX
+#define PIN_SERIAL1_RX PIN_GPS_RX
 
 // PCF8563 RTC Module
 #define PCF8563_RTC 0x51

--- a/variants/nrf52840/seeed_solar_node/variant.h
+++ b/variants/nrf52840/seeed_solar_node/variant.h
@@ -115,13 +115,13 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #define GPS_L76K
 #ifdef GPS_L76K
-#define PIN_GPS_RX D6 // 44
-#define PIN_GPS_TX D7 // 43
+#define PIN_GPS_TX D6 // 44
+#define PIN_GPS_RX D7 // 43
 #define HAS_GPS 1
 #define GPS_BAUDRATE 9600
 #define GPS_THREAD_INTERVAL 50
-#define PIN_SERIAL1_RX PIN_GPS_TX
-#define PIN_SERIAL1_TX PIN_GPS_RX
+#define PIN_SERIAL1_TX PIN_GPS_TX
+#define PIN_SERIAL1_RX PIN_GPS_RX
 #define PIN_GPS_STANDBY D0
 #define GPS_EN D18 // P1.05
 #endif

--- a/variants/nrf52840/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/nrf52840/seeed_xiao_nrf52840_kit/variant.h
@@ -147,12 +147,12 @@ static const uint8_t SCK = PIN_SPI_SCK;
  */
 // GPS L76K
 #ifdef GPS_L76K
-#define PIN_GPS_RX D6
-#define PIN_GPS_TX D7
+#define PIN_GPS_TX D6
+#define PIN_GPS_RX D7
 #define HAS_GPS 1
 #define GPS_THREAD_INTERVAL 50
-#define PIN_SERIAL1_RX PIN_GPS_TX
-#define PIN_SERIAL1_TX PIN_GPS_RX
+#define PIN_SERIAL1_TX PIN_GPS_TX
+#define PIN_SERIAL1_RX PIN_GPS_RX
 #define PIN_GPS_STANDBY D0
 #else
 #define PIN_SERIAL1_RX (-1)


### PR DESCRIPTION
https://github.com/meshtastic/firmware/pull/8486 inadvertantly changed the behaviour of the GPS_TX_PIN and GPS_RX_PIN defines on non-ESP32 architectures - GPS_TX_PIN is now the serial TX pin and GPS_RX_PIN is the serial RX pin, rather than being some combination defined per variant. This was already the behaviour on ESP32 platforms.
Try to straighten it out.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
