### PR TITLE
Make rotary encoder long press move to next screen

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1687,7 +1687,8 @@ int Screen::handleInputEvent(const InputEvent *event)
         if (!inputIntercepted) {
             if (event->inputEvent == INPUT_BROKER_LEFT || event->inputEvent == INPUT_BROKER_ALT_PRESS) {
                 showPrevFrame();
-            } else if (event->inputEvent == INPUT_BROKER_RIGHT || event->inputEvent == INPUT_BROKER_USER_PRESS) {
+            } else if (event->inputEvent == INPUT_BROKER_RIGHT || event->inputEvent == INPUT_BROKER_USER_PRESS ||
+                       event->inputEvent == INPUT_BROKER_SELECT_LONG) {
                 showNextFrame();
             } else if (event->inputEvent == INPUT_BROKER_UP_LONG) {
                 // Long press up button for fast frame switching


### PR DESCRIPTION
With this trivial improvement, a single rotary encoder is sufficient to fully use the BaseUI.  Without this change, I could find no way to access the many available information screens.

## 🤝 Attestations

- [x ] I have tested that my proposed changes behave as described.
- [x ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x ] Other (please specify below)
          Tested on DIY NRF52 Promicro E22 board