### PR TITLE
InkHUD: Replace assert in UTF8 decoder to prevent unexpected reboot

### DIFF
--- a/src/graphics/niche/InkHUD/AppletFont.cpp
+++ b/src/graphics/niche/InkHUD/AppletFont.cpp
@@ -124,7 +124,7 @@ uint32_t InkHUD::AppletFont::toUtf32(std::string utf8)
         utf32 |= (utf8.at(3) & 0b00111111);
         break;
     default:
-        assert(false);
+        return 0;
     }
 
     return utf32;


### PR DESCRIPTION
Fixes a reboot caused when InkHUD received a malformed UTF8 character. The old decoder used an assert on invalid UTF8 lengths, which triggered a reboot during message rendering. This change replaces the assert with a safe fallback so malformed characters no longer crash the device.

Need to test to recreate the issue discussed on https://github.com/meshtastic/firmware/issues/8806 and see if this really solves the original issue.