### PR TITLE
Revert the Revert "Fix Station G2 Lora Power Settings"

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -126,6 +126,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TX_GAIN_LORA 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10, 9, 9, 8, 7
 #endif
 
+#ifdef STATION_G2
+#define NUM_PA_POINTS 19
+#define TX_GAIN_LORA 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 19, 19, 18, 18
+#endif
+
 #ifdef RAK13302
 #define NUM_PA_POINTS 22
 #define TX_GAIN_LORA 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 8


### PR DESCRIPTION
There is no need for any 'an additional lora param to handle line loss gain compensation'! https://github.com/meshtastic/firmware/issues/8445

This revert fixing the issue should never have been merged: https://github.com/meshtastic/firmware/pull/8332

This PR here is fixing https://github.com/meshtastic/firmware/issues/8440