### PR TITLE
Cleanup: Remove icarus custom framework-arduinoespressif32

### DIFF
--- a/variants/esp32s3/icarus/platformio.ini
+++ b/variants/esp32s3/icarus/platformio.ini
@@ -7,8 +7,6 @@ board_build.mcu = esp32s3
 board_build.partitions = default_8MB.csv
 upload_protocol = esptool
 upload_speed = 921600
-; TODO renovate or remove
-platform_packages = platformio/framework-arduinoespressif32@https://github.com/PowerFeather/powerfeather-meshtastic-arduino-lib/releases/download/2.0.16a/esp32-2.0.16.zip
 build_unflags =
   ${esp32s3_base.build_unflags}
   -DARDUINO_USB_MODE=1


### PR DESCRIPTION
`icarus` uses a custom (outdated) `framework-arduinoespressif32`.

This is pure tech debt... and not going to work with the coming Arduino 3.x update. It's gotta go!