### PR TITLE
rp2xx0: Update to arduino-pico 5.4.4

### DIFF
--- a/variants/rp2040/rp2040.ini
+++ b/variants/rp2040/rp2040.ini
@@ -2,12 +2,12 @@
 [rp2040_base]
 platform =
   # TODO renovate
-  https://github.com/maxgerhardt/platform-raspberrypi#76ecf3c7e9dd4503af0331154c4ca1cddc4b03e5
-  ; For arduino-pico >= 4.4.3
+  https://github.com/maxgerhardt/platform-raspberrypi#cc24cfef37ed22ca9f2a6aead28c2deb76c39f24
+  ; For arduino-pico >= 5.4.4
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  framework-arduinopico@https://github.com/earlephilhower/arduino-pico#4.4.3
+  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.4.4/rp2040-5.4.4.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m
@@ -17,6 +17,7 @@ build_flags =
   -Isrc/platform/rp2xx0/hardware_rosc/include
   -Isrc/platform/rp2xx0/pico_sleep/include
   -D__PLAT_RP2040__
+  -D__FREERTOS=1
 #  -D _POSIX_THREADS
 build_src_filter = 
   ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<modules/esp32> -<platform/nrf52/> -<platform/stm32wl> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp>

--- a/variants/rp2350/rp2350.ini
+++ b/variants/rp2350/rp2350.ini
@@ -2,12 +2,12 @@
 [rp2350_base]
 platform =
   # TODO renovate
-  https://github.com/maxgerhardt/platform-raspberrypi#76ecf3c7e9dd4503af0331154c4ca1cddc4b03e5
-  ; For arduino-pico >= 4.4.3
+  https://github.com/maxgerhardt/platform-raspberrypi#cc24cfef37ed22ca9f2a6aead28c2deb76c39f24
+  ; For arduino-pico >= 5.4.4
 extends = arduino_base
 platform_packages =
   # TODO renovate
-  framework-arduinopico@https://github.com/earlephilhower/arduino-pico#4.4.3
+  arduino-pico@https://github.com/earlephilhower/arduino-pico/releases/download/5.4.4/rp2040-5.4.4.zip
 
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m
@@ -15,6 +15,7 @@ build_flags =
   ${arduino_base.build_flags} -Wno-unused-variable -Wcast-align
   -Isrc/platform/rp2xx0
   -D__PLAT_RP2350__
+  -D__FREERTOS=1
 build_src_filter = 
   ${arduino_base.build_src_filter} -<platform/esp32/> -<nimble/> -<modules/esp32> -<platform/nrf52/> -<platform/stm32wl> -<mesh/eth/> -<mesh/wifi/> -<mesh/http/> -<mesh/raspihttp> -<platform/rp2xx0/pico_sleep> -<platform/rp2xx0/hardware_rosc>
 


### PR DESCRIPTION
Update `arduino-pico` framework from 4.4.3 to 5.4.4.

Changelogs: 
- https://github.com/earlephilhower/arduino-pico/releases
- https://github.com/earlephilhower/arduino-pico/compare/4.4.3...5.4.4

Includes explicitly enabling FREERTOS support (to address breaking change https://github.com/earlephilhower/arduino-pico/pull/3063)

Compile tested (working) -- not yet run-tested.