### PR TITLE
Fixed shouldFilterReceived function to check prev relay according to the function definition

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -113,7 +113,7 @@ bool Router::shouldDecrementHopLimit(const meshtastic_MeshPacket *p)
 
         // Check 3: role check (moderate cost - multiple comparisons)
         if (!IS_ONE_OF(node->user.role, meshtastic_Config_DeviceConfig_Role_ROUTER,
-                       meshtastic_Config_DeviceConfig_Role_ROUTER_LATE)) {
+                       meshtastic_Config_DeviceConfig_Role_ROUTER_LATE, meshtastic_Config_DeviceConfig_Role_CLIENT_BASE)) {
             continue;
         }
 


### PR DESCRIPTION
Function `shouldDecrementHopLimit` [definition](https://github.com/meshtastic/firmware/blob/abab6ce81568d3ca32f47ad4a0eff2dbff9e0608/src/mesh/Router.h#L115) states that hop_limit should not be decreased if prev relay has one of the following roles:
- ROUTER
- ROUTER_LATE
- CLIENT_BASE

The function [implementation](https://github.com/meshtastic/firmware/blob/abab6ce81568d3ca32f47ad4a0eff2dbff9e0608/src/mesh/Router.cpp#L115-L116) only checks if it is ROUTER or ROUTER_LATE.

I noticed this bug because I have two static nodes on different frequencies with role `CLIENT_BASE`, which have favorited each other. These nodes mesh over UDP and work as a bridge between the frequencies. In this setup, one hop was always lost when packets go through the bridge. After the fix the issue is gone.


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
  - [x] Ebyte E32 + ESP32S3 based
