### PR TITLE
Update diy_promicro platformio.ini

### DIFF
--- a/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
+++ b/variants/nrf52840/diy/nrf52_promicro_diy_tcxo/platformio.ini
@@ -36,5 +36,5 @@ lib_deps =
   ${inkhud.lib_deps} ; InkHUD libs first, so we get GFXRoot instead of AdafruitGFX
   ${nrf52840_base.lib_deps}
 extra_scripts =
-  ${env.extra_scripts}
+  ${nrf52840_base.extra_scripts}
   variants/nrf52840/diy/nrf52_promicro_diy_tcxo/custom_build_tasks.py ; Add to PIO's Project Tasks pane: preset builds for common displays


### PR DESCRIPTION
Thus PR updates extra_scripts definition.
Current env.extra_scripts don't triggers `extra_scripts/nrf52_extra.py`  and user have to convert hex to uf2 manually.

Currently in build results:
```
{'name': 'firmware-nrf52_promicro_diy-inkhud-2.7.17.b002844aa.elf', 'md5': '0a0809c77b7146305fadde5c5a26d788', 'bytes': 1204876}
{'name': 'firmware-nrf52_promicro_diy-inkhud-2.7.17.b002844aa.hex', 'md5': '73e699fd0e7be8b7f9c0eacc2739a18c', 'bytes': 1835731}
{'name': 'firmware-nrf52_promicro_diy-inkhud-2.7.17.b002844aa-ota.zip', 'md5': '197d9d33ac4ab70f17291fedd62ad261', 'bytes': 653681}
```

After changes
```
{'name': 'firmware-nrf52_promicro_diy-inkhud-2.7.17.b002844aa.elf', 'md5': '0a0809c77b7146305fadde5c5a26d788', 'bytes': 1204876}
{'name': 'firmware-nrf52_promicro_diy-inkhud-2.7.17.b002844aa.hex', 'md5': '73e699fd0e7be8b7f9c0eacc2739a18c', 'bytes': 1835731}
{'name': 'firmware-nrf52_promicro_diy-inkhud-2.7.17.b002844aa.uf2', 'md5': 'cfc3056f1da4601006a43fc91d45d04e', 'bytes': 1305600}
{'name': 'firmware-nrf52_promicro_diy-inkhud-2.7.17.b002844aa-ota.zip', 'md5': '197d9d33ac4ab70f17291fedd62ad261', 'bytes': 653681}
```


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] DIY Promicro Inkhud
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
