### PR TITLE
Use IF_SCREEN macro to guard against null screen object

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -195,15 +195,13 @@ void MeshService::handleToRadio(meshtastic_MeshPacket &p)
 
     p.rx_time = getValidTime(RTCQualityFromNet); // Record the time the packet arrived from the phone
 
-#if HAS_SCREEN
-    if (p.decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP && p.decoded.payload.size > 0 && p.to != NODENUM_BROADCAST &&
-        p.to != 0) // DM only
-    {
-        perhapsDecode(&p);
-        const StoredMessage &sm = messageStore.addFromPacket(p);
-        graphics::MessageRenderer::handleNewMessage(nullptr, sm, p); // notify UI
-    }
-#endif
+    IF_SCREEN(if (p.decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP && p.decoded.payload.size > 0 &&
+                  p.to != NODENUM_BROADCAST && p.to != 0) // DM only
+              {
+                  perhapsDecode(&p);
+                  const StoredMessage &sm = messageStore.addFromPacket(p);
+                  graphics::MessageRenderer::handleNewMessage(nullptr, sm, p); // notify UI
+              })
     // Send the packet into the mesh
     DEBUG_HEAP_BEFORE;
     auto a = packetPool.allocCopy(p);

--- a/src/modules/TextMessageModule.cpp
+++ b/src/modules/TextMessageModule.cpp
@@ -21,18 +21,17 @@ ProcessMessage TextMessageModule::handleReceived(const meshtastic_MeshPacket &mp
     // We only store/display messages destined for us.
     devicestate.rx_text_message = mp;
     devicestate.has_rx_text_message = true;
-#if HAS_SCREEN
-    // Guard against running in MeshtasticUI
-    if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
-        // Store in the central message history
-        const StoredMessage &sm = messageStore.addFromPacket(mp);
+    IF_SCREEN(
+        // Guard against running in MeshtasticUI or with no screen
+        if (config.display.displaymode != meshtastic_Config_DisplayConfig_DisplayMode_COLOR) {
+            // Store in the central message history
+            const StoredMessage &sm = messageStore.addFromPacket(mp);
 
-        // Pass message to renderer (banner + thread switching + scroll reset)
-        // Use the global Screen singleton to retrieve the current OLED display
-        auto *display = screen ? screen->getDisplayDevice() : nullptr;
-        graphics::MessageRenderer::handleNewMessage(display, sm, mp);
-    }
-#endif
+            // Pass message to renderer (banner + thread switching + scroll reset)
+            // Use the global Screen singleton to retrieve the current OLED display
+            auto *display = screen ? screen->getDisplayDevice() : nullptr;
+            graphics::MessageRenderer::handleNewMessage(display, sm, mp);
+        })
     // Only trigger screen wake if configuration allows it
     if (shouldWakeOnReceivedMessage()) {
         powerFSM.trigger(EVENT_RECEIVED_MSG);


### PR DESCRIPTION
Found a crash in native, caused by HAVE_SCREEN being defined, but no screen present.