### PR TITLE
Use correct name for ALT_BUTTON_PIN

### DIFF
--- a/variants/esp32s3/t-beam-1w/variant.h
+++ b/variants/esp32s3/t-beam-1w/variant.h
@@ -15,7 +15,7 @@
 
 // Buttons
 #define BUTTON_PIN 0      // BUTTON 1
-#define BUTTON_PIN_ALT 17 // BUTTON 2
+#define ALT_BUTTON_PIN 17 // BUTTON 2
 
 // SPI (shared by LoRa and SD)
 #define SPI_MOSI 11


### PR DESCRIPTION
The top button was non-functional as the variant.h file was written. This gets it working as intended.