### PR TITLE
Add MQTT GPIO control and status topics

### DIFF
--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -104,6 +104,7 @@ class MQTT : private concurrency::OSThread
     std::string cryptTopic = "/2/e/";   // msh/2/e/CHANNELID/NODEID
     std::string jsonTopic = "/2/json/"; // msh/2/json/CHANNELID/NODEID
     std::string mapTopic = "/2/map/";   // For protobuf-encoded MapReport messages
+    std::string gpioTopic = "/2/gpio/"; // msh/2/gpio/NODEID/control or /status
 
     // For map reporting (only applies when enabled)
     const uint32_t default_map_position_precision = 14; // defaults to max. offset of ~1459m
@@ -133,6 +134,13 @@ class MQTT : private concurrency::OSThread
 
     // Check if we should report unencrypted information about our node for consumption by a map
     void perhapsReportToMap();
+
+    // Handle GPIO control messages received from MQTT
+    void onGpioReceive(char *topic, byte *payload, size_t length);
+
+  public:
+    // Publish GPIO status to MQTT
+    void publishGpioStatus(uint64_t gpio_mask, uint64_t gpio_value);
 
     /// Return 0 if sleep is okay, veto sleep if we are connected to pubsub server
     // int preflightSleepCb(void *unused = NULL) { return pubSub.connected() ? 1 : 0; }


### PR DESCRIPTION
Implement dedicated MQTT topics for GPIO control:
- Subscribe to msh/{root}/2/gpio/{NODE_ID}/control for commands
- Publish status to msh/{root}/2/gpio/{NODE_ID}/status

Supported JSON command formats:
- Simple: {"pin": N, "value": V} or {"pin": N, "command": "read"}
- Advanced: {"command": "write/read/watch", "gpio_mask": M, "gpio_value": V}

Status response format:
{"type":"gpio_status","gpio_mask":M,"gpio_value":V,"timestamp":T,"node_id":"!xxx"}

The RemoteHardwareModule now publishes GPIO status to MQTT when:
- GPIO write commands are executed
- GPIO read responses are sent
- Watched GPIOs change state

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌

- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentially duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and commnunity members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
