### PR TITLE
Actions: CI for feature/ branches

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -8,7 +8,9 @@ on:
     branches:
       - master
       - develop
+      - pioarduino # Remove when merged // use `feature/` in the future.
       - event/*
+      - feature/*
     paths-ignore:
       - "**.md"
       - version.properties
@@ -18,7 +20,9 @@ on:
     branches:
       - master
       - develop
+      - pioarduino # Remove when merged // use `feature/` in the future.
       - event/*
+      - feature/*
     paths-ignore:
       - "**.md"
       #- "**.yml"


### PR DESCRIPTION
Run CI on `feature/` branches... and the existing `pioarduino` branch (renaming breaks existing PRs... let's just stick to `feature/` going forward and clean that up later).