### PR TITLE
Feat/serial logger

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -264,6 +264,10 @@ void RedirectablePrint::log_to_ble(const char *logLevel, const char *format, va_
 #endif
 }
 
+// Static variable initialization
+Print *RedirectablePrint::uartLogDestination = nullptr;
+
+
 meshtastic_LogRecord_Level RedirectablePrint::getLogLevel(const char *logLevel)
 {
     meshtastic_LogRecord_Level ll = meshtastic_LogRecord_Level_UNSET; // default to unset
@@ -343,6 +347,7 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
         log_to_serial(logLevel, newFormat, arg);
         log_to_syslog(logLevel, newFormat, arg);
         log_to_ble(logLevel, newFormat, arg);
+        // log_to_uart(logLevel, newFormat, arg);
 
         va_end(arg);
 #ifdef HAS_FREE_RTOS

--- a/src/RedirectablePrint.h
+++ b/src/RedirectablePrint.h
@@ -56,4 +56,9 @@ class RedirectablePrint : public Print
   private:
     void log_to_syslog(const char *logLevel, const char *format, va_list arg);
     void log_to_ble(const char *logLevel, const char *format, va_list arg);
+    // void log_to_uart(const char *logLevel, const char *format, va_list arg);
+
+  public:
+    // Static pointer for UART log forwarding (set by SerialModule when in LOG mode)
+    static Print *uartLogDestination;
 };

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -85,7 +85,11 @@ typedef enum _meshtastic_ModuleConfig_SerialConfig_Serial_Mode {
     meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT = 7,
     /* Used to configure and view some parameters of MeshSolar.
 https://heltec.org/project/meshsolar/ */
-    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG = 8
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG = 8,
+    /* Log all debug messages to UART (telemetry, device info, etc.) */
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_LOG = 9,
+    /* Log only text messages to UART (with time, to, from, channel info) */
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_LOG_TEXT_ONLY = 10
 } meshtastic_ModuleConfig_SerialConfig_Serial_Mode;
 
 /* TODO: REPLACE */
@@ -483,8 +487,8 @@ extern "C" {
 #define _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Baud)(meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_921600+1))
 
 #define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT
-#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MAX meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG
-#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Mode)(meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MS_CONFIG+1))
+#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MAX meshtastic_ModuleConfig_SerialConfig_Serial_Mode_LOG_TEXT_ONLY
+#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Mode)(meshtastic_ModuleConfig_SerialConfig_Serial_Mode_LOG_TEXT_ONLY+1))
 
 #define _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE
 #define _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MAX meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_BACK


### PR DESCRIPTION
## 🙏 Thank you for sending in a pull request, here's some tips to get started!

Add a few additional serial modes to allow logging of packets to uart. 
Tested and consumed by an openlog on a RAK 4630 base.

``` 
examples - may be 
=== Meshtastic Packet Log Mode (LOG) ===
Packet logs will be logged to UART
Time: 1 seconds since boot

[??:??:??] ID:0x522caf74 FROM:0xf21ce71e (e71e) TO:0xf21ce71e PORT:65
[??:??:??] ID:0x522caf75 FROM:0xf21ce71e (e71e) TO:0xf21ce71e PORT:6
[00:53:24] ID:0x7af731f9 FROM:0xf21ce71e (e71e) TO:0xf21ce71e ROUTING variant=3
[00:53:29] ID:0x9e554dfa FROM:0xf21ce71e (e71e) TO:BROADCAST NODEINFO short_name=e71e long_name=dev caves e71e
[00:53:44] ID:0x255219fb FROM:0xf21ce71e (e71e) TO:BROADCAST POSITION lat=-310940157 lon=1509332873 alt=380 sats=0
[00:54:40] ID:0x3a9a8c59 FROM:0x710c5ed7 (DEVA) TO:0xf21ce71e MSG:DM ina
[00:54:40] ID:0x3a0af1fe FROM:0xf21ce71e (e71e) TO:0x710c5ed7 ROUTING variant=3
[00:54:41] ID:0xd863a1ca FROM:0x710c5ed7 (DEVA) TO:0xf21ce71e ROUTING variant=3
[00:54:44] ID:0x3a9a8c5a FROM:0x710c5ed7 (DEVA) TO:0xf21ce71e MSG:DM in b
[00:54:44] ID:0xbdc8d9ff FROM:0xf21ce71e (e71e) TO:0x710c5ed7 ROUTING variant=3
[00:54:45] ID:0xa62035cb FROM:0x710c5ed7 (DEVA) TO:0xf21ce71e ROUTING variant=3
[00:54:52] ID:0x3a9a8c5b FROM:0x710c5ed7 (DEVA) TO:BROADCAST MSG:Bcst in a
[00:55:25] ID:0x522caf76 FROM:0xf21ce71e (e71e) TO:BROADCAST MSG:Bcst out
[00:55:27] ID:0xac4df601 FROM:0xf21ce71e (e71e) TO:0xf21ce71e ROUTING variant=3
[00:55:43] ID:0x522caf77 FROM:0xf21ce71e (e71e) TO:0x710c5ed7 MSG:DM out
[00:55:45] ID:0xfd4a69cf FROM:0x710c5ed7 (DEVA) TO:0xf21ce71e ROUTING variant=3
[00:55:45] ID:0x8d84be02 FROM:0xf21ce71e (e71e) TO:0x710c5ed7 ROUTING variant=3


=== Meshtastic Text-Only Log Mode (LOG_TEXT_ONLY) ===
Only text messages with metadata will be logged to UART
Format: [HH:MM:SS] FROM:0xXXXX (name) TO:BROADCAST/DM CH:channelname (index) MSG:message
Time: 5 seconds since boot

[??:??:??] ID:0x3a9a8c4c FROM:0x710c5ed7 (DEVA) TO:BROADCAST MSG:Out bct
[??:??:??] ID:0x3a9a8c4d FROM:0x710c5ed7 (DEVA) TO:BROADCAST MSG:In bct
[23:41:21] ID:0x522caf5f FROM:0xf21ce71e (e71e) TO:BROADCAST MSG:Out
[23:41:38] ID:0x522caf60 FROM:0xf21ce71e (e71e) TO:0x710c5ed7 MSG:DM out
[23:41:50] ID:0x3a9a8c4e FROM:0x710c5ed7 (DEVA) TO:0xf21ce71e MSG:DM in

```

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631 (custom w/ OpenLog. ) 
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  
  Requires: 
  https://github.com/meshtastic/protobufs/pull/841
  Doco : 
  https://github.com/meshtastic/meshtastic/pull/2187
  
  
  Keeping as draft at the minute - it hasn't been linted and it's bedtime
