### PR TITLE
Optimize builds to reduce duplicate dependency checks

### DIFF
--- a/bin/build-esp32.sh
+++ b/bin/build-esp32.sh
@@ -22,7 +22,7 @@ export APP_VERSION=$VERSION
 
 basename=firmware-$1-$VERSION
 
-pio run --environment $1 # -v
+pio run --environment $1 -t mtjson # -v
 
 cp $BUILDDIR/$basename.elf $OUTDIR/$basename.elf
 
@@ -32,20 +32,10 @@ cp $BUILDDIR/$basename.factory.bin $OUTDIR/$basename.factory.bin
 echo "Copying ESP32 update bin file"
 cp $BUILDDIR/$basename.bin $OUTDIR/$basename.bin
 
-echo "Building Filesystem for ESP32 targets"
-# If you want to build the webui, uncomment the following lines
-# pio run --environment $1 -t buildfs
-# cp .pio/build/$1/littlefs.bin $OUTDIR/littlefswebui-$1-$VERSION.bin
-# # Remove webserver files from the filesystem and rebuild
-# ls -l data/static # Diagnostic list of files
-# rm -rf data/static
-pio run --environment $1 -t buildfs --disable-auto-clean
+echo "Copying Filesystem for ESP32 targets"
 cp $BUILDDIR/littlefs-$1-$VERSION.bin $OUTDIR/littlefs-$1-$VERSION.bin
 cp bin/device-install.* $OUTDIR/
 cp bin/device-update.* $OUTDIR/
 
-# Generate the manifest file
-echo "Generating Meshtastic manifest"
-TIMEFORMAT="Generated manifest in %E seconds"
-time pio run --environment $1 -t mtjson --silent --disable-auto-clean
+echo "Copying manifest"
 cp $BUILDDIR/$basename.mt.json $OUTDIR/$basename.mt.json

--- a/bin/build-nrf52.sh
+++ b/bin/build-nrf52.sh
@@ -22,7 +22,7 @@ export APP_VERSION=$VERSION
 
 basename=firmware-$1-$VERSION
 
-pio run --environment $1 # -v
+pio run --environment $1 -t mtjson # -v
 
 cp $BUILDDIR/$basename.elf $OUTDIR/$basename.elf
 
@@ -47,8 +47,5 @@ if (echo $1 | grep -q "rak4631"); then
 	cp $SRCHEX $OUTDIR/
 fi
 
-# Generate the manifest file
-echo "Generating Meshtastic manifest"
-TIMEFORMAT="Generated manifest in %E seconds"
-time pio run --environment $1 -t mtjson --silent --disable-auto-clean
+echo "Copying manifest"
 cp $BUILDDIR/$basename.mt.json $OUTDIR/$basename.mt.json

--- a/bin/build-rp2xx0.sh
+++ b/bin/build-rp2xx0.sh
@@ -22,15 +22,12 @@ export APP_VERSION=$VERSION
 
 basename=firmware-$1-$VERSION
 
-pio run --environment $1 # -v
+pio run --environment $1 -t mtjson # -v
 
 cp $BUILDDIR/$basename.elf $OUTDIR/$basename.elf
 
 echo "Copying uf2 file"
 cp $BUILDDIR/$basename.uf2 $OUTDIR/$basename.uf2
 
-# Generate the manifest file
-echo "Generating Meshtastic manifest"
-TIMEFORMAT="Generated manifest in %E seconds"
-time pio run --environment $1 -t mtjson --silent --disable-auto-clean
+echo "Copying manifest"
 cp $BUILDDIR/$basename.mt.json $OUTDIR/$basename.mt.json

--- a/bin/build-stm32wl.sh
+++ b/bin/build-stm32wl.sh
@@ -22,15 +22,12 @@ export APP_VERSION=$VERSION
 
 basename=firmware-$1-$VERSION
 
-pio run --environment $1 # -v
+pio run --environment $1 -t mtjson # -v
 
 cp $BUILDDIR/$basename.elf $OUTDIR/$basename.elf
 
 echo "Copying STM32 bin file"
 cp $BUILDDIR/$basename.bin $OUTDIR/$basename.bin
 
-# Generate the manifest file
-echo "Generating Meshtastic manifest"
-TIMEFORMAT="Generated manifest in %E seconds"
-time pio run --environment $1 -t mtjson --silent --disable-auto-clean
+echo "Copying manifest"
 cp $BUILDDIR/$basename.mt.json $OUTDIR/$basename.mt.json

--- a/bin/platformio-pre.py
+++ b/bin/platformio-pre.py
@@ -11,6 +11,9 @@ else:
     prefsLoc = env["PROJECT_DIR"] + "/version.properties"
     verObj = readProps(prefsLoc)
     env.Replace(PROGNAME=f"firmware-{env.get('PIOENV')}-{verObj['long']}")
+    env.Replace(ESP32_FS_IMAGE_NAME=f"littlefs-{env.get('PIOENV')}-{verObj['long']}")
 
 # Print the new program name for verification
 print(f"PROGNAME: {env.get('PROGNAME')}")
+if platform.name == "espressif32":
+    print(f"ESP32_FS_IMAGE_NAME: {env.get('ESP32_FS_IMAGE_NAME')}")


### PR DESCRIPTION
The 'mtjson' PlatformIO target will now build all required pieces when they don't exist.

In CI -- this allows us to invoke *only* `pio run -e <board_name> -t mtjson` and avoid duplicate dependency scans, which are EXTREMELY heavy.
Decreases esp32 build time by about 60 seconds (adds up fast).

Tested at https://github.com/vidplace7/meshtastic-firmware/actions/runs/20152012877