### PR TITLE
Macro guard heap_caps_malloc_extmem_enable from SENSECAP_INDICATOR

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -447,8 +447,10 @@ void setup()
     LOG_INFO("\n\n//\\ E S H T /\\ S T / C\n");
 
 #if defined(ARCH_ESP32) && defined(BOARD_HAS_PSRAM)
+#ifndef SENSECAP_INDICATOR
     // use PSRAM for malloc calls > 256 bytes
     heap_caps_malloc_extmem_enable(256);
+#endif
 #endif
 
 #if defined(DEBUG_MUTE) && defined(DEBUG_PORT)


### PR DESCRIPTION
It was discovered that following https://github.com/meshtastic/firmware/pull/8891 the SEEED SenseCap Indicator did not have an operational screen. Currently macro guarding heap_caps_malloc_extmem_enable from SENSECAP_INDICATOR until this can be better researched.