### PR TITLE
Fix PR#8061 SensorLib nRF ThinkNode M-series

### DIFF
--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -15,5 +15,5 @@ lib_deps =
   ${nrf52840_base.lib_deps}
   # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
-  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
-  lewisxhe/PCF8563_Library@1.0.1
+  ; # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
+  ; lewisxhe/SensorLib@0.3.3

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/variant.h
@@ -114,7 +114,8 @@ extern "C" {
 #define LR11X0_DIO_AS_RF_SWITCH
 
 // PCF8563 RTC Module
-#define PCF8563_RTC 0x51
+// REVISIT https://github.com/meshtastic/firmware/pull/9084
+// #define PCF8563_RTC 0x51
 
 #ifdef __cplusplus
 }

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -12,5 +12,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M6>
 lib_deps =
   ${nrf52840_base.lib_deps}
-  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
-  lewisxhe/PCF8563_Library@1.0.1
+  ; # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
+  ; lewisxhe/SensorLib@0.3.3

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
@@ -119,7 +119,8 @@ static const uint8_t A0 = PIN_A0;
 #define PIN_SERIAL2_TX (24)
 
 // PCF8563 RTC Module
-#define PCF8563_RTC 0x51
+// REVISIT https://github.com/meshtastic/firmware/pull/9084
+// #define PCF8563_RTC 0x51
 
 // SPI
 #define SPI_INTERFACES_COUNT 1


### PR DESCRIPTION
Addendum to https://github.com/meshtastic/firmware/pull/8061
Try-fix Elecrow thinknode NRF M-series.

`lewisxhe/PCF8563_Library` has been replaced with `lewisxhe/SensorLib` and it seems just these two were missed.