### PR TITLE
Increase default position broadcast intervals and enforce minimums for the public default channels

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -13,7 +13,10 @@
 #define min_default_telemetry_interval_secs 30 * 60
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
 #define default_telemetry_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
-#define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 15 * 60)
+#define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
+#define default_broadcast_smart_minimum_interval_secs 5 * 60
+#define min_default_broadcast_interval_secs 60 * 60
+#define min_default_broadcast_smart_minimum_interval_secs 5 * 60
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)
 #define default_sds_secs IF_ROUTER(ONE_DAY, UINT32_MAX) // Default to forever super deep sleep
 #define default_ls_secs IF_ROUTER(ONE_DAY, 5 * 60)

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -69,10 +69,11 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     // In event mode we want to prevent excessive position broadcasts
     // we set the minimum interval to 5m
     const uint32_t minimumTimeThreshold =
-        max(uint32_t(300000), Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30));
+        max(uint32_t(300000), Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs,
+                                                                default_broadcast_smart_minimum_interval_secs));
 #else
-    const uint32_t minimumTimeThreshold =
-        Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs, 30);
+    const uint32_t minimumTimeThreshold = Default::getConfiguredOrDefaultMs(config.position.broadcast_smart_minimum_interval_secs,
+                                                                            default_broadcast_smart_minimum_interval_secs);
 #endif
 };
 


### PR DESCRIPTION
This pull request introduces new minimum interval constants for position broadcasts and ensures that these minimums are enforced when broadcasting positions over default channels. It also updates the configuration logic to use these new constants, improving consistency and preventing excessive position broadcasts.

**Position broadcast interval enforcement:**

* Added new constants in `Default.h` for minimum broadcast intervals: `min_default_broadcast_interval_secs` (1 hour) and `min_default_broadcast_smart_minimum_interval_secs` (5 minutes), and updated the default values for position broadcast intervals.
* Updated `NodeDB::NodeDB()` to enforce the new minimum broadcast intervals when positions are sent over default channels, ensuring position broadcasts are not too frequent.

