### PR TITLE
tryfix: T3S3 ePaper eInk updates

### DIFF
--- a/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
@@ -13,7 +13,10 @@ build_flags =
   -DEINK_WIDTH=250
   -DEINK_HEIGHT=122
   -DUSE_EINK_DYNAMICDISPLAY            ; Enable Dynamic EInk
-  -DEINK_LIMIT_FASTREFRESH=10          ; How many consecutive fast-refreshes are permitted
+  -DEINK_LIMIT_FASTREFRESH=20          ; How many consecutive fast-refreshes are permitted    //20
+  -DEINK_LIMIT_RATE_BACKGROUND_SEC=30  ; Minimum interval between BACKGROUND updates          //30
+  -DEINK_LIMIT_RATE_RESPONSIVE_SEC=1   ; Minimum interval between RESPONSIVE updates
+  -DEINK_BACKGROUND_USES_FAST          ; (Optional) Use FAST refresh for both BACKGROUND and RESPONSIVE, until a limit is reached.
 
 lib_deps =
   ${esp32s3_base.lib_deps}


### PR DESCRIPTION
fixes https://github.com/meshtastic/firmware/issues/8571 and https://github.com/meshtastic/firmware/issues/8875

enabling all fast refresh (background) options to prevent blocking radiolib

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
    - [X] T3S3 ePaper BaseUI
    - [X] T3S3 ePaper InkHUD
