### PR TITLE
In autoconf, don't probe Wire unless i2c device is set

### DIFF
--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -279,7 +279,7 @@ void portduinoSetup()
         //      RAK6421-13300-S1:aabbcc123456:5ba85807d92138b7519cfb60460573af:3061e8d8
         // <model string>:mac address :<16 random unique bytes in hexidecimal> : crc32
         // crc32 is calculated on the eeprom string up to but not including the final colon
-        if (strlen(autoconf_product) < 6) {
+        if (strlen(autoconf_product) < 6 && portduino_config.i2cdev != "") {
             try {
                 char *mac_start = nullptr;
                 char *devID_start = nullptr;


### PR DESCRIPTION
Found another bit of code that crashes my desktop, by probing the wrong i2c bus.