### PR TITLE
PIO: Fix ESP32 sub-variant inheritance

### DIFF
--- a/variants/esp32c3/diy/esp32c3_super_mini/platformio.ini
+++ b/variants/esp32c3/diy/esp32c3_super_mini/platformio.ini
@@ -4,7 +4,7 @@
 extends = esp32c3_base
 board = esp32-c3-devkitm-1
 build_flags =
-  ${esp32_base.build_flags}
+  ${esp32c3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32c3/diy/esp32c3_super_mini
   -D ARDUINO_USB_MODE=1

--- a/variants/esp32c3/hackerboxes_esp32c3_oled/platformio.ini
+++ b/variants/esp32c3/hackerboxes_esp32c3_oled/platformio.ini
@@ -3,7 +3,7 @@ extends = esp32c3_base
 board = esp32-c3-devkitm-1
 board_level = extra
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32c3_base.build_flags}
   -D PRIVATE_HW
   -D ARDUINO_USB_MODE=1
   -D ARDUINO_USB_CDC_ON_BOOT=1

--- a/variants/esp32c3/heltec_esp32c3/platformio.ini
+++ b/variants/esp32c3/heltec_esp32c3/platformio.ini
@@ -3,7 +3,7 @@ extends = esp32c3_base
 board = esp32-c3-devkitm-1
 board_level = pr
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32c3_base.build_flags}
   -D HELTEC_HT62
   -I variants/esp32c3/heltec_esp32c3
 monitor_speed = 115200

--- a/variants/esp32c3/heltec_hru_3601/platformio.ini
+++ b/variants/esp32c3/heltec_hru_3601/platformio.ini
@@ -2,7 +2,7 @@
 extends = esp32c3_base
 board = adafruit_qtpy_esp32c3
 build_flags =
-  ${esp32_base.build_flags}
+  ${esp32c3_base.build_flags}
   -D HELTEC_HRU_3601
   -I variants/esp32c3/heltec_hru_3601
 lib_deps = ${esp32c3_base.lib_deps}

--- a/variants/esp32c3/m5stack-stamp-c3/platformio.ini
+++ b/variants/esp32c3/m5stack-stamp-c3/platformio.ini
@@ -3,7 +3,7 @@ extends = esp32c3_base
 board = esp32-c3-devkitm-1
 board_level = extra
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32c3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32c3/m5stack-stamp-c3
 monitor_speed = 115200

--- a/variants/esp32s3/bpi_picow_esp32_s3/platformio.ini
+++ b/variants/esp32s3/bpi_picow_esp32_s3/platformio.ini
@@ -8,9 +8,9 @@ board_level = extra
 upload_protocol = esptool
 ;upload_port = /dev/ttyACM2
 lib_deps =
-  ${esp32_base.lib_deps}
+  ${esp32s3_base.lib_deps}
   caveman99/ESP32 Codec2@^1.0.1
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32s3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32s3/bpi_picow_esp32_s3

--- a/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
@@ -9,14 +9,14 @@ upload_protocol = esptool
 ;upload_port = /dev/ttyACM1
 upload_speed = 921600
 lib_deps =
-  ${esp32_base.lib_deps}
+  ${esp32s3_base.lib_deps}
   zinggjm/GxEPD2@^1.6.2
   adafruit/Adafruit NeoPixel @ ^1.12.0
 build_unflags =
   ${esp32s3_base.build_unflags}
   -DARDUINO_USB_MODE=1
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32s3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32s3/diy/my_esp32s3_diy_eink
   -Dmy

--- a/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
@@ -9,13 +9,13 @@ upload_protocol = esptool
 ;upload_port = /dev/ttyACM0
 upload_speed = 921600
 lib_deps =
-  ${esp32_base.lib_deps}
+  ${esp32s3_base.lib_deps}
   adafruit/Adafruit NeoPixel @ ^1.12.0
 build_unflags =
   ${esp32s3_base.build_unflags}
   -DARDUINO_USB_MODE=1
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32s3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32s3/diy/my_esp32s3_diy_oled
   -DBOARD_HAS_PSRAM

--- a/variants/esp32s3/heltec_vision_master_e213/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e213/platformio.ini
@@ -27,7 +27,7 @@ board = heltec_vision_master_e213
 board_level = pr
 board_build.partitions = default_8MB.csv
 build_src_filter =
-  ${esp32_base.build_src_filter}
+  ${esp32s3_base.build_src_filter}
   ${inkhud.build_src_filter}
 build_flags =  
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/heltec_vision_master_e290/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e290/platformio.ini
@@ -29,7 +29,7 @@ extends = esp32s3_base, inkhud
 board = heltec_vision_master_e290
 board_build.partitions = default_8MB.csv
 build_src_filter = 
-  ${esp32_base.build_src_filter} 
+  ${esp32s3_base.build_src_filter}
   ${inkhud.build_src_filter}
 build_flags = 
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/heltec_wireless_paper/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper/platformio.ini
@@ -27,7 +27,7 @@ extends = esp32s3_base, inkhud
 board = heltec_wifi_lora_32_V3
 board_build.partitions = default_8MB.csv
 build_src_filter =
