### PR TITLE
EXCLUDE_AUDIO on (original) ESP32

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -65,8 +65,6 @@ lib_deps =
   https://github.com/dbinfrago/libpax/archive/3cdc0371c375676a97967547f4065607d4c53fd1.zip
   # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib
   https://github.com/lewisxhe/XPowersLib/archive/v0.3.2.zip
-  # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
-  https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
   rweather/Crypto@0.4.0
 

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -6,3 +6,4 @@ custom_esp32_kind = esp32
 
 build_flags =
   ${esp32_common.build_flags}
+  -DMESHTASTIC_EXCLUDE_AUDIO=1

--- a/variants/esp32c3/esp32c3.ini
+++ b/variants/esp32c3/esp32c3.ini
@@ -4,3 +4,8 @@ custom_esp32_kind = esp32c3
 
 monitor_speed = 115200
 monitor_filters = esp32_c3_exception_decoder
+
+lib_deps =
+  ${esp32_common.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
+  https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip

--- a/variants/esp32s2/esp32s2.ini
+++ b/variants/esp32s2/esp32s2.ini
@@ -12,7 +12,12 @@ build_flags =
   -DHAS_BLUETOOTH=0
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER
   -DMESHTASTIC_EXCLUDE_BLUETOOTH
-  
+
+lib_deps =
+  ${esp32_common.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
+  https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip
+
 lib_ignore = 
   ${esp32_common.lib_ignore}
   NimBLE-Arduino

--- a/variants/esp32s3/esp32s3.ini
+++ b/variants/esp32s3/esp32s3.ini
@@ -3,3 +3,8 @@ extends = esp32_common
 custom_esp32_kind = esp32s3
 
 monitor_speed = 115200
+
+lib_deps =
+  ${esp32_common.lib_deps}
+  # renovate: datasource=git-refs depName=meshtastic-ESP32_Codec2 packageName=https://github.com/meshtastic/ESP32_Codec2 gitBranch=master
+  https://github.com/meshtastic/ESP32_Codec2/archive/633326c78ac251c059ab3a8c430fcdf25b41672f.zip


### PR DESCRIPTION
Disabled the Audio module on for the original-ESP32 family.
iram is scarce and this is the biggest module by far.

Should fix compiles on the `-g1` series (currently failing // iram overruns)