### PR TITLE
Expose bootloader version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1567,6 +1567,11 @@ extern meshtastic_DeviceMetadata getDeviceMetadata()
 #if !(MESHTASTIC_EXCLUDE_PKI)
     deviceMetadata.hasPKC = true;
 #endif
+
+#if defined(ARCH_NRF52)
+    deviceMetadata.bootloader_version = NRF_TIMER2->CC[0]; // BOOTLOADER_VERSION_REGISTER
+#endif
+
     return deviceMetadata;
 }
 

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1141,6 +1141,7 @@ typedef struct _meshtastic_DeviceMetadata {
     /* Bit field of boolean for excluded modules
  (bitwise OR of ExcludedModules) */
     uint32_t excluded_modules;
+    uint32_t bootloader_version;
 } meshtastic_DeviceMetadata;
 
 /* Packets from the radio to the phone will appear on the fromRadio characteristic.


### PR DESCRIPTION
Expose bootloader version for RAK4631 devices to check the support for OTA - related to https://github.com/meshtastic/Meshtastic-Android/issues/3883

Should work for other nrf52 devices that use [Adafruit](https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/6a9a6a3e6d0f86918e9286188426a279976645bd/src/main.c#L120) bootloader. 

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
