### PR TITLE
Fix GPS Buffer full issue on NRF52480 (Seeed T1000E)

### DIFF
--- a/variants/nrf52840/nrf52.ini
+++ b/variants/nrf52840/nrf52.ini
@@ -19,7 +19,6 @@ build_type = release
 build_flags =
   -include variants/nrf52840/cpp_overrides/lfs_util.h
   ${arduino_base.build_flags}
-  -DSERIAL_BUFFER_SIZE=1024
   -Wno-unused-variable
   -Isrc/platform/nrf52
   -DLFS_NO_ASSERT                      ; Disable LFS assertions , see https://github.com/meshtastic/firmware/pull/3818

--- a/variants/nrf52840/nrf52832.ini
+++ b/variants/nrf52840/nrf52832.ini
@@ -1,7 +1,9 @@
 [nrf52832_base]
 extends = nrf52_base
 
-build_flags = ${nrf52_base.build_flags} 
+build_flags =
+  ${nrf52_base.build_flags}
+  -DSERIAL_BUFFER_SIZE=1024
 
 lib_deps =
   ${nrf52_base.lib_deps}

--- a/variants/nrf52840/nrf52840.ini
+++ b/variants/nrf52840/nrf52840.ini
@@ -1,7 +1,9 @@
 [nrf52840_base]
 extends = nrf52_base
 
-build_flags = ${nrf52_base.build_flags} 
+build_flags =
+   ${nrf52_base.build_flags}
+  -DSERIAL_BUFFER_SIZE=4096
 
 lib_deps =
   ${nrf52_base.lib_deps}


### PR DESCRIPTION
We set the buffer size to 1024 on NRF52480, less than other platforms:

esp32.ini:  -DSERIAL_BUFFER_SIZE=4096
esp32c6.ini:  -DSERIAL_BUFFER_SIZE=4096
nrf52.ini:  -DSERIAL_BUFFER_SIZE=1024

However, 115200 baud, like the T1000e uses is about 12 times that - almost 15 bytes per millisecond. 15 bytes * 200 millisecond (our GPS poll rate)  = 3000 bytes, which is longer than our buffer on the nrf52 platform. This causes "GPS Buffer full" errors on the T1000e and other devices based on NRF52480 with newer GPS chips.

This patch increases SERIAL_BUFFER_SIZE for nrf52480 to 4096 to align with other platforms. It keeps the original 1024 for the nrf52832, which has fewer resources.

Fixes https://github.com/meshtastic/firmware/issues/5767

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [x] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