-  ${esp32_base.build_src_filter} 
+  ${esp32s3_base.build_src_filter}
   ${inkhud.build_src_filter}
 build_flags =
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/link32_s3_v1/platformio.ini
+++ b/variants/esp32s3/link32_s3_v1/platformio.ini
@@ -3,7 +3,7 @@ extends = esp32s3_base
 board = esp32-s3-devkitc-1
 board_level = extra
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32s3_base.build_flags}
   -D LINK_32
   -I variants/esp32s3/link32_s3_v1
   -DARDUINO_USB_CDC_ON_BOOT

--- a/variants/esp32s3/m5stack_cores3/platformio.ini
+++ b/variants/esp32s3/m5stack_cores3/platformio.ini
@@ -6,8 +6,8 @@ board_check = true
 board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 build_flags = 
-  ${esp32_base.build_flags} 
+  ${esp32s3_base.build_flags}
   -D PRIVATE_HW
   -D M5STACK_CORES3
   -I variants/esp32s3/m5stack_cores3
-lib_deps = ${esp32_base.lib_deps}
+lib_deps = ${esp32s3_base.lib_deps}

--- a/variants/esp32s3/mesh-tab/platformio.ini
+++ b/variants/esp32s3/mesh-tab/platformio.ini
@@ -46,9 +46,9 @@ build_flags = ${esp32s3_base.build_flags}
   -D VIEW_320x240
   -D USE_PACKET_API
   -I variants/esp32s3/mesh-tab
-build_src_filter = ${esp32_base.build_src_filter}
+build_src_filter = ${esp32s3_base.build_src_filter}
 lib_deps =
-  ${esp32_base.lib_deps}
+  ${esp32s3_base.lib_deps}
   ${device-ui_base.lib_deps}
   lovyan03/LovyanGFX@^1.2.0
 

--- a/variants/esp32s3/nibble_esp32/platformio.ini
+++ b/variants/esp32s3/nibble_esp32/platformio.ini
@@ -3,6 +3,6 @@ extends = esp32s3_base
 board = esp32-s3-zero
 board_level = extra
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32s3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32s3/nibble_esp32

--- a/variants/esp32s3/rak3312/platformio.ini
+++ b/variants/esp32s3/rak3312/platformio.ini
@@ -6,6 +6,6 @@ board_check = true
 upload_protocol = esptool
 
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32s3_base.build_flags}
   -D RAK3312
   -I variants/esp32s3/rak3312

--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -8,7 +8,7 @@ upload_protocol = esptool
 board_build.partitions = default_8MB.csv
 
 build_flags = 
-  ${esp32_base.build_flags} 
+  ${esp32s3_base.build_flags}
   -D RAK3312
   -D RAK_WISMESH_TAP_V2 
   -I variants/esp32s3/rak_wismesh_tap_v2

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -9,7 +9,7 @@ board_check = true
 board_build.partitions = partition-table-8MB.csv
 upload_protocol = esptool
 
-build_flags = ${esp32_base.build_flags}
+build_flags = ${esp32s3_base.build_flags}
   -Ivariants/esp32s3/seeed-sensecap-indicator
   -DSENSECAP_INDICATOR
   -DCONFIG_ARDUHAL_LOG_COLORS

--- a/variants/esp32s3/t-deck-pro/platformio.ini
+++ b/variants/esp32s3/t-deck-pro/platformio.ini
@@ -5,7 +5,7 @@ board_check = true
 upload_protocol = esptool
 
 build_flags = 
-  ${esp32_base.build_flags} -I variants/esp32s3/t-deck-pro
+  ${esp32s3_base.build_flags} -I variants/esp32s3/t-deck-pro
   -D T_DECK_PRO
   -D USE_EINK
   -D EINK_DISPLAY_MODEL=GxEPD2_310_GDEQ031T10

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -6,7 +6,7 @@ board_check = true
 board_build.partitions = default_16MB.csv
 upload_protocol = esptool
 
-build_flags = ${esp32_base.build_flags} 
+build_flags = ${esp32s3_base.build_flags}
   -DT_WATCH_S3
   -Ivariants/esp32s3/t-watch-s3
   -DPCF8563_RTC=0x51

--- a/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
@@ -5,7 +5,7 @@ board_check = true
 upload_protocol = esptool
 
 build_flags = 
-  ${esp32_base.build_flags}
+  ${esp32s3_base.build_flags}
   -D TLORA_T3S3_EPAPER
   -I variants/esp32s3/tlora_t3s3_epaper
   -DUSE_EINK
@@ -28,7 +28,7 @@ board = tlora-t3s3-v1
 board_check = true
 upload_protocol = esptool
 build_src_filter =
-  ${esp32_base.build_src_filter}
+  ${esp32s3_base.build_src_filter}
   ${inkhud.build_src_filter}
 build_flags =
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/tlora_t3s3_v1/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_v1/platformio.ini
@@ -5,4 +5,6 @@ board_check = true
 upload_protocol = esptool
 
 build_flags = 
-  ${esp32_base.build_flags} -D TLORA_T3S3_V1 -I variants/esp32s3/tlora_t3s3_v1
+  ${esp32s3_base.build_flags}
+  -D TLORA_T3S3_V1
+  -I variants/esp32s3/tlora_t3s3_v1


### PR DESCRIPTION
Cleanup PIO inheritance for ESP32 sub-variants (ESP32-c3, s3, etc)

Always inherit from the `esp32*_base` of the sub-variant; do not pull directly from `esp32_base` for libdeps and build_flags.
Inheritance was already setup correctly in many variants, this just cleans up / normalizes the variants.