### PR TITLE
Add 'cleanup' to required PR labels

### DIFF
--- a/.github/workflows/pr_enforce_labels.yml
+++ b/.github/workflows/pr_enforce_labels.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(label => label.name);
-            const requiredLabels = ['bugfix', 'enhancement', 'hardware-support', 'dependencies', 'submodules', 'github_actions', 'trunk'];
+            const requiredLabels = ['bugfix', 'enhancement', 'hardware-support', 'dependencies', 'submodules', 'github_actions', 'trunk', 'cleanup'];
             const hasRequiredLabel = labels.some(label => requiredLabels.includes(label));
             if (!hasRequiredLabel) {
               core.setFailed(`PR must have at least one of the following labels before it can be merged: ${requiredLabels.join(', ')}.`);


### PR DESCRIPTION
I added a "cleanup" label, now making it pass the enforce-label check.