### PR TITLE
PlatformIO: Restructure networking_base for re-use

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -103,16 +103,12 @@ lib_deps =
 	thingsboard/TBPubSubClient@2.12.1
 	# renovate: datasource=custom.pio depName=NTPClient packageName=arduino-libraries/library/NTPClient
 	arduino-libraries/NTPClient@3.2.1
+
+; Extra TCP/IP networking libs for supported devices
+[networking_extra]
+lib_deps =
 	# renovate: datasource=custom.pio depName=Syslog packageName=arcao/library/Syslog
 	arcao/Syslog@2.0.0
-
-; Minimal networking libs for nrf52 (excludes Syslog to save flash)
-[nrf52_networking_base]
-lib_deps =
-	# renovate: datasource=custom.pio depName=TBPubSubClient packageName=thingsboard/library/TBPubSubClient
-	thingsboard/TBPubSubClient@2.12.1
-	# renovate: datasource=custom.pio depName=NTPClient packageName=arduino-libraries/library/NTPClient
-	arduino-libraries/NTPClient@3.2.1
 
 [radiolib_base]
 lib_deps =

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -53,6 +53,7 @@ build_flags =
 lib_deps =
   ${arduino_base.lib_deps}
   ${networking_base.lib_deps}
+  ${networking_extra.lib_deps}
   ${environmental_base.lib_deps}
   ${environmental_extra.lib_deps}
   ${radiolib_base.lib_deps}

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -21,6 +21,7 @@ build_src_filter =
 lib_deps =
   ${env.lib_deps}
   ${networking_base.lib_deps}
+  ${networking_extra.lib_deps}
   ${radiolib_base.lib_deps}
   ${environmental_base.lib_deps}
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto

--- a/variants/nrf52840/rak2560/platformio.ini
+++ b/variants/nrf52840/rak2560/platformio.ini
@@ -13,7 +13,7 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak2560> +<mesh/api/> +<mqtt/> +<serialization/>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  ${nrf52_networking_base.lib_deps}
+  ${networking_base.lib_deps}
   # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
   # renovate: datasource=github-tags depName=RAK-OneWireSerial packageName=beegee-tokyo/RAK-OneWireSerial

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -22,7 +22,7 @@ build_src_filter = ${nrf52_base.build_src_filter} \
   -<graphics/fonts/EinkDisplayFonts.cpp>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  ${nrf52_networking_base.lib_deps}
+  ${networking_base.lib_deps}
   # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
   # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S

--- a/variants/nrf52840/rak_wismeshtap/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtap/platformio.ini
@@ -17,7 +17,7 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak_wismeshtap> +<mesh/eth/> +<mesh/api/> +<mqtt/>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  ${nrf52_networking_base.lib_deps}
+  ${networking_base.lib_deps}
   # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
   # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S

--- a/variants/rp2040/rak11310/platformio.ini
+++ b/variants/rp2040/rak11310/platformio.ini
@@ -14,6 +14,7 @@ build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rp2040/rak11310
 lib_deps =
   ${rp2040_base.lib_deps}
   ${networking_base.lib_deps}
+  ${networking_extra.lib_deps}
   # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
   # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S

--- a/variants/rp2040/rpipicow/platformio.ini
+++ b/variants/rp2040/rpipicow/platformio.ini
@@ -16,5 +16,6 @@ build_src_filter = ${rp2040_base.build_src_filter} +<mesh/wifi/>
 lib_deps =
   ${rp2040_base.lib_deps}
   ${networking_base.lib_deps}
+  ${networking_extra.lib_deps}
 debug_build_flags = ${rp2040_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rp2350/rpipico2w/platformio.ini
+++ b/variants/rp2350/rpipico2w/platformio.ini
@@ -30,4 +30,5 @@ build_src_filter = ${rp2350_base.build_src_filter} +<mesh/wifi/>
 lib_deps =
   ${rp2350_base.lib_deps}
   ${networking_base.lib_deps}
+  ${networking_extra.lib_deps}
 debug_build_flags = ${rp2350_base.build_flags}, -g


### PR DESCRIPTION
Restructure platformio.ini for `nrf52_networking_base` and `networking_base` to avoid double-defining dependencies and adopt the var naming convention used elsewhere in the project.

|                                Old var | New var                   |
| ------------------------------------ | -------------------------- |
| `nrf52_networking_base` | `networking_base` |
| `networking_base`            | `networking_extra` |

`networking_base` (previously `nrf52_networking_base`) will likely be used in the pioarduino porting efforts, genericizing the name makes sense.