### PR TITLE
modules: serial: add text message mode looking at detection sensor port only

### DIFF
--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -85,7 +85,9 @@ typedef enum _meshtastic_ModuleConfig_SerialConfig_Serial_Mode {
     meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT = 7,
     /* Used to configure and view some parameters of MeshSolar.
 https://heltec.org/project/meshsolar/ */
-    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG = 8
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG = 8,
+    /* Text messages from detection sensor app port only */
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DETECTION_SENSOR_APP_TEXTMSG = 9
 } meshtastic_ModuleConfig_SerialConfig_Serial_Mode;
 
 /* TODO: REPLACE */

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -119,6 +119,9 @@ SerialModuleRadio::SerialModuleRadio() : MeshModule("SerialModuleRadio")
     case meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO:
         ourPortNum = meshtastic_PortNum_POSITION_APP;
         break;
+    case meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DETECTION_SENSOR_APP_TEXTMSG:
+        ourPortNum = meshtastic_PortNum_DETECTION_SENSOR_APP;
+        break;
     default:
         ourPortNum = meshtastic_PortNum_SERIAL_APP;
         // restrict to the serial channel for rx
@@ -402,7 +405,8 @@ ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp
             if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT ||
                 moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_SIMPLE) {
                 serialPrint->write(p.payload.bytes, p.payload.size);
-            } else if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_TEXTMSG) {
+            } else if (moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_TEXTMSG ||
+                        moduleConfig.serial.mode == meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DETECTION_SENSOR_APP_TEXTMSG) {
                 meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(getFrom(&mp));
                 const char *sender = (node && node->has_user) ? node->user.short_name : "???";
                 serialPrint->println();

--- a/test/test_serial/SerialModule.cpp
+++ b/test/test_serial/SerialModule.cpp
@@ -71,11 +71,17 @@ void test_serialConfigWithOverrideConsoleSimpleModeIsInvalid(void)
     TEST_ASSERT_FALSE(SerialModule::isValidConfig(config));
 }
 
-// Test that configuration with override_console_serial_port and TEXTMSG mode is invalid.
+// Test that configuration with override_console_serial_port and TEXTMSG or DETECTION_SENSOR_APP_TEXTMSG mode is invalid.
 void test_serialConfigWithOverrideConsoleTextMsgModeIsInvalid(void)
 {
-    meshtastic_ModuleConfig_SerialConfig config = {
+    meshtastic_ModuleConfig_SerialConfig config;
+    config = {
         .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_TEXTMSG};
+
+    TEST_ASSERT_FALSE(SerialModule::isValidConfig(config));
+
+    config = {
+        .enabled = true, .override_console_serial_port = true, .mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DETECTION_SENSOR_APP_TEXTMSG};
 
     TEST_ASSERT_FALSE(SerialModule::isValidConfig(config));
 }
@@ -116,6 +122,10 @@ void test_serialConfigVariousModesWithoutOverrideAreValid(void)
 
     // Test CALTOPO mode
     config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_CALTOPO;
+    TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
+
+    // Test DETECTION_SENSOR_APP_TEXTMSG mode
+    config.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DETECTION_SENSOR_APP_TEXTMSG;
     TEST_ASSERT_TRUE(SerialModule::isValidConfig(config));
 }
 


### PR DESCRIPTION
Its my first PR here, so apologies if I have gotten anything wrong. 

I was a little surprised that the detection sensor app messages were showing up as messages on android but not being output over the serial port with the text message mode. This adds a new mode to only output messages received on that port. This allows me to easily interface remote sensors using the detection sensor module with a base node running the serial module.

Tested with a pair of Heltec (Lora32) V3 nodes.