### PR TITLE
Remove screen activation in powerExit function

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -219,8 +219,6 @@ static void powerIdle()
 
 static void powerExit()
 {
-    if (screen)
-        screen->setOn(true);
     setBluetoothEnable(true);
 }
 


### PR DESCRIPTION
This seems to be a potential source of unintended screen wakes.
Only tested with the Hackaday Communicator so far.