### PR TITLE
KZ_863 is not wide lora

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -171,7 +171,8 @@ const RegionInfo regions[] = {
                 863 - 868 MHz <25 mW EIRP, 500kHz channels allowed, must not be used at airfields
                                 https://github.com/meshtastic/firmware/issues/7204
     */
-    RDEF(KZ_433, 433.075f, 434.775f, 100, 0, 10, true, false, false), RDEF(KZ_863, 863.0f, 868.0f, 100, 0, 30, true, false, true),
+    RDEF(KZ_433, 433.075f, 434.775f, 100, 0, 10, true, false, false),
+    RDEF(KZ_863, 863.0f, 868.0f, 100, 0, 30, true, false, false),
 
     /*
         Nepal


### PR DESCRIPTION
KZ_863 was set to wide_lora = true. This was a mistake, induced because the regulations would allow SHORT_TURBO. However, that interpretation of the code was incorrect and wide_lora has a different meaning.

Fixes https://github.com/meshtastic/firmware/issues/9054
