### PR TITLE
PIO: Renovate all the things

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -162,8 +162,8 @@ lib_deps =
 	emotibit/EmotiBit MLX90632@1.0.8
 	# renovate: datasource=custom.pio depName=Adafruit MLX90614 packageName=adafruit/library/Adafruit MLX90614 Library
 	adafruit/Adafruit MLX90614 Library@2.1.5
-	# renovate: datasource=github-tags depName=INA3221 packageName=sgtwilko/INA3221
-	https://github.com/sgtwilko/INA3221#bb03d7e9bfcc74fc798838a54f4f99738f29fc6a
+	# renovate: datasource=git-refs depName=INA3221 packageName=https://github.com/sgtwilko/INA3221 gitBranch=FixOverflow
+	https://github.com/sgtwilko/INA3221/archive/bb03d7e9bfcc74fc798838a54f4f99738f29fc6a.zip
 	# renovate: datasource=custom.pio depName=QMC5883L Compass packageName=mprograms/library/QMC5883LCompass
 	mprograms/QMC5883LCompass@1.2.3
 	# renovate: datasource=custom.pio depName=DFRobot_RTU packageName=dfrobot/library/DFRobot_RTU

--- a/src/graphics/niche/InkHUD/PlatformioConfig.ini
+++ b/src/graphics/niche/InkHUD/PlatformioConfig.ini
@@ -8,4 +8,5 @@ build_flags =
   -D MESHTASTIC_EXCLUDE_INPUTBROKER ; Suppress default input handling
   -D HAS_BUTTON=0 ; Suppress default ButtonThread
 lib_deps =
+  # TODO renovate
   https://github.com/ZinggJM/GFX_Root#2.0.0 ; Used by InkHUD as a "slimmer" version of AdafruitGFX

--- a/variants/esp32/betafpv_2400_tx_micro/platformio.ini
+++ b/variants/esp32/betafpv_2400_tx_micro/platformio.ini
@@ -15,4 +15,5 @@ upload_protocol = esptool
 upload_speed = 460800
 lib_deps =
   ${esp32_base.lib_deps}
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32/chatter2/platformio.ini
+++ b/variants/esp32/chatter2/platformio.ini
@@ -9,4 +9,5 @@ build_flags =
   
 lib_deps =
   ${esp32_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -62,8 +62,8 @@ lib_deps =
   h2zero/NimBLE-Arduino@1.4.3
   # renovate: datasource=git-refs depName=libpax packageName=https://github.com/dbinfrago/libpax gitBranch=master
   https://github.com/dbinfrago/libpax/archive/3cdc0371c375676a97967547f4065607d4c53fd1.zip
-  # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib
-  https://github.com/lewisxhe/XPowersLib/archive/v0.3.2.zip
+  # renovate: datasource=custom.pio depName=XPowersLib packageName=lewisxhe/library/XPowersLib
+  lewisxhe/XPowersLib@0.3.2
   # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto

--- a/variants/esp32/m5stack_core/platformio.ini
+++ b/variants/esp32/m5stack_core/platformio.ini
@@ -25,4 +25,5 @@ lib_ignore =
   m5stack-core
 lib_deps = 
   ${esp32_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -18,7 +18,9 @@ build_flags =
   -DM5STACK
 lib_deps = 
   ${esp32_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 lib_ignore =
   m5stack-coreink

--- a/variants/esp32/radiomaster_900_bandit/platformio.ini
+++ b/variants/esp32/radiomaster_900_bandit/platformio.ini
@@ -13,4 +13,5 @@ board_build.f_cpu = 240000000L
 upload_protocol = esptool
 lib_deps =
   ${esp32_base.lib_deps}
+  # renovate: datasource=github-tags depName=STK8xxx-Accelerometer packageName=gjelsoe/STK8xxx-Accelerometer
   https://github.com/gjelsoe/STK8xxx-Accelerometer/archive/v0.1.1.zip

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -20,5 +20,7 @@ build_flags =
 
 lib_deps =
   ${env:tbeam.lib_deps}
-  https://github.com/meshtastic/st7796/archive/refs/tags/1.0.5.zip ; display addon
-  lewisxhe/SensorLib@0.3.1 ; touchscreen addon
+  # renovate: datasource=github-tags depName=meshtastic-st7796 packageName=meshtastic/st7796
+  https://github.com/meshtastic/st7796/archive/1.0.5.zip
+  # renovate: datasource=custom.pio depName=lewisxhe-SensorLib packageName=lewisxhe/library/SensorLib
+  lewisxhe/SensorLib@0.3.1

--- a/variants/esp32/wiphone/platformio.ini
+++ b/variants/esp32/wiphone/platformio.ini
@@ -10,6 +10,9 @@ build_flags =
   -I variants/esp32/wiphone
 lib_deps = 
   ${esp32_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
+  # renovate: datasource=custom.pio depName=SX1509 IO Expander packageName=sparkfun/library/SX1509 IO Expander
   sparkfun/SX1509 IO Expander@3.0.6
+  # renovate: datasource=custom.pio depName=APA102 packageName=pololu/library/APA102
   pololu/APA102@3.0.0

--- a/variants/esp32c3/heltec_hru_3601/platformio.ini
+++ b/variants/esp32c3/heltec_hru_3601/platformio.ini
@@ -6,4 +6,5 @@ build_flags =
   -D HELTEC_HRU_3601
   -I variants/esp32c3/heltec_hru_3601
 lib_deps = ${esp32c3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32c6/m5stack_unitc6l/platformio.ini
+++ b/variants/esp32c6/m5stack_unitc6l/platformio.ini
@@ -12,7 +12,9 @@ build_unflags =
   -D HAS_WIFI
 lib_deps =
   ${esp32c6_base.lib_deps}
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2
+  # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
   h2zero/NimBLE-Arduino@2.3.7
 build_flags = 
   ${esp32c6_base.build_flags}

--- a/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
+++ b/variants/esp32s3/ELECROW-ThinkNode-M5/platformio.ini
@@ -16,6 +16,9 @@ build_flags =
   -DEINK_BACKGROUND_USES_FAST          ; (Optional) Use FAST refresh for both BACKGROUND and RESPONSIVE, until a limit is reached.
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
+  # renovate: datasource=custom.pio depName=PCA9557-arduino packageName=maxpromer/library/PCA9557-arduino
   maxpromer/PCA9557-arduino@1.0.0

--- a/variants/esp32s3/bpi_picow_esp32_s3/platformio.ini
+++ b/variants/esp32s3/bpi_picow_esp32_s3/platformio.ini
@@ -9,6 +9,7 @@ upload_protocol = esptool
 ;upload_port = /dev/ttyACM2
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=caveman99-ESP32_Codec2 packageName=caveman99/library/ESP32 Codec2
   caveman99/ESP32 Codec2@1.0.1
 build_flags = 
   ${esp32s3_base.build_flags}

--- a/variants/esp32s3/crowpanel-esp32s3-5-epaper/platformio.ini
+++ b/variants/esp32s3/crowpanel-esp32s3-5-epaper/platformio.ini
@@ -25,6 +25,7 @@ build_flags =
   ;-DEINK_LIMIT_RATE_RESPONSIVE_SEC=1 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/33db3fa8ee6fc47d160bdb44f8f127c9a9203a10.zip
 
 [env:crowpanel-esp32s3-4-epaper]
@@ -54,6 +55,7 @@ build_flags =
   ;-DEINK_LIMIT_RATE_RESPONSIVE_SEC=1 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/33db3fa8ee6fc47d160bdb44f8f127c9a9203a10.zip
 
 [env:crowpanel-esp32s3-2-epaper]
@@ -83,4 +85,5 @@ build_flags =
   ;-DEINK_LIMIT_RATE_RESPONSIVE_SEC=1 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/33db3fa8ee6fc47d160bdb44f8f127c9a9203a10.zip

--- a/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
@@ -10,7 +10,9 @@ upload_protocol = esptool
 upload_speed = 921600
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2
 build_unflags =
   ${esp32s3_base.build_unflags}

--- a/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
@@ -10,6 +10,7 @@ upload_protocol = esptool
 upload_speed = 921600
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2
 build_unflags =
   ${esp32s3_base.build_unflags}

--- a/variants/esp32s3/dreamcatcher/platformio.ini
+++ b/variants/esp32s3/dreamcatcher/platformio.ini
@@ -12,7 +12,9 @@ build_flags =
   -D ARDUINO_USB_CDC_ON_BOOT=1
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
   earlephilhower/ESP8266Audio@1.9.9
+  # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
 
 [env:dreamcatcher-2206] 

--- a/variants/esp32s3/elecrow_panel/platformio.ini
+++ b/variants/esp32s3/elecrow_panel/platformio.ini
@@ -41,9 +41,13 @@ build_flags = ${esp32s3_base.build_flags} -Os
 
 lib_deps = ${esp32s3_base.lib_deps}
   ${device-ui_base.lib_deps}
+  # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
   earlephilhower/ESP8266Audio@1.9.9
+  # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.0.1
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.0 ; note: v1.2.7 breaks the elecrow 7" display functionality
+  # renovate: datasource=custom.pio depName=TCA9534 packageName=hideakitai/library/TCA9534
   hideakitai/TCA9534@0.1.1
 
 [crowpanel_small_esp32s3_base] ; 2.4, 2.8, 3.5 inch

--- a/variants/esp32s3/esp32-s3-pico/platformio.ini
+++ b/variants/esp32s3/esp32-s3-pico/platformio.ini
@@ -22,5 +22,7 @@ build_flags = ${esp32s3_base.build_flags}
   -DEINK_HEIGHT=128
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32s3/hackaday-communicator/platformio.ini
+++ b/variants/esp32s3/hackaday-communicator/platformio.ini
@@ -12,4 +12,5 @@ build_flags = ${esp32s3_base.build_flags}
   -I variants/esp32s3/hackaday-communicator
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-Arduino_GFX packageName=https://github.com/meshtastic/Arduino_GFX gitBranch=master
   https://github.com/meshtastic/Arduino_GFX/archive/054e81ffaf23784830a734e3c184346789349406.zip

--- a/variants/esp32s3/heltec_sensor_hub/platformio.ini
+++ b/variants/esp32s3/heltec_sensor_hub/platformio.ini
@@ -9,4 +9,5 @@ build_flags =
   -D HELTEC_SENSOR_HUB
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2

--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -21,8 +21,6 @@ build_flags =
   -D I2C_SCL=18
   -D I2C_SDA1=4
   -D I2C_SCL1=3
-lib_deps = 
-  ${heltec_v4_base.lib_deps}
 
 [env:heltec-v4-tft]
 extends = heltec_v4_base
@@ -105,6 +103,10 @@ build_flags =
 
 lib_deps = ${heltec_v4_base.lib_deps}
   ; ${device-ui_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.0
+  # renovate: datasource=git-refs depName=Quency-D_chsc6x packageName=https://github.com/Quency-D/chsc6x gitBranch=master
   https://github.com/Quency-D/chsc6x/archive/5cbead829d6b432a8d621ed1aafd4eb474fd4f27.zip
+  ; TODO revert to official device-ui (when merged)
+  # renovate: datasource=git-refs depName=Quency-D_device-ui packageName=https://github.com/Quency-D/device-ui gitBranch=heltec-v4-tft
   https://github.com/Quency-D/device-ui/archive/7c9870b8016641190b059bdd90fe16c1012a39eb.zip

--- a/variants/esp32s3/heltec_vision_master_e213/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e213/platformio.ini
@@ -17,7 +17,9 @@ build_flags =
   -DEINK_HASQUIRK_GHOSTING             ; Display model is identified as "prone to ghosting"
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200
 

--- a/variants/esp32s3/heltec_vision_master_e290/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_e290/platformio.ini
@@ -20,7 +20,9 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/448c8538129fde3d02a7cb5e6fc81971ad92547f.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200
 

--- a/variants/esp32s3/heltec_vision_master_t190/platformio.ini
+++ b/variants/esp32s3/heltec_vision_master_t190/platformio.ini
@@ -8,6 +8,8 @@ build_flags =
   -D HELTEC_VISION_MASTER_T190
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
+  # renovate: datasource=git-refs depName=meshtastic-st7789 packageName=https://github.com/meshtastic/st7789 gitBranch=main
   https://github.com/meshtastic/st7789/archive/bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f.zip
 upload_speed = 921600

--- a/variants/esp32s3/heltec_wireless_paper/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper/platformio.ini
@@ -18,7 +18,9 @@ build_flags =
   -D EINK_HASQUIRK_GHOSTING             ; Display model is identified as "prone to ghosting"
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/1655054ba298e0e29fc2044741940f927f9c2a43.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200
 

--- a/variants/esp32s3/heltec_wireless_paper_v1/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_paper_v1/platformio.ini
@@ -15,6 +15,8 @@ build_flags =
   -D EINK_LIMIT_GHOSTING_PX=2000        ; (Optional) How much image ghosting is tolerated
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 upload_speed = 115200

--- a/variants/esp32s3/heltec_wireless_tracker/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker/platformio.ini
@@ -12,4 +12,5 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32s3/heltec_wireless_tracker_V1_0/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_V1_0/platformio.ini
@@ -11,4 +11,5 @@ build_flags =
   ;-D DEBUG_DISABLED ; uncomment this line to disable DEBUG output
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker_v2/platformio.ini
@@ -10,4 +10,5 @@ build_flags =
   -D HELTEC_WIRELESS_TRACKER_V2
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7

--- a/variants/esp32s3/icarus/platformio.ini
+++ b/variants/esp32s3/icarus/platformio.ini
@@ -7,6 +7,7 @@ board_build.mcu = esp32s3
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool
 upload_speed = 921600
+; TODO renovate or remove
 platform_packages = platformio/framework-arduinoespressif32@https://github.com/PowerFeather/powerfeather-meshtastic-arduino-lib/releases/download/2.0.16a/esp32-2.0.16.zip
 build_unflags =
   ${esp32s3_base.build_unflags}

--- a/variants/esp32s3/mesh-tab/platformio.ini
+++ b/variants/esp32s3/mesh-tab/platformio.ini
@@ -50,6 +50,7 @@ build_src_filter = ${esp32s3_base.build_src_filter}
 lib_deps =
   ${esp32s3_base.lib_deps}
   ${device-ui_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
 
 [mesh_tab_xpt2046]

--- a/variants/esp32s3/picomputer-s3/platformio.ini
+++ b/variants/esp32s3/picomputer-s3/platformio.ini
@@ -15,6 +15,7 @@ build_flags =
 
 lib_deps = 
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
 
 build_src_filter =

--- a/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
+++ b/variants/esp32s3/rak_wismesh_tap_v2/platformio.ini
@@ -15,6 +15,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
 
 [ft5x06]

--- a/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
+++ b/variants/esp32s3/seeed-sensecap-indicator/platformio.ini
@@ -24,10 +24,12 @@ build_flags = ${esp32s3_base.build_flags}
   -DUSE_ARDUINO_HAL_GPIO
 
 lib_deps = ${esp32s3_base.lib_deps}
+  ; TODO switch back to official LovyanGFX
   https://github.com/mverch67/LovyanGFX/archive/4c76238c1344162a234ae917b27651af146d6fb2.zip
+  # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
   earlephilhower/ESP8266Audio@1.9.9
+  # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
-
 
 [env:seeed-sensecap-indicator-tft]
 extends = env:seeed-sensecap-indicator
@@ -64,4 +66,5 @@ build_flags =
 lib_deps =
   ${env:seeed-sensecap-indicator.lib_deps}
   ${device-ui_base.lib_deps}
+  ; TODO switch back to official bb_captouch
   https://github.com/mverch67/bb_captouch/archive/8626412fe650d808a267791c0eae6e5860c85a5d.zip ; alternative touch library supporting FT6x36

--- a/variants/esp32s3/t-deck-pro/platformio.ini
+++ b/variants/esp32s3/t-deck-pro/platformio.ini
@@ -17,7 +17,11 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.4
+  # renovate: datasource=git-refs depName=CSE_Touch packageName=https://github.com/CIRCUITSTATE/CSE_Touch gitBranch=main
   https://github.com/CIRCUITSTATE/CSE_Touch/archive/b44f23b6f870b848f1fbe453c190879bc6cfaafa.zip
+  # renovate: datasource=github-tags depName=CSE_CST328 packageName=CIRCUITSTATE/CSE_CST328
   https://github.com/CIRCUITSTATE/CSE_CST328/archive/refs/tags/v0.0.4.zip
+  # renovate: datasource=git-refs depName=BQ27220 packageName=https://github.com/mverch67/BQ27220 gitBranch=main
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip

--- a/variants/esp32s3/t-deck/platformio.ini
+++ b/variants/esp32s3/t-deck/platformio.ini
@@ -12,8 +12,11 @@ build_flags = ${esp32s3_base.build_flags}
   -I variants/esp32s3/t-deck
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
+  # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
   earlephilhower/ESP8266Audio@1.9.9
+  # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
 
 [env:t-deck-tft]
@@ -68,4 +71,5 @@ build_flags =
 lib_deps =
   ${env:t-deck.lib_deps}
   ${device-ui_base.lib_deps}
+  # renovate: datasource=github-tags depName=bb_captouch packageName=bitbank2/bb_captouch
   https://github.com/bitbank2/bb_captouch/archive/refs/tags/1.3.1.zip

--- a/variants/esp32s3/t-eth-elite/platformio.ini
+++ b/variants/esp32s3/t-eth-elite/platformio.ini
@@ -15,4 +15,5 @@ lib_ignore =
 
 lib_deps = 
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=github-tags depName=ETHClass2 packageName=meshtastic/ETHClass2
   https://github.com/meshtastic/ETHClass2/archive/v1.0.0.zip

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -13,9 +13,15 @@ build_flags = ${esp32s3_base.build_flags}
   -DHAS_BMA423=1
 
 lib_deps = ${esp32s3_base.lib_deps}
-	lovyan03/LovyanGFX@1.2.7
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
+  lovyan03/LovyanGFX@1.2.7
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
+  # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4
+  # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
   earlephilhower/ESP8266Audio@1.9.9
+  # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
+  # renovate: datasource=custom.pio depName=lewisxhe-SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.2.0

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -7,6 +7,7 @@ board_check = true
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 
 build_flags = 

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -17,14 +17,23 @@ build_flags = ${esp32s3_base.build_flags}
   -D ROTARY_BUXTRONICS
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
+  # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
   earlephilhower/ESP8266Audio@1.9.9
+  # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.0.1
+  # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
+  # renovate: datasource=custom.pio depName=lewisxhe-SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.3.1
-  https://github.com/pschatzmann/arduino-audio-driver/archive/refs/tags/v0.1.3.zip
+  # renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
+  https://github.com/pschatzmann/arduino-audio-driver/archive/v0.1.3.zip
+  # TODO renovate
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip
+  # TODO renovate
   https://github.com/mverch67/RotaryEncoder/archive/da958a21389cbcd485989705df602a33e092dd88.zip
 
 [env:tlora-pager-tft]

--- a/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
+++ b/variants/esp32s3/tlora_t3s3_epaper/platformio.ini
@@ -20,6 +20,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/b202ebfec6a4821e098cf7a625ba0f6f2400292d.zip
 
 [env:tlora-t3s3-epaper-inkhud]

--- a/variants/esp32s3/tracksenger/platformio.ini
+++ b/variants/esp32s3/tracksenger/platformio.ini
@@ -12,6 +12,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
 
 [env:tracksenger-lcd]
@@ -28,6 +29,7 @@ build_flags =
 
 lib_deps =
   ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
 
 [env:tracksenger-oled]

--- a/variants/esp32s3/unphone/platformio.ini
+++ b/variants/esp32s3/unphone/platformio.ini
@@ -27,10 +27,12 @@ build_src_filter =
   +<../variants/esp32s3/unphone>
 
 lib_deps = ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.0
+  # TODO renovate
   https://gitlab.com/hamishcunningham/unphonelibrary#meshtastic@9.0.0
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
   adafruit/Adafruit NeoPixel@1.15.2
-
 
 [env:unphone-tft]
 board_level = extra

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -6,6 +6,7 @@ board = cross_platform
 board_level = extra
 lib_deps = 
   ${portduino_base.lib_deps}
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
 
 build_src_filter = ${portduino_base.build_src_filter}

--- a/variants/nrf52840/Dongle_nRF52840-pca10059-v1/platformio.ini
+++ b/variants/nrf52840/Dongle_nRF52840-pca10059-v1/platformio.ini
@@ -11,5 +11,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/Dongle_nRF52840-pca10059-v1>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
 debug_tool = jlink

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/platformio.ini
@@ -23,8 +23,11 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M1>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/33db3fa8ee6fc47d160bdb44f8f127c9a9203a10.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
+  # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
 ;upload_protocol = fs
 
@@ -45,4 +48,5 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -13,5 +13,7 @@ build_flags =
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M3>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -12,4 +12,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M6>
 lib_deps =
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/ME25LS01-4Y10TD_e-ink/platformio.ini
+++ b/variants/nrf52840/ME25LS01-4Y10TD_e-ink/platformio.ini
@@ -15,6 +15,7 @@ board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ME25LS01-4Y10TD_e-ink>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 upload_protocol = nrfutil

--- a/variants/nrf52840/MakePython_nRF52840_eink/platformio.ini
+++ b/variants/nrf52840/MakePython_nRF52840_eink/platformio.ini
@@ -12,7 +12,9 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/MakePython_nRF52840_eink>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
 debug_tool = jlink
 ;upload_port = /dev/ttyACM4

--- a/variants/nrf52840/MakePython_nRF52840_oled/platformio.ini
+++ b/variants/nrf52840/MakePython_nRF52840_oled/platformio.ini
@@ -8,5 +8,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/MakePython_nRF52840_oled>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
   https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
 debug_tool = jlink

--- a/variants/nrf52840/TWC_mesh_v4/platformio.ini
+++ b/variants/nrf52840/TWC_mesh_v4/platformio.ini
@@ -8,5 +8,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/TWC_mesh_v4>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
 debug_tool = jlink

--- a/variants/nrf52840/canaryone/platformio.ini
+++ b/variants/nrf52840/canaryone/platformio.ini
@@ -11,5 +11,6 @@ build_flags =
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/canaryone>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 ;upload_protocol = fs

--- a/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114-inkhud/platformio.ini
@@ -14,6 +14,7 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 extra_scripts =
   ${env.extra_scripts}

--- a/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_node_t114/platformio.ini
@@ -13,5 +13,7 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_node_t114>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
+  # renovate: datasource=git-refs depName=meshtastic-st7789 packageName=https://github.com/meshtastic/st7789 gitBranch=main
   https://github.com/meshtastic/st7789/archive/bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f.zip

--- a/variants/nrf52840/heltec_mesh_pocket/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_pocket/platformio.ini
@@ -25,9 +25,10 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_pocket> 
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
-  https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
-
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
+  https://github.com/meshtastic/GxEPD2/archive/b202ebfec6a4821e098cf7a625ba0f6f2400292d.zip
 
 [env:heltec-mesh-pocket-5000-inkhud]
 extends = nrf52840_base, inkhud
@@ -71,9 +72,10 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_pocket> 
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
-  https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
-
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
+  https://github.com/meshtastic/GxEPD2/archive/b202ebfec6a4821e098cf7a625ba0f6f2400292d.zip
 
 [env:heltec-mesh-pocket-10000-inkhud]
 extends = nrf52840_base, inkhud

--- a/variants/nrf52840/heltec_mesh_solar/platformio.ini
+++ b/variants/nrf52840/heltec_mesh_solar/platformio.ini
@@ -13,9 +13,13 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/heltec_mesh_solar>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=git-refs depName=NMIoT-meshsolar packageName=https://github.com/NMIoT/meshsolar gitBranch=main
   https://github.com/NMIoT/meshsolar/archive/dfc5330dad443982e6cdd37a61d33fc7252f468b.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
-  ArduinoJson@6.21.4
+  # renovate: datasource=custom.pio depName=ArduinoJson packageName=bblanchon/library/ArduinoJson
+  bblanchon/ArduinoJson@6.21.4
+
 [env:heltec-mesh-solar]
 extends = heltec_mesh_solar_base
 build_flags = ${heltec_mesh_solar_base.build_flags}
@@ -48,6 +52,7 @@ build_flags = ${heltec_mesh_solar_base.build_flags}
   -DEINK_HASQUIRK_GHOSTING             ; Display model is identified as "prone to ghosting"
 lib_deps =
   ${heltec_mesh_solar_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/a05c11c02862624266b61599b0d6ba93e33c6f24.zip
 
 [env:heltec-mesh-solar-inkhud]
@@ -70,7 +75,6 @@ build_flags = ${heltec_mesh_solar_base.build_flags}
 lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${heltec_mesh_solar_base.lib_deps}
-
 
 [env:heltec-mesh-solar-oled]
 extends = heltec_mesh_solar_base
@@ -112,4 +116,5 @@ build_flags = ${heltec_mesh_solar_base.build_flags}
   -DPIN_SPI1_SCK=ST7789_SCK
 lib_deps =
   ${heltec_mesh_solar_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-st7789 packageName=https://github.com/meshtastic/st7789 gitBranch=main
   https://github.com/meshtastic/st7789/archive/bd33ea58ddfe4a5e4a66d53300ccbd38d66ac21f.zip

--- a/variants/nrf52840/meshlink/platformio.ini
+++ b/variants/nrf52840/meshlink/platformio.ini
@@ -46,6 +46,7 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/meshlink>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/monteops_hw1/platformio.ini
+++ b/variants/nrf52840/monteops_hw1/platformio.ini
@@ -10,6 +10,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/monteop
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}
+  # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/muzi_base/platformio.ini
+++ b/variants/nrf52840/muzi_base/platformio.ini
@@ -10,6 +10,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52840_base.build_src_filter} +<../variants/nrf52840/muzi_base>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=ArtronShop_RX8130CE packageName=artronshop/library/ArtronShop_RX8130CE
   artronshop/ArtronShop_RX8130CE@1.0.0
-
-

--- a/variants/nrf52840/nano-g2-ultra/platformio.ini
+++ b/variants/nrf52840/nano-g2-ultra/platformio.ini
@@ -10,5 +10,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/nano-g2-ultra>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 ;upload_protocol = fs

--- a/variants/nrf52840/r1-neo/platformio.ini
+++ b/variants/nrf52840/r1-neo/platformio.ini
@@ -13,6 +13,9 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/r1-neo>
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}
+  # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+  # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  # renovate: datasource=custom.pio depName=ArtronShop_RX8130CE packageName=artronshop/library/ArtronShop_RX8130CE
   artronshop/ArtronShop_RX8130CE@1.0.0

--- a/variants/nrf52840/rak2560/platformio.ini
+++ b/variants/nrf52840/rak2560/platformio.ini
@@ -14,7 +14,9 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak2560
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${nrf52_networking_base.lib_deps}
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=github-tags depName=RAK-OneWireSerial packageName=beegee-tokyo/RAK-OneWireSerial
   https://github.com/beegee-tokyo/RAK-OneWireSerial/archive/0.0.2.zip
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak3401_1watt/platformio.ini
+++ b/variants/nrf52840/rak3401_1watt/platformio.ini
@@ -16,9 +16,13 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak3401
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  # renovate: datasource=custom.pio depName=RAK12035_SoilMoisture packageName=beegee-tokyo/library/RAK12035_SoilMoisture
   beegee-tokyo/RAK12035_SoilMoisture@1.0.4
+  # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
 
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -23,9 +23,13 @@ build_src_filter = ${nrf52_base.build_src_filter} \
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${nrf52_networking_base.lib_deps}
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+  # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  # renovate: datasource=custom.pio depName=RAK12035_SoilMoisture packageName=beegee-tokyo/library/RAK12035_SoilMoisture
   beegee-tokyo/RAK12035_SoilMoisture@1.0.4
   # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
@@ -50,6 +54,7 @@ build_flags =
 
 lib_deps =
   ${env:rak4631.lib_deps}
+  # TODO renovate
   https://github.com/geeksville/Armduino-Semihosting/archive/35b538fdf208c3530c1434cd099a08e486672ee4.zip
 
 ; NOTE: the pyocd support for semihosting is buggy.  So I switched to using the builtin platformio support for the stlink adapter which worked much better.

--- a/variants/nrf52840/rak4631_epaper/platformio.ini
+++ b/variants/nrf52840/rak4631_epaper/platformio.ini
@@ -14,10 +14,15 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak4631_epaper>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  # renovate: datasource=custom.pio depName=RAK12034 packageName=beegee-tokyo/library/RAKwireless RAK12034
   beegee-tokyo/RAKwireless RAK12034@1.0.0
+  # renovate: datasource=custom.pio depName=RAK12035_SoilMoisture packageName=beegee-tokyo/library/RAK12035_SoilMoisture
   beegee-tokyo/RAK12035_SoilMoisture@1.0.4
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak4631_epaper_onrxtx/platformio.ini
+++ b/variants/nrf52840/rak4631_epaper_onrxtx/platformio.ini
@@ -16,10 +16,15 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak4631_epaper_onrxtx>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  # renovate: datasource=custom.pio depName=RAK12034 packageName=beegee-tokyo/library/RAKwireless RAK12034
   beegee-tokyo/RAKwireless RAK12034@1.0.0
+  # renovate: datasource=custom.pio depName=RAK12035_SoilMoisture packageName=beegee-tokyo/library/RAK12035_SoilMoisture
   beegee-tokyo/RAK12035_SoilMoisture@1.0.4
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak4631_eth_gw/platformio.ini
+++ b/variants/nrf52840/rak4631_eth_gw/platformio.ini
@@ -27,11 +27,15 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak4631
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${networking_base.lib_deps}
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+  # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
   # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
+  # renovate: datasource=custom.pio depName=ArduinoJson packageName=bblanchon/library/ArduinoJson
   bblanchon/ArduinoJson@6.21.4
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
 ; Note: as of 6/2013 the serial/bootloader based programming takes approximately 30 seconds
@@ -53,6 +57,7 @@ build_flags =
 
 lib_deps =
   ${env:rak4631_eth_gw.lib_deps}
+  # TODO renovate
   https://github.com/geeksville/Armduino-Semihosting/archive/35b538fdf208c3530c1434cd099a08e486672ee4.zip
 
 ; NOTE: the pyocd support for semihosting is buggy.  So I switched to using the builtin platformio support for the stlink adapter which worked much better.

--- a/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
+++ b/variants/nrf52840/rak4631_nomadstar_meteor_pro/platformio.ini
@@ -15,6 +15,7 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak4631_nomadstar_meteor_pro> +<mesh/api/> +<mqtt/>
 lib_deps =
   ${nrf52840_base.lib_deps}
+  # TODO renovate
   https://github.com/NomadStar-outdoor/IOBoard-RGB-LP5562-Library.git#9c366c8
 
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)
@@ -37,6 +38,7 @@ build_flags =
 
 lib_deps =
   ${env:rak4631.lib_deps}
+  # TODO renovate
   https://github.com/geeksville/Armduino-Semihosting/archive/35b538fdf208c3530c1434cd099a08e486672ee4.zip
 
 ; NOTE: the pyocd support for semihosting is buggy.  So I switched to using the builtin platformio support for the stlink adapter which worked much better.

--- a/variants/nrf52840/rak_wismeshtap/platformio.ini
+++ b/variants/nrf52840/rak_wismeshtap/platformio.ini
@@ -18,12 +18,19 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/rak_wis
 lib_deps = 
   ${nrf52840_base.lib_deps}
   ${nrf52_networking_base.lib_deps}
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+  # renovate: datasource=custom.pio depName=RAK NCP5623 RGB LED packageName=rakwireless/library/RAKwireless NCP5623 RGB LED library
   rakwireless/RAKwireless NCP5623 RGB LED library@1.0.3
+  # renovate: datasource=custom.pio depName=TFT_eSPI packageName=bodmer/library/TFT_eSPI
   bodmer/TFT_eSPI@2.5.43
+  # renovate: datasource=custom.pio depName=RAK12034 packageName=beegee-tokyo/library/RAKwireless RAK12034
   beegee-tokyo/RAKwireless RAK12034@1.0.0
+  # renovate: datasource=custom.pio depName=RAK14014-FT6336U packageName=beegee-tokyo/library/RAK14014-FT6336U
   beegee-tokyo/RAK14014-FT6336U@1.0.1
+  # renovate: datasource=custom.pio depName=RAK12035_SoilMoisture packageName=beegee-tokyo/library/RAK12035_SoilMoisture
   beegee-tokyo/RAK12035_SoilMoisture@1.0.4
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/seeed_wio_tracker_L1_eink/platformio.ini
+++ b/variants/nrf52840/seeed_wio_tracker_L1_eink/platformio.ini
@@ -24,7 +24,8 @@ board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/seeed_wio_tracker_L1_eink>
 lib_deps =
   ${nrf52840_base.lib_deps}
-  https://github.com/meshtastic/GxEPD2#b202ebfec6a4821e098cf7a625ba0f6f2400292d
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
+  https://github.com/meshtastic/GxEPD2/archive/b202ebfec6a4821e098cf7a625ba0f6f2400292d.zip
 debug_tool = jlink
 
 [env:seeed_wio_tracker_L1_eink-inkhud]

--- a/variants/nrf52840/t-echo-lite/platformio.ini
+++ b/variants/nrf52840/t-echo-lite/platformio.ini
@@ -20,5 +20,6 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/t-echo-lite>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/a05c11c02862624266b61599b0d6ba93e33c6f24.zip
 ;upload_protocol = fs

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -20,7 +20,9 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/t-echo>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
 ;upload_protocol = fs
 
@@ -41,4 +43,5 @@ build_src_filter =
 lib_deps = 
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/tracker-t1000-e/platformio.ini
+++ b/variants/nrf52840/tracker-t1000-e/platformio.ini
@@ -16,6 +16,7 @@ board_build.ldscript = src/platform/nrf52/nrf52840_s140_v7.ld
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/tracker-t1000-e>
 lib_deps = 
   ${nrf52840_base.lib_deps}
+  # TODO renovate
   https://github.com/meshtastic/QMA6100P_Arduino_Library/archive/14c900b8b2e4feaac5007a7e41e0c1b7f0841136.zip
 debug_tool = jlink
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/rp2040/rak11310/platformio.ini
+++ b/variants/rp2040/rak11310/platformio.ini
@@ -14,7 +14,9 @@ build_src_filter = ${rp2040_base.build_src_filter} +<../variants/rp2040/rak11310
 lib_deps =
   ${rp2040_base.lib_deps}
   ${networking_base.lib_deps}
+  # renovate: datasource=custom.pio depName=Melopero RV3028 packageName=melopero/library/Melopero RV3028
   melopero/Melopero RV3028@1.2.0
+  # renovate: datasource=github-tags depName=RAK13800-W5100S packageName=RAKWireless/RAK13800-W5100S
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
 debug_build_flags = ${rp2040_base.build_flags}, -g
 debug_tool = cmsis-dap ; for e.g. Picotool

--- a/variants/rp2040/rpipico/platformio.ini
+++ b/variants/rp2040/rpipico/platformio.ini
@@ -3,7 +3,6 @@ extends = rp2040_base
 board = rpipico
 board_level = pr
 upload_protocol = picotool
-
 # add our variants files to the include and src paths
 build_flags =
   ${rp2040_base.build_flags}

--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -4,7 +4,7 @@ platform =
   # renovate: datasource=custom.pio depName=platformio/ststm32 packageName=platformio/platform/ststm32
   platformio/ststm32@19.4.0
 platform_packages =
-  # TODO renovate
+  # renovate: datasource=github-tags depName=Arduino_Core_STM32 packageName=stm32duino/Arduino_Core_STM32
   platformio/framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.10.1.zip
 extra_scripts =
   ${env.extra_scripts}
@@ -51,7 +51,6 @@ debug_tool = stlink
 lib_deps =
   ${env.lib_deps}
   ${radiolib_base.lib_deps}
-
   # renovate: datasource=git-refs depName=caveman99-stm32-Crypto packageName=https://github.com/caveman99/Crypto gitBranch=main
   https://github.com/caveman99/Crypto/archive/1aa30eb536bd52a576fde6dfa393bf7349cf102d.zip
 


### PR DESCRIPTION
Add `renovate` annotations wherever possible within the `variants/` directory tree.
This will assist with keeping our packages up to date while aligning with efforts in #8984 (reproducible builds, no fuzzy matches).

This could get a bit noisy initially :sweat_smile: close PRs for packages we *don't* want to update and I can remove the annotation (with a comment explaining why we're holding back versions).