### PR TITLE
Disable boosted gain when using an external PA/LNA like Heltec v4

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -545,7 +545,11 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     config.has_security = true;
     config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_ALL;
 
+#ifdef USE_GC1109_PA
+    config.lora.sx126x_rx_boosted_gain = false; // Disable for boards with external PA/LNA (e.g., Heltec V4)
+#else
     config.lora.sx126x_rx_boosted_gain = true;
+#endif
     config.lora.tx_enabled =
         true; // FIXME: maybe false in the future, and setting region to enable it. (unset region forces it off)
     config.lora.override_duty_cycle = false;

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -143,6 +143,14 @@ template <typename T> bool SX126xInterface<T>::init()
         lora.setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
     }
 #endif
+#ifdef USE_GC1109_PA
+    // Force boosted gain OFF for boards with external PA/LNA
+    uint16_t result = lora.setRxBoostedGainMode(false);
+    LOG_INFO("Set RX gain to power saving mode (boosted mode off; forced for external PA/LNA); result: %d", result);
+    if (config.lora.sx126x_rx_boosted_gain) {
+        LOG_WARN("Overriding sx126x_rx_boosted_gain to false for board with external PA/LNA");
+    }
+#else
     if (config.lora.sx126x_rx_boosted_gain) {
         uint16_t result = lora.setRxBoostedGainMode(true);
         LOG_INFO("Set RX gain to boosted mode; result: %d", result);
@@ -150,6 +158,7 @@ template <typename T> bool SX126xInterface<T>::init()
         uint16_t result = lora.setRxBoostedGainMode(false);
         LOG_INFO("Set RX gain to power saving mode (boosted mode off); result: %d", result);
     }
+#endif
 
 #if 0
     // Read/write a register we are not using (only used for FSK mode) to test SPI comms


### PR DESCRIPTION
Enabling it will cause too much gain and RX will be worse. Let the dedicated chip handle the gain.

This is probably why a lot of people with Heltec v4 are observing bad RX.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V4
