### PR TITLE
Revert NimBLE 2.X upgrade

### DIFF
--- a/src/nimble/NimbleBluetooth.h
+++ b/src/nimble/NimbleBluetooth.h
@@ -12,11 +12,16 @@ class NimbleBluetooth : BluetoothApi
     bool isConnected();
     int getRssi();
     void sendLog(const uint8_t *logMessage, size_t length);
+#if defined(NIMBLE_TWO)
     void startAdvertising();
+#endif
     bool isDeInit = false;
 
   private:
     void setupService();
+#if !defined(NIMBLE_TWO)
+    void startAdvertising();
+#endif
 };
 
 void setBluetoothEnable(bool enable);

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -38,7 +38,6 @@ build_flags =
   -DAXP_DEBUG_PORT=Serial
   -DCONFIG_BT_NIMBLE_ENABLED
   -DCONFIG_BT_NIMBLE_MAX_BONDS=6 # default is 3
-  -DCONFIG_BT_NIMBLE_ROLE_CENTRAL_DISABLED
   -DCONFIG_NIMBLE_CPP_LOG_LEVEL=2
   -DCONFIG_BT_NIMBLE_MAX_CCCDS=20
   -DCONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=8192
@@ -60,7 +59,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-esp32_https_server packageName=https://github.com/meshtastic/esp32_https_server gitBranch=master
   https://github.com/meshtastic/esp32_https_server/archive/3223704846752e6d545139204837bdb2a55459ca.zip
   # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
-  h2zero/NimBLE-Arduino@^2.3.7
+  h2zero/NimBLE-Arduino@^1.4.3
   # renovate: datasource=git-refs depName=libpax packageName=https://github.com/dbinfrago/libpax gitBranch=master
   https://github.com/dbinfrago/libpax/archive/3cdc0371c375676a97967547f4065607d4c53fd1.zip
   # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib

--- a/variants/esp32c3/esp32c3.ini
+++ b/variants/esp32c3/esp32c3.ini
@@ -4,8 +4,3 @@ custom_esp32_kind = esp32c3
 
 monitor_speed = 115200
 monitor_filters = esp32_c3_exception_decoder
-
-build_flags =
-	${esp32_base.build_flags}
-	-DCONFIG_BT_NIMBLE_EXT_ADV=1
-	-DCONFIG_BT_NIMBLE_MAX_EXT_ADV_INSTANCES=2

--- a/variants/esp32c6/m5stack_unitc6l/platformio.ini
+++ b/variants/esp32c6/m5stack_unitc6l/platformio.ini
@@ -13,7 +13,7 @@ build_unflags =
 lib_deps =
   ${esp32c6_base.lib_deps}
   adafruit/Adafruit NeoPixel@^1.12.3
-  h2zero/NimBLE-Arduino@^2.3.7
+  h2zero/NimBLE-Arduino@^2.3.6
 build_flags = 
   ${esp32c6_base.build_flags}
   -D M5STACK_UNITC6L
@@ -24,6 +24,7 @@ build_flags =
   -D HAS_BLUETOOTH=1
 	-DCONFIG_BT_NIMBLE_EXT_ADV=1
 	-DCONFIG_BT_NIMBLE_MAX_EXT_ADV_INSTANCES=2
+  -D NIMBLE_TWO
 monitor_speed=115200
 lib_ignore =
   NonBlockingRTTTL

--- a/variants/esp32s3/esp32s3.ini
+++ b/variants/esp32s3/esp32s3.ini
@@ -3,8 +3,3 @@ extends = esp32_base
 custom_esp32_kind = esp32s3
 
 monitor_speed = 115200
-
-build_flags =
-	${esp32_base.build_flags}
-	-DCONFIG_BT_NIMBLE_EXT_ADV=1
-	-DCONFIG_BT_NIMBLE_MAX_EXT_ADV_INSTANCES=2


### PR DESCRIPTION
Having difficulty getting the upgrade to correctly advertise and persist bonds on S3 devices, so just yanking it for now.
Closes https://github.com/meshtastic/firmware/issues/9049