### PR TITLE
Add EByte EoRa-Hub

### DIFF
--- a/boards/CDEBYTE_EoRa-Hub.json
+++ b/boards/CDEBYTE_EoRa-Hub.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default.csv",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": ["wifi"],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "CDEBYTE_EoRa-Hub",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.cdebyte.com/products/EoRa-HUB-900TB",
+  "vendor": "CDEBYTE"
+}

--- a/variants/esp32s3/CDEBYTE_EoRa-Hub/pins_arduino.h
+++ b/variants/esp32s3/CDEBYTE_EoRa-Hub/pins_arduino.h
@@ -1,0 +1,28 @@
+// Need this file for ESP32-S3
+// No need to modify this file, changes to pins imported from variant.h
+// Most is similar to https://github.com/espressif/arduino-esp32/blob/master/variants/esp32s3/pins_arduino.h
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include <variant.h>
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+// Serial
+static const uint8_t TX = UART_TX;
+static const uint8_t RX = UART_RX;
+
+// Default SPI will be mapped to Radio
+static const uint8_t SS = LORA_CS;
+static const uint8_t SCK = LORA_SCK;
+static const uint8_t MOSI = LORA_MOSI;
+static const uint8_t MISO = LORA_MISO;
+
+// The default Wire will be mapped to PMU and RTC
+static const uint8_t SCL = I2C_SCL;
+static const uint8_t SDA = I2C_SDA;
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32s3/CDEBYTE_EoRa-Hub/platformio.ini
+++ b/variants/esp32s3/CDEBYTE_EoRa-Hub/platformio.ini
@@ -1,0 +1,8 @@
+[env:CDEBYTE_EoRa-Hub]
+extends = esp32s3_base
+board = CDEBYTE_EoRa-Hub
+board_level = extra
+build_flags =
+  ${esp32s3_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/esp32s3/CDEBYTE_EoRa-Hub

--- a/variants/esp32s3/CDEBYTE_EoRa-Hub/rfswitch.h
+++ b/variants/esp32s3/CDEBYTE_EoRa-Hub/rfswitch.h
@@ -1,0 +1,19 @@
+#include "RadioLib.h"
+
+// This is rewritten to match the requirements of the E80-900M2213S
+// The E80 does not conform to the reference Semtech switches(!) and therefore needs a custom matrix.
+// See footnote #3 in "https://www.cdebyte.com/products/E80-900M2213S/2#Pin"
+// RF Switch Matrix SubG RFO_HP_LF / RFO_LP_LF / RFI_[NP]_LF0
+// DIO5 -> RFSW0_V1
+// DIO6 -> RFSW1_V2
+// DIO7 -> not connected on E80 module - note that GNSS and Wifi scanning are not possible.
+
+static const uint32_t rfswitch_dio_pins[] = {RADIOLIB_LR11X0_DIO5, RADIOLIB_LR11X0_DIO6, RADIOLIB_LR11X0_DIO7, RADIOLIB_NC, RADIOLIB_NC};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    // mode             DIO5  DIO6  DIO7
+    {LR11x0::MODE_STBY, {LOW, LOW, LOW}},  {LR11x0::MODE_RX, {LOW, HIGH, LOW}},
+    {LR11x0::MODE_TX, {HIGH, HIGH, LOW}},  {LR11x0::MODE_TX_HP, {HIGH, LOW, LOW}},
+    {LR11x0::MODE_TX_HF, {LOW, LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW, HIGH}},
+    {LR11x0::MODE_WIFI, {LOW, LOW, LOW}},  END_OF_MODE_TABLE,
+};

--- a/variants/esp32s3/CDEBYTE_EoRa-Hub/variant.h
+++ b/variants/esp32s3/CDEBYTE_EoRa-Hub/variant.h
@@ -1,0 +1,50 @@
+// EByte EoRA-Hub
+// Uses E80 (LR1121) LoRa module
+
+#define LED_PIN 35
+
+// Button - user interface
+#define BUTTON_PIN 0 // BOOT button
+
+#define BATTERY_PIN 1
+#define ADC_CHANNEL ADC1_GPIO1_CHANNEL
+#define ADC_MULTIPLIER 103.0 // Calibrated value
+#define ADC_ATTENUATION ADC_ATTEN_DB_0
+#define ADC_CTRL 37
+#define ADC_CTRL_ENABLED LOW
+
+// Display - OLED connected via I2C by the default hardware configuration
+#define HAS_SCREEN 1
+#define USE_SSD1306
+#define I2C_SCL 17
+#define I2C_SDA 18
+
+// UART - The 1mm JST SH connector closest to the USB-C port
+#define UART_TX 43
+#define UART_RX 44
+
+// Peripheral I2C - The 1mm JST SH connector furthest from the USB-C port which follows Adafruit connection standard. There are no
+// pull-up resistors on these lines, the downstream device needs to include them. TODO: test, currently untested
+#define I2C_SCL1 21
+#define I2C_SDA1 10
+
+// Radio
+#define USE_LR1121
+
+#define LORA_SCK 9
+#define LORA_MOSI 10
+#define LORA_MISO 11
+#define LORA_RESET 12
+#define LORA_CS 8
+#define LORA_DIO9 13
+
+// LR1121
+#define LR1121_IRQ_PIN 14
+#define LR1121_NRESET_PIN LORA_RESET
+#define LR1121_BUSY_PIN LORA_DIO9
+#define LR1121_SPI_NSS_PIN LORA_CS
+#define LR1121_SPI_SCK_PIN LORA_SCK
+#define LR1121_SPI_MOSI_PIN LORA_MOSI
+#define LR1121_SPI_MISO_PIN LORA_MISO
+#define LR11X0_DIO3_TCXO_VOLTAGE 1.8
+#define LR11X0_DIO_AS_RF_SWITCH


### PR DESCRIPTION
Based on the scattered work in the comments of #6978 + the existing working E80 rfswitch from the promicro-diy variant. 
Shoutout to @lagoesp @patricklouvel @Szetya

Cleaned up and tested on my EoRA-Hub :+1: 

<img width="2684" height="1287" alt="image" src="https://github.com/user-attachments/assets/dbfaf02e-9539-4efe-a036-d22fa25f69c3" />


Closes #6978