### PR TITLE
Change I2C pins to NFC pads for XIAO nRF52840

### DIFF
--- a/variants/nrf52840/seeed_xiao_nrf52840_kit/variant.h
+++ b/variants/nrf52840/seeed_xiao_nrf52840_kit/variant.h
@@ -189,8 +189,8 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define PIN_WIRE_SCL D7
 #else
 // Use NFC pads for I2C as done on Seeed Solar Node 
-#define PIN_WIRE_SDA D14 // P0.09
-#define PIN_WIRE_SCL D15 // P0.10
+#define PIN_WIRE_SDA (9) // P0.09
+#define PIN_WIRE_SCL (10) // P0.10
 #endif
 
 static const uint8_t SDA = PIN_WIRE_SDA;


### PR DESCRIPTION
Change the default I2C pins to match the Seeed Solar Node, allowing use of I2C sensors in DIY nodes based on the Seeed NRF52840 kit

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
 Seeed NRF52840 Kit