### PR TITLE
device-install: Consistently use write-flash

### DIFF
--- a/bin/device-install.sh
+++ b/bin/device-install.sh
@@ -32,6 +32,19 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
+# esptool v5 supports commands with dashes and deprecates commands with
+# underscores. Prior versions only support commands with underscores
+if ${ESPTOOL_CMD} | grep --quiet write-flash
+then
+    ESPTOOL_WRITE_FLASH=write-flash
+    ESPTOOL_ERASE_FLASH=erase-flash
+    ESPTOOL_READ_FLASH_STATUS=read-flash-status
+else
+    ESPTOOL_WRITE_FLASH=write_flash
+    ESPTOOL_ERASE_FLASH=erase_flash
+    ESPTOOL_READ_FLASH_STATUS=read_flash_status
+fi
+
 set -e
 
 # Usage info
@@ -83,7 +96,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [[ $BPS_RESET == true ]]; then
-    $ESPTOOL_CMD --baud $RESET_BAUD --after no_reset read_flash_status
+    $ESPTOOL_CMD --baud $RESET_BAUD --after no_reset ${ESPTOOL_READ_FLASH_STATUS}
     exit 0
 fi
 
@@ -144,12 +157,12 @@ if [[ -f "$FILENAME" && "$FILENAME" == *.factory.bin ]]; then
     fi
 
     echo "Trying to flash ${FILENAME}, but first erasing and writing system information"
-    $ESPTOOL_CMD erase-flash
-    $ESPTOOL_CMD write-flash $FIRMWARE_OFFSET "${FILENAME}"
+    $ESPTOOL_CMD ${ESPTOOL_ERASE_FLASH}
+    $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} $FIRMWARE_OFFSET "${FILENAME}"
     echo "Trying to flash ${OTAFILE} at offset ${OTA_OFFSET}"
-    $ESPTOOL_CMD write_flash $OTA_OFFSET "${OTAFILE}"
+    $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} $OTA_OFFSET "${OTAFILE}"
     echo "Trying to flash ${SPIFFSFILE}, at offset ${OFFSET}"
-    $ESPTOOL_CMD write_flash $OFFSET "${SPIFFSFILE}"
+    $ESPTOOL_CMD ${ESPTOOL_WRITE_FLASH} $OFFSET "${SPIFFSFILE}"
 
 else
     show_help

--- a/bin/device-update.sh
+++ b/bin/device-update.sh
@@ -20,6 +20,17 @@ else
     exit 1
 fi
 
+# esptool v5 supports commands with dashes and deprecates commands with
+# underscores. Prior versions only support commands with underscores
+if ${ESPTOOL_CMD} | grep --quiet write-flash
+then
+    ESPTOOL_WRITE_FLASH=write-flash
+    ESPTOOL_READ_FLASH_STATUS=read-flash-status
+else
+    ESPTOOL_WRITE_FLASH=write_flash
+    ESPTOOL_READ_FLASH_STATUS=read_flash_status
+fi
+
 # Usage info
 show_help() {
 cat << EOF
@@ -69,7 +80,7 @@ done
 shift "$((OPTIND-1))"
 
 if [ "$CHANGE_MODE" = true ]; then
-    $ESPTOOL_CMD --baud $RESET_BAUD --after no_reset read_flash_status
+    $ESPTOOL_CMD --baud $RESET_BAUD --after no_reset ${ESPTOOL_READ_FLASH_STATUS}
     exit 0
 fi
 
@@ -80,7 +91,7 @@ fi
 
 if [[ -f "$FILENAME" && "$FILENAME" != *.factory.bin ]]; then
     echo "Trying to flash update ${FILENAME}"
-    $ESPTOOL_CMD --baud $FLASH_BAUD write-flash $UPDATE_OFFSET "${FILENAME}"
+    $ESPTOOL_CMD --baud $FLASH_BAUD ${ESPTOOL_WRITE_FLASH} $UPDATE_OFFSET "${FILENAME}"
 else
     show_help
     echo "Invalid file: ${FILENAME}"


### PR DESCRIPTION
Esptool accepts the write-flash command only on newer versions while older versions only accepted write_flash. Use write-flash consistently to avoid partial flashing with older esptool version.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
