### PR TITLE
Correctly set type for event_mode max() position threshold

### DIFF
--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -69,7 +69,7 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     // In event mode we want to prevent excessive position broadcasts
     // we set the minimum interval to 5m
     const uint32_t minimumTimeThreshold =
-        max(300000, Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30));
+        max(uint32_t(300000), Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30));
 #else
     const uint32_t minimumTimeThreshold =
         Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);


### PR DESCRIPTION
Tiny fix for max() comparison in event_mode by explicitly setting the type. Discovered when creating the [event/hamcation2026](https://github.com/meshtastic/firmware/tree/event/hamcation2026) branch.