### PR TITLE
Rxmitfix

### DIFF
--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -245,7 +245,8 @@ uint32_t RadioInterface::getPacketTime(const meshtastic_MeshPacket *p, bool rece
 /** The delay to use for retransmitting dropped packets */
 uint32_t RadioInterface::getRetransmissionMsec(const meshtastic_MeshPacket *p)
 {
-    size_t numbytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_Data_msg, &p->decoded);
+    size_t numbytes =p->which_payload_variant == meshtastic_MeshPacket_decoded_tag ? 
+      pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_Data_msg, &p->decoded) : 200;
     uint32_t packetAirtime = getPacketTime(numbytes + sizeof(PacketHeader));
     // Make sure enough time has elapsed for this packet to be sent and an ACK is received.
     // LOG_DEBUG("Waiting for flooding message with airtime %d and slotTime is %d", packetAirtime, slotTimeMsec);


### PR DESCRIPTION
## 🙏 Thank you for sending in a pull request, here's some tips to get started!

This is a one line PR (no issue created) that changes `RadioInterface::getRetransmissionMsec` to handle the case of the packet being encrypted. This method is called by NextHopRouter when adding a packet for retranmssion. When the node is at least one hop away from the sending node, the packet handed to this method is encrypted.

When the packet is encrypted, the current code throws an error `Panic: can't encode protobuf reason='bytes size exceeded'` because of the call to `pb_encode_to_bytes`.   When this happens whatever value that gets placed in `numbytes` by this method results in the packet never being retransmitted about 90% of time (at least in my tests).  

The fix sets the `numbytes` value to 200 if the packet is encrypted instead of trying to determine the size of the encrypted packet - I don't believe this retransmission time calculation is that critical, but the need to retransmit is critical. After the fix, in my tests the packet was always retransmitted (if needed).

If probably could be improved if the packet size calculation was done correctly for encrypted packets instead of returning a default value, but I did not investigate that.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
