### PR TITLE
Enable USB_MODE to acknowledge RTS/DTR reset signal from esptool for heltec-v4

### DIFF
--- a/boards/heltec_v4.json
+++ b/boards/heltec_v4.json
@@ -9,7 +9,7 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
-      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_USB_MODE=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],


### PR DESCRIPTION
Change ARDUINO_USB_MODE from 0 to 1 in the board definition. This switches to the ESP32-S3's Hardware CDC and JTAG mode, which properly handles the reset signals for automatic reboot after firmware updates.

Other boards in this codebase (like t-deck-pro, seeed-sensecap-indicator, wiscore_rak3312) already use ARDUINO_USB_MODE=1.

## 🤝 Attestations


- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
Heltec (Lora32) V4