### PR TITLE
Update lewisxhe/SensorLib to 0.3.3

### DIFF
--- a/variants/esp32/m5stack_coreink/platformio.ini
+++ b/variants/esp32/m5stack_coreink/platformio.ini
@@ -21,7 +21,7 @@ lib_deps =
   # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.5
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.2
+  lewisxhe/SensorLib@0.3.3
 lib_ignore =
   m5stack-coreink
 monitor_filters = esp32_exception_decoder

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -23,4 +23,4 @@ lib_deps =
   # renovate: datasource=github-tags depName=meshtastic-st7796 packageName=meshtastic/st7796
   https://github.com/meshtastic/st7796/archive/1.0.5.zip
   # renovate: datasource=custom.pio depName=lewisxhe-SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.1
+  lewisxhe/SensorLib@0.3.3

--- a/variants/esp32s3/t-watch-s3/platformio.ini
+++ b/variants/esp32s3/t-watch-s3/platformio.ini
@@ -14,12 +14,10 @@ lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.7
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.2
+  lewisxhe/SensorLib@0.3.3
   # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4
   # renovate: datasource=custom.pio depName=ESP8266Audio packageName=earlephilhower/library/ESP8266Audio
   earlephilhower/ESP8266Audio@1.9.9
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
-  # renovate: datasource=custom.pio depName=lewisxhe-SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.2.0

--- a/variants/esp32s3/tbeam-s3-core/platformio.ini
+++ b/variants/esp32s3/tbeam-s3-core/platformio.ini
@@ -8,7 +8,7 @@ board_check = true
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.2
+  lewisxhe/SensorLib@0.3.3
 
 build_flags = 
   ${esp32s3_base.build_flags} 

--- a/variants/esp32s3/tlora-pager/platformio.ini
+++ b/variants/esp32s3/tlora-pager/platformio.ini
@@ -28,7 +28,7 @@ lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
   lewisxhe/PCF8563_Library@1.0.1
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.2
+  lewisxhe/SensorLib@0.3.3
   # renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
   https://github.com/pschatzmann/arduino-audio-driver/archive/v0.1.3.zip
   # TODO renovate

--- a/variants/nrf52840/nano-g2-ultra/platformio.ini
+++ b/variants/nrf52840/nano-g2-ultra/platformio.ini
@@ -11,5 +11,5 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/nano-g2
 lib_deps = 
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.2
+  lewisxhe/SensorLib@0.3.3
 ;upload_protocol = fs

--- a/variants/nrf52840/t-echo/platformio.ini
+++ b/variants/nrf52840/t-echo/platformio.ini
@@ -23,7 +23,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-GxEPD2 packageName=https://github.com/meshtastic/GxEPD2 gitBranch=master
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.2
+  lewisxhe/SensorLib@0.3.3
 ;upload_protocol = fs
 
 [env:t-echo-inkhud]
@@ -44,4 +44,4 @@ lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  lewisxhe/SensorLib@0.3.2
+  lewisxhe/SensorLib@0.3.3


### PR DESCRIPTION
Pre-req for ESP-Arduino 3.x update.

Update lewisxhe/SensorLib to 0.3.3

Very minor change, supporting IDF 5.x (which Arduino 3.x is based on)
https://github.com/lewisxhe/SensorLib/releases/tag/v0.3.3