### PR TITLE
Add option to Mute/Unmute Channel to BaseUI

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -517,7 +517,7 @@ void menuHandler::messageResponseMenu()
             auto &chan = channels.getByIndex(chIndex);
             if (chan.settings.has_module_settings) {
                 chan.settings.module_settings.is_muted = !chan.settings.module_settings.is_muted;
-                saveUIConfig();
+                nodeDB->saveToDisk();
             }
 
             // Delete submenu


### PR DESCRIPTION
- Add option to Mute/Unmute Channel to BaseUI
- Is gated to confirm that full chat list or DM views does not show this option
- Leverages https://github.com/meshtastic/firmware/pull/7957 functionality to mute popups and sounds