### PR TITLE
tryfix: heltec-wireless-tracker periodic gnss config loss

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -834,8 +834,13 @@ void GPS::setPowerState(GPSPowerState newState, uint32_t sleepTime)
     case GPS_IDLE:
         if (oldState == GPS_ACTIVE || oldState == GPS_IDLE) // If hardware already awake, no changes needed
             break;
-        if (oldState != GPS_ACTIVE && oldState != GPS_IDLE) // If hardware just waking now, clear buffer
+        if (oldState != GPS_ACTIVE && oldState != GPS_IDLE) { // If hardware just waking now, clear buffer
+            if (gnssModel == GNSS_MODEL_UC6580) {
+                didSerialInit = false;
+                setup(); // Re-setup UC6580 after wake - it loses config in sleep
+            }
             clearBuffer();
+        }
         powerMon->setState(meshtastic_PowerMon_State_GPS_Active); // Report change for power monitoring (during testing)
         writePinEN(true);                                         // Power (EN pin): on
         setPowerPMU(true);                                        // Power (PMU): on


### PR DESCRIPTION
The Heltec Wireless Tracker and its UC6580 doesn't support a soft sleep, so we hard sleep it.

It was discovered that this causes the gnss chip to lose its settings. This means the buffer overflows with NMEA messages we don't use, and constellations that were previously enabled may be disabled.

This patch attempts to fix it by performing the configuration of the UC6580 chip every time it comes back from hardsleep.

Fixes https://github.com/meshtastic/firmware/issues/5088

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
