### PR TITLE
Use truncated position for smart position

### DIFF
--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -45,8 +45,12 @@ bool PositionModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
 {
     auto p = *pptr;
 
-    // If inbound message is a replay (or spoof!) of our own messages, we shouldn't process
-    // (why use second-hand sources for our own data?)
+    const auto transport = mp.transport_mechanism;
+    if (isFromUs(&mp) && !IS_ONE_OF(transport, meshtastic_MeshPacket_TransportMechanism_TRANSPORT_INTERNAL,
+                                    meshtastic_MeshPacket_TransportMechanism_TRANSPORT_API)) {
+        LOG_WARN("Ignoring packet supposedly from us over external transport");
+        return true;
+    }
 
     // FIXME this can in fact happen with packets sent from EUD (src=RX_SRC_USER)
     // to set fixed location, EUD-GPS location or just the time (see also issue #900)


### PR DESCRIPTION
If we have imprecise location and smart position on lets not send smart position even if we move if our new position will get truncated to the previous position. We now take into account truncating when deciding the distance travelled for smart pos.
Tested by walking around and sending client notification if the moved distance is greater than the threshold but the truncated position isnt.

This is useful for reducing the amount of positions that are sent.
![IMG_5186](https://github.com/user-attachments/assets/acfe7391-df9f-4690-86d8-6ddec25c0721)

## 🤝 Attestations

- [ x ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ x ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
