### PR TITLE
CI: tiny - include mt-ota in firmware zips

### DIFF
--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -201,6 +201,7 @@ jobs:
             ./device-*.bat
             ./littlefs-*.bin
             ./bleota*bin
+            ./mt-*-ota.bin
             ./Meshtastic_nRF52_factory_erase*.uf2
           retention-days: 30
 


### PR DESCRIPTION
Whoops! addendum to #9258 and #9261 