### PR TITLE
Fix Rotary enc long press

### DIFF
--- a/src/input/RotaryEncoderInterruptBase.cpp
+++ b/src/input/RotaryEncoderInterruptBase.cpp
@@ -93,6 +93,8 @@ int32_t RotaryEncoderInterruptBase::runOnce()
 
     if (!pressDetected) {
         this->action = ROTARY_ACTION_NONE;
+    } else if (now - pressStartTime < LONG_PRESS_DURATION) {
+        return (20); // keep checking for long/short until time expires
     }
 
     return INT32_MAX;


### PR DESCRIPTION
Rotary encoder INPUT_BROKER_SELECT_LONG events were not being generated on long press of the encoder select switch.  Thus, upper case characters could not be entered in "Free Text" messages via the encoder.

The root cause was RotaryEncoderInterruptBase::runOnce() only being called once after RotaryEncoderInterruptBase::intPressHandler() because it always returned INT32_MAX.

The easy fix is to return 20 if the press is still detected and LONG_PRESS_DURATION has not passed.

## 🤝 Attestations

- [ X] I have tested that my proposed changes behave as described.
- [ X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
Tested on DIY NRF52 Promicro E22 board
