### PR TITLE
Fix command syntax for erase and write flash

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -216,8 +216,8 @@ if [ -f "${FILENAME}" ] && [ -n "${FILENAME##*"update"*}" ]; then
     fi
 
     echo "Trying to flash ${FILENAME}, but first erasing and writing system information"
-    $ESPTOOL_CMD erase-flash
-    $ESPTOOL_CMD write-flash $FIRMWARE_OFFSET "${FILENAME}"
+    $ESPTOOL_CMD erase_flash
+    $ESPTOOL_CMD write_flash $FIRMWARE_OFFSET "${FILENAME}"
     echo "Trying to flash ${OTAFILE} at offset ${OTA_OFFSET}"
     $ESPTOOL_CMD write_flash $OTA_OFFSET "${OTAFILE}"
     echo "Trying to flash ${SPIFFSFILE}, at offset ${OFFSET}"


### PR DESCRIPTION
I've tested this when flashing a lilygo device. Changing the parameters allowed me to use device-install shell script to interact with esptool again.

esptool.py v4.8.1
    read_flash          Read SPI flash content
    write_flash         Write a binary blob to flash


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
