### PR TITLE
Replace PIO fuzzy version matches (reproducible builds)

### DIFF
--- a/variants/esp32/betafpv_2400_tx_micro/platformio.ini
+++ b/variants/esp32/betafpv_2400_tx_micro/platformio.ini
@@ -15,4 +15,4 @@ upload_protocol = esptool
 upload_speed = 460800
 lib_deps =
   ${esp32_base.lib_deps}
-  adafruit/Adafruit NeoPixel @ ^1.12.0
+  adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32/chatter2/platformio.ini
+++ b/variants/esp32/chatter2/platformio.ini
@@ -9,4 +9,4 @@ build_flags =
   
 lib_deps =
   ${esp32_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -59,7 +59,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-esp32_https_server packageName=https://github.com/meshtastic/esp32_https_server gitBranch=master
   https://github.com/meshtastic/esp32_https_server/archive/3223704846752e6d545139204837bdb2a55459ca.zip
   # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
-  h2zero/NimBLE-Arduino@^1.4.3
+  h2zero/NimBLE-Arduino@1.4.3
   # renovate: datasource=git-refs depName=libpax packageName=https://github.com/dbinfrago/libpax gitBranch=master
   https://github.com/dbinfrago/libpax/archive/3cdc0371c375676a97967547f4065607d4c53fd1.zip
   # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib

--- a/variants/esp32/m5stack_core/platformio.ini
+++ b/variants/esp32/m5stack_core/platformio.ini
@@ -25,4 +25,4 @@ lib_ignore =
   m5stack-core
 lib_deps = 
   ${esp32_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -18,8 +18,8 @@ build_flags =
   -DM5STACK
 lib_deps = 
   ${esp32_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
-  lewisxhe/PCF8563_Library@^1.0.1
+  zinggjm/GxEPD2@1.6.5
+  lewisxhe/PCF8563_Library@1.0.1
 lib_ignore =
   m5stack-coreink
 monitor_filters = esp32_exception_decoder

--- a/variants/esp32/wiphone/platformio.ini
+++ b/variants/esp32/wiphone/platformio.ini
@@ -10,6 +10,6 @@ build_flags =
   -I variants/esp32/wiphone
 lib_deps = 
   ${esp32_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
-  sparkfun/SX1509 IO Expander@^3.0.5
-  pololu/APA102@^3.0.0
+  lovyan03/LovyanGFX@1.2.7
+  sparkfun/SX1509 IO Expander@3.0.6
+  pololu/APA102@3.0.0

--- a/variants/esp32c3/heltec_hru_3601/platformio.ini
+++ b/variants/esp32c3/heltec_hru_3601/platformio.ini
@@ -6,4 +6,4 @@ build_flags =
   -D HELTEC_HRU_3601
   -I variants/esp32c3/heltec_hru_3601
 lib_deps = ${esp32c3_base.lib_deps}
-  adafruit/Adafruit NeoPixel @ ^1.12.0
+  adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32c6/m5stack_unitc6l/platformio.ini
+++ b/variants/esp32c6/m5stack_unitc6l/platformio.ini
@@ -12,8 +12,8 @@ build_unflags =
   -D HAS_WIFI
 lib_deps =
   ${esp32c6_base.lib_deps}
-  adafruit/Adafruit NeoPixel@^1.12.3
-  h2zero/NimBLE-Arduino@^2.3.6
+  adafruit/Adafruit NeoPixel@1.15.2
+  h2zero/NimBLE-Arduino@2.3.7
 build_flags = 
   ${esp32c6_base.build_flags}
   -D M5STACK_UNITC6L

--- a/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
@@ -17,5 +17,5 @@ build_flags =
 
 lib_deps = ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
-  lewisxhe/PCF8563_Library@^1.0.1
-  maxpromer/PCA9557-arduino @ ^1.0.0
+  lewisxhe/PCF8563_Library@1.0.1
+  maxpromer/PCA9557-arduino@1.0.0

--- a/variants/esp32s3/bpi_picow_esp32_s3/platformio.ini
+++ b/variants/esp32s3/bpi_picow_esp32_s3/platformio.ini
@@ -9,7 +9,7 @@ upload_protocol = esptool
 ;upload_port = /dev/ttyACM2
 lib_deps =
   ${esp32s3_base.lib_deps}
-  caveman99/ESP32 Codec2@^1.0.1
+  caveman99/ESP32 Codec2@1.0.1
 build_flags = 
   ${esp32s3_base.build_flags}
   -D PRIVATE_HW

--- a/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
@@ -10,8 +10,8 @@ upload_protocol = esptool
 upload_speed = 921600
 lib_deps =
   ${esp32s3_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
-  adafruit/Adafruit NeoPixel @ ^1.12.0
+  zinggjm/GxEPD2@1.6.5
+  adafruit/Adafruit NeoPixel@1.15.2
 build_unflags =
   ${esp32s3_base.build_unflags}
   -DARDUINO_USB_MODE=1

--- a/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
@@ -10,7 +10,7 @@ upload_protocol = esptool
 upload_speed = 921600
 lib_deps =
   ${esp32s3_base.lib_deps}
-  adafruit/Adafruit NeoPixel @ ^1.12.0
+  adafruit/Adafruit NeoPixel@1.15.2
 build_unflags =
   ${esp32s3_base.build_unflags}
   -DARDUINO_USB_MODE=1

--- a/variants/esp32s3/dreamcatcher/platformio.ini
+++ b/variants/esp32s3/dreamcatcher/platformio.ini
@@ -12,8 +12,8 @@ build_flags =
   -D ARDUINO_USB_CDC_ON_BOOT=1
 
 lib_deps = ${esp32s3_base.lib_deps}
-  earlephilhower/ESP8266Audio@^1.9.9
-  earlephilhower/ESP8266SAM@^1.0.1
+  earlephilhower/ESP8266Audio@1.9.9
+  earlephilhower/ESP8266SAM@1.1.0
 
 [env:dreamcatcher-2206] 
 extends = esp32s3_base

--- a/variants/esp32s3/esp32-s3-pico/platformio.ini
+++ b/variants/esp32s3/esp32-s3-pico/platformio.ini
@@ -22,5 +22,5 @@ build_flags = ${esp32s3_base.build_flags}
   -DEINK_HEIGHT=128
 
 lib_deps = ${esp32s3_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
-  adafruit/Adafruit NeoPixel @ ^1.12.0
+  zinggjm/GxEPD2@1.6.5
+  adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32s3/heltec_sensor_hub/platformio.ini
+++ b/variants/esp32s3/heltec_sensor_hub/platformio.ini
@@ -9,4 +9,4 @@ build_flags =
   -D HELTEC_SENSOR_HUB
 
 lib_deps = ${esp32s3_base.lib_deps}
-  adafruit/Adafruit NeoPixel @ ^1.12.0
+  adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32s3/heltec_vision_master_e213/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e213/platformio.ini
@@ -18,7 +18,7 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200
 
 [env:heltec-vision-master-e213-inkhud]

--- a/variants/esp32s3/heltec_vision_master_e290/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e290/platformio.ini
@@ -21,7 +21,7 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/448c8538129fde3d02a7cb5e6fc81971ad92547f.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200
 
 [env:heltec-vision-master-e290-inkhud]

--- a/variants/esp32s3/heltec_vision_master_t190/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_t190/platformio.ini
@@ -8,6 +8,6 @@ build_flags =
   -D HELTEC_VISION_MASTER_T190
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
   https://github.com/meshtastic/st7789/archive/bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f.zip
 upload_speed = 921600

--- a/variants/esp32s3/heltec_wireless_paper/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper/platformio.ini
@@ -19,7 +19,7 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200
 
 [env:heltec-wireless-paper-inkhud]

--- a/variants/esp32s3/heltec_wireless_paper_v1/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper_v1/platformio.ini
@@ -16,5 +16,5 @@ build_flags =
 lib_deps =
   ${esp32s3_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200

--- a/variants/esp32s3/heltec_wireless_tracker/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker/platformio.ini
@@ -12,4 +12,4 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32s3/heltec_wireless_tracker_V1_0/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_V1_0/platformio.ini
@@ -11,4 +11,4 @@ build_flags =
   ;-D DEBUG_DISABLED ; uncomment this line to disable DEBUG output
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
@@ -10,4 +10,4 @@ build_flags =
   -D HELTEC_WIRELESS_TRACKER_V2
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32s3/mesh-tab/platformio.ini
+++ b/variants/esp32s3/mesh-tab/platformio.ini
@@ -50,7 +50,7 @@ build_src_filter = ${esp32s3_base.build_src_filter}
 lib_deps =
   ${esp32s3_base.lib_deps}
   ${device-ui_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7
 
 [mesh_tab_xpt2046]
 extends = mesh_tab_base

--- a/variants/esp32s3/picomputer-s3/platformio.ini
+++ b/variants/esp32s3/picomputer-s3/platformio.ini
@@ -15,7 +15,7 @@ build_flags =
 
 lib_deps = 
   ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7
 
 build_src_filter =
   ${esp32s3_base.build_src_filter}

--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -15,7 +15,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7
 
 [ft5x06]
 extends = mesh_tab_base

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -25,8 +25,8 @@ build_flags = ${esp32s3_base.build_flags}
 
 lib_deps = ${esp32s3_base.lib_deps}
   https://github.com/mverch67/LovyanGFX/archive/4c76238c1344162a234ae917b27651af146d6fb2.zip
-  earlephilhower/ESP8266Audio@^1.9.9
-  earlephilhower/ESP8266SAM@^1.0.1
+  earlephilhower/ESP8266Audio@1.9.9
+  earlephilhower/ESP8266SAM@1.1.0
 
 
 [env:seeed-sensecap-indicator-tft]

--- a/variants/esp32s3/t-deck-pro/platformio.ini
+++ b/variants/esp32s3/t-deck-pro/platformio.ini
@@ -17,7 +17,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  https://github.com/ZinggJM/GxEPD2/archive/refs/tags/1.6.4.zip
+  zinggjm/GxEPD2@1.6.4
   https://github.com/CIRCUITSTATE/CSE_Touch/archive/b44f23b6f870b848f1fbe453c190879bc6cfaafa.zip
   https://github.com/CIRCUITSTATE/CSE_CST328/archive/refs/tags/v0.0.4.zip
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -12,9 +12,9 @@ build_flags = ${esp32s3_base.build_flags}
   -I variants/esp32s3/t-deck
 
 lib_deps = ${esp32s3_base.lib_deps}
-	lovyan03/LovyanGFX@^1.2.0
-  earlephilhower/ESP8266Audio@^1.9.9
-  earlephilhower/ESP8266SAM@^1.0.1
+  lovyan03/LovyanGFX@1.2.7
+  earlephilhower/ESP8266Audio@1.9.9
+  earlephilhower/ESP8266SAM@1.1.0
 
 [env:t-deck-tft]
 extends = env:t-deck

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -13,9 +13,9 @@ build_flags = ${esp32s3_base.build_flags}
   -DHAS_BMA423=1
 
 lib_deps = ${esp32s3_base.lib_deps}
-	lovyan03/LovyanGFX@^1.2.0
+	lovyan03/LovyanGFX@1.2.7
   lewisxhe/PCF8563_Library@1.0.1
-  adafruit/Adafruit DRV2605 Library@^1.2.2
-  earlephilhower/ESP8266Audio@^1.9.9
-  earlephilhower/ESP8266SAM@^1.0.1
+  adafruit/Adafruit DRV2605 Library@1.2.4
+  earlephilhower/ESP8266Audio@1.9.9
+  earlephilhower/ESP8266SAM@1.1.0
   lewisxhe/SensorLib@0.2.0

--- a/variants/esp32s3/tracksenger/platformio.ini
+++ b/variants/esp32s3/tracksenger/platformio.ini
@@ -12,7 +12,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7
 
 [env:tracksenger-lcd]
 extends = esp32s3_base
@@ -28,7 +28,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7
 
 [env:tracksenger-oled]
 extends = esp32s3_base

--- a/variants/esp32s3/unphone/platformio.ini
+++ b/variants/esp32s3/unphone/platformio.ini
@@ -27,9 +27,9 @@ build_src_filter =
   +<../variants/esp32s3/unphone>
 
 lib_deps = ${esp32s3_base.lib_deps}
-  lovyan03/LovyanGFX@ 1.2.0
+  lovyan03/LovyanGFX@1.2.0
   https://gitlab.com/hamishcunningham/unphonelibrary#meshtastic@9.0.0
-  adafruit/Adafruit NeoPixel @ ^1.12.0
+  adafruit/Adafruit NeoPixel@1.15.2
 
 
 [env:unphone-tft]

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -26,7 +26,7 @@ lib_deps =
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
   rweather/Crypto@0.4.0
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
-  lovyan03/LovyanGFX@^1.2.0
+  lovyan03/LovyanGFX@1.2.7
   # renovate: datasource=git-refs depName=libch341-spi-userspace packageName=https://github.com/pine64/libch341-spi-userspace gitBranch=main
   https://github.com/pine64/libch341-spi-userspace/archive/af9bc27c9c30fa90772279925b7c5913dff789b4.zip
   # renovate: datasource=custom.pio depName=adafruit/Adafruit seesaw Library packageName=adafruit/library/Adafruit seesaw Library

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -6,7 +6,7 @@ board = cross_platform
 board_level = extra
 lib_deps = 
   ${portduino_base.lib_deps}
-  melopero/Melopero RV3028@^1.1.0
+  melopero/Melopero RV3028@1.2.0
 
 build_src_filter = ${portduino_base.build_src_filter}
 

--- a/variants/nrf52840/Dongle_nRF52840-pca10059-v1/platformio.ini
+++ b/variants/nrf52840/Dongle_nRF52840-pca10059-v1/platformio.ini
@@ -11,5 +11,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/Dongle_nRF52840-pca10059-v1>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
+  zinggjm/GxEPD2@1.6.5
 debug_tool = jlink

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
@@ -24,8 +24,8 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/33db3fa8ee6fc47d160bdb44f8f127c9a9203a10.zip
-  lewisxhe/PCF8563_Library@^1.0.1
-  khoih-prog/nRF52_PWM@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
+  khoih-prog/nRF52_PWM@1.0.1
 ;upload_protocol = fs
 
 [env:thinknode_m1-inkhud]
@@ -45,4 +45,4 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -13,5 +13,5 @@ build_flags =
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M3>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  khoih-prog/nRF52_PWM@^1.0.1
-  lewisxhe/PCF8563_Library@^1.0.1
+  khoih-prog/nRF52_PWM@1.0.1
+  lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -12,4 +12,4 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M6>
 lib_deps =
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/nrf52840/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -15,7 +15,7 @@ board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ME25LS01-4Y10TD_e-ink>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
+  zinggjm/GxEPD2@1.6.5
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 upload_protocol = nrfutil
 ;upload_port = /dev/ttyACM1

--- a/variants/nrf52840/MakePython_nRF52840_eink/platformio.ini
+++ b/variants/nrf52840/MakePython_nRF52840_eink/platformio.ini
@@ -13,6 +13,6 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/MakePyt
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
-  zinggjm/GxEPD2@^1.6.2
+  zinggjm/GxEPD2@1.6.5
 debug_tool = jlink
 ;upload_port = /dev/ttyACM4

--- a/variants/nrf52840/TWC_mesh_v4/platformio.ini
+++ b/variants/nrf52840/TWC_mesh_v4/platformio.ini
@@ -8,5 +8,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/TWC_mesh_v4>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
+  zinggjm/GxEPD2@1.6.5
 debug_tool = jlink

--- a/variants/nrf52840/canaryone/platformio.ini
+++ b/variants/nrf52840/canaryone/platformio.ini
@@ -11,5 +11,5 @@ build_flags =
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/canaryone>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 ;upload_protocol = fs

--- a/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
@@ -14,7 +14,7 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 extra_scripts =
   ${env.extra_scripts}
   variants/nrf52840/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py ; Add to PIO's Project Tasks pane: preset builds for common displays

--- a/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
@@ -13,5 +13,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_node_t114>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
   https://github.com/meshtastic/st7789/archive/bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f.zip

--- a/variants/nrf52840/heltec_mesh_pocket/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_pocket/platformio.ini
@@ -25,7 +25,7 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_pocket> 
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
   https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
 
 
@@ -71,7 +71,7 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_pocket> 
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
   https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
 
 

--- a/variants/nrf52840/heltec_mesh_solar/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_solar/platformio.ini
@@ -14,7 +14,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/NMIoT/meshsolar/archive/dfc5330dad443982e6cdd37a61d33fc7252f468b.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
   ArduinoJson@6.21.4
 [env:heltec-mesh-solar]
 extends = heltec_mesh_solar_base

--- a/variants/nrf52840/nano-g2-ultra/platformio.ini
+++ b/variants/nrf52840/nano-g2-ultra/platformio.ini
@@ -10,5 +10,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/nano-g2-ultra>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 ;upload_protocol = fs

--- a/variants/nrf52840/nrf52.ini
+++ b/variants/nrf52840/nrf52.ini
@@ -2,7 +2,7 @@
 ; Instead of the standard nordicnrf52 platform, we use our fork which has our added variant files
 platform =
   # renovate: datasource=custom.pio depName=platformio/nordicnrf52 packageName=platformio/platform/nordicnrf52
-  platformio/nordicnrf52@^10.8.0
+  platformio/nordicnrf52@10.10.0
 extends = arduino_base
 platform_packages =
   ; our custom Git version until they merge our PR

--- a/variants/nrf52840/r1-neo/platformio.ini
+++ b/variants/nrf52840/r1-neo/platformio.ini
@@ -14,5 +14,5 @@ lib_deps =
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
-  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
+  rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
   artronshop/ArtronShop_RX8130CE@1.0.0

--- a/variants/nrf52840/rak2560/platformio.ini
+++ b/variants/nrf52840/rak2560/platformio.ini
@@ -14,7 +14,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak2560
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${nrf52_networking_base.lib_deps}
-  melopero/Melopero RV3028@^1.1.0
+  melopero/Melopero RV3028@1.2.0
   https://github.com/beegee-tokyo/RAK-OneWireSerial/archive/0.0.2.zip
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak3401_1watt/platformio.ini
+++ b/variants/nrf52840/rak3401_1watt/platformio.ini
@@ -16,9 +16,9 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak3401
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}
-  melopero/Melopero RV3028@^1.1.0
-  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
-  beegee-tokyo/RAK12035_SoilMoisture@^1.0.4
+  melopero/Melopero RV3028@1.2.0
+  rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  beegee-tokyo/RAK12035_SoilMoisture@1.0.4
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
 
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -23,10 +23,10 @@ build_src_filter = ${nrf52_base.build_src_filter} \
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${nrf52_networking_base.lib_deps}
-  melopero/Melopero RV3028@^1.1.0
+  melopero/Melopero RV3028@1.2.0
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
-  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
-  beegee-tokyo/RAK12035_SoilMoisture@^1.0.4
+  rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  beegee-tokyo/RAK12035_SoilMoisture@1.0.4
   # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
 
@@ -42,7 +42,7 @@ extends = env:rak4631
 board_level = extra
 
 ; if the builtin version of openocd has a buggy version of semihosting, so use the external version
-; platform_packages = platformio/tool-openocd@^3.1200.0
+; platform_packages = platformio/tool-openocd@3.1200.0
 
 build_flags =
   ${env:rak4631.build_flags}
@@ -59,6 +59,6 @@ lib_deps =
 ; In theory I could change those scripts.  But for now I'm trying going back to a DAP adapter but with the external openocd.
 
 upload_protocol = stlink
-; eventually use platformio/tool-pyocd@^2.3600.0 instad
+; eventually use platformio/tool-pyocd@2.3600.0 instad
 ;upload_protocol = custom
 ;upload_command = pyocd flash -t nrf52840 $UPLOADERFLAGS $SOURCE

--- a/variants/nrf52840/rak4631_epaper/platformio.ini
+++ b/variants/nrf52840/rak4631_epaper/platformio.ini
@@ -14,11 +14,11 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak4631_epaper>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
-  melopero/Melopero RV3028@^1.1.0
-  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
-  beegee-tokyo/RAKwireless RAK12034@^1.0.0
-  beegee-tokyo/RAK12035_SoilMoisture@^1.0.4
+  zinggjm/GxEPD2@1.6.5
+  melopero/Melopero RV3028@1.2.0
+  rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  beegee-tokyo/RAKwireless RAK12034@1.0.0
+  beegee-tokyo/RAK12035_SoilMoisture@1.0.4
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ;upload_protocol = jlink

--- a/variants/nrf52840/rak4631_epaper_onrxtx/platformio.ini
+++ b/variants/nrf52840/rak4631_epaper_onrxtx/platformio.ini
@@ -16,11 +16,11 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak4631_epaper_onrxtx>
 lib_deps = 
   ${nrf52840_base.lib_deps}
-  zinggjm/GxEPD2@^1.6.2
-  melopero/Melopero RV3028@^1.1.0
-  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
-  beegee-tokyo/RAKwireless RAK12034@^1.0.0
-  beegee-tokyo/RAK12035_SoilMoisture@^1.0.4
+  zinggjm/GxEPD2@1.6.5
+  melopero/Melopero RV3028@1.2.0
+  rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  beegee-tokyo/RAKwireless RAK12034@1.0.0
+  beegee-tokyo/RAK12035_SoilMoisture@1.0.4
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ;upload_protocol = jlink

--- a/variants/nrf52840/rak4631_eth_gw/platformio.ini
+++ b/variants/nrf52840/rak4631_eth_gw/platformio.ini
@@ -27,12 +27,12 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak4631
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}
-  melopero/Melopero RV3028@^1.1.0
+  melopero/Melopero RV3028@1.2.0
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
-  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
+  rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
   # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
-  bblanchon/ArduinoJson @ 6.21.4
+  bblanchon/ArduinoJson@6.21.4
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ; Note: as of 6/2013 the serial/bootloader based programming takes approximately 30 seconds
 ;upload_protocol = jlink
@@ -45,7 +45,7 @@ extends = env:rak4631
 board_level = extra
 
 ; if the builtin version of openocd has a buggy version of semihosting, so use the external version
-; platform_packages = platformio/tool-openocd@^3.1200.0
+; platform_packages = platformio/tool-openocd@3.1200.0
 
 build_flags =
   ${env:rak4631_eth_gw.build_flags}
@@ -62,6 +62,6 @@ lib_deps =
 ; In theory I could change those scripts.  But for now I'm trying going back to a DAP adapter but with the external openocd.
 
 upload_protocol = stlink
-; eventually use platformio/tool-pyocd@^2.3600.0 instad
+; eventually use platformio/tool-pyocd@2.3600.0 instad
 ;upload_protocol = custom
 ;upload_command = pyocd flash -t nrf52840 $UPLOADERFLAGS $SOURCE

--- a/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
+++ b/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
@@ -29,7 +29,7 @@ extends = env:rak4631_nomadstar_meteor_pro
 board_level = extra
 
 ; if the builtin version of openocd has a buggy version of semihosting, so use the external version
-; platform_packages = platformio/tool-openocd@^3.1200.0
+; platform_packages = platformio/tool-openocd@3.1200.0
 
 build_flags =
   ${env:rak4631.build_flags}
@@ -46,6 +46,6 @@ lib_deps =
 ; In theory I could change those scripts.  But for now I'm trying going back to a DAP adapter but with the external openocd.
 
 upload_protocol = stlink
-; eventually use platformio/tool-pyocd@^2.3600.0 instad
+; eventually use platformio/tool-pyocd@2.3600.0 instad
 ;upload_protocol = custom
 ;upload_command = pyocd flash -t nrf52840 $UPLOADERFLAGS $SOURCE

--- a/variants/nrf52840/rak_wismeshtap/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtap/platformio.ini
@@ -18,13 +18,13 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak_wis
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${nrf52_networking_base.lib_deps}
-  melopero/Melopero RV3028@^1.1.0
+  melopero/Melopero RV3028@1.2.0
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
-  rakwireless/RAKwireless NCP5623 RGB LED library@^1.0.2
-  bodmer/TFT_eSPI
-  beegee-tokyo/RAKwireless RAK12034@^1.0.0
-  beegee-tokyo/RAK14014-FT6336U @ 1.0.1
-  beegee-tokyo/RAK12035_SoilMoisture@^1.0.4
+  rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  bodmer/TFT_eSPI@2.5.43
+  beegee-tokyo/RAKwireless RAK12034@1.0.0
+  beegee-tokyo/RAK14014-FT6336U@1.0.1
+  beegee-tokyo/RAK12035_SoilMoisture@1.0.4
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ;upload_protocol = jlink

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -21,7 +21,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/t-echo>
 lib_deps = 
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1
 ;upload_protocol = fs
 
 [env:t-echo-inkhud]
@@ -41,4 +41,4 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  lewisxhe/PCF8563_Library@1.0.1

--- a/variants/rp2040/rak11310/platformio.ini
+++ b/variants/rp2040/rak11310/platformio.ini
@@ -14,7 +14,7 @@ build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rp2040/rak11310
 lib_deps =
   ${rp2040_base.lib_deps}
   ${networking_base.lib_deps}
-  melopero/Melopero RV3028@^1.1.0
+  melopero/Melopero RV3028@1.2.0
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
 debug_build_flags = ${rp2040_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool


### PR DESCRIPTION
Replace all PlatformIO fuzzy version matches with explicit versions.
This allows for reproducible builds into the future :+1: and better aligns with our CI structure (pre-seeded cache images).

This change does **not** introduce version *changes*, but simply "updates" to the version already being referenced by the fuzzy-match (^).
