### PR TITLE
T-Deck Pro: speed up eink force refresh

### DIFF
--- a/src/graphics/EInkDisplay2.h
+++ b/src/graphics/EInkDisplay2.h
@@ -9,6 +9,15 @@
 #include "GxEPD2Multi.h"
 #endif
 
+// Limit how often we push a full E-Ink refresh. T-Deck Pro needs faster updates for typing.
+#ifndef EINK_FORCE_DISPLAY_THROTTLE_MS
+#if defined(T_DECK_PRO)
+#define EINK_FORCE_DISPLAY_THROTTLE_MS 200
+#else
+#define EINK_FORCE_DISPLAY_THROTTLE_MS 1000
+#endif
+#endif
+
 /**
  * An adapter class that allows using the GxEPD2 library as if it was an OLEDDisplay implementation.
  *
@@ -42,7 +51,7 @@ class EInkDisplay : public OLEDDisplay
      *
      * @return true if we did draw the screen
      */
-    virtual bool forceDisplay(uint32_t msecLimit = 1000);
+    virtual bool forceDisplay(uint32_t msecLimit = EINK_FORCE_DISPLAY_THROTTLE_MS);
 
     /**
      * Run any code needed to complete an update, after the physical refresh has completed.


### PR DESCRIPTION
## Fix: Improve E-Ink refresh responsiveness during keyboard input on T-Deck Pro

### Problem

On **LilyGo T-Deck Pro**, there is an intermittent issue where **E-Ink does not refresh in time after keyboard input**, with a repro probability of roughly **~40%** during fast typing or rapid UI interactions.

The root cause is that the existing **1s throttle** on `forceDisplay()` can suppress legitimate, user-driven refresh requests, causing visible lag between input events and screen updates.

This is especially noticeable during:

* Keyboard typing (e.g. canned message editing)
* Rapid UI state changes
* Screen wake / quick page transitions

---

### Solution

Reduce the `forceDisplay()` throttle **only on T-Deck Pro** from **1000 ms → 200 ms**, allowing faster response to *event-driven* UI updates while still preventing uncontrolled refresh loops.

Important clarifications:

* This change **does not introduce any autonomous or periodic refresh**
* The display is still refreshed **only when events explicitly trigger `forceDisplay()`**
* No background timers or polling were added

---

### Code Path & Scope Analysis

**What the 200 ms limit actually affects**

The throttle only defines the *minimum interval* between consecutive `forceDisplay()` calls **when such calls already exist**.

Typical call sites include:

* Screen wake / page switch
  (`Screen::handleSetOn`, `handleSetFrames`, `handleFrameEvent`)
* Message / state updates triggering `forceDisplay(true)`
* Input events (e.g. keyboard input in `CannedMessageModule`)
* Automatic screen rotation / slideshow transitions

**If none of these events occur, the screen will not refresh.**

**Device scope**

* **Only applies to `T_DECK_PRO`**
* All other devices keep the original **1s throttle**

---

### New Effective Upper Bound

* Maximum refresh rate under high-frequency input: **5 Hz (one refresh every 200 ms)**
* This is:

  * Significantly more responsive than 1 Hz
  * Still far below any “aggressive” E-Ink refresh pattern

---

### Risk Assessment

** Power consumption**

* Increased refresh rate only during *active typing or rapid UI changes*
* No impact during idle or standby
* Overall power increase is **localized and bounded**

** E-Ink aging / ghosting**

* Additional refreshes occur only during active interaction
* 5 Hz is still a low refresh frequency for E-Ink
* Immediate feedback during typing is a reasonable trade-off
* Existing ghosting mitigation (full refresh / flags) remains available

** Potential side effects**

* A pathological case where some background code calls `forceDisplay()` in a tight loop would become more visible with a shorter throttle
* Current call sites are all UI- or input-driven, not unbounded loops
* No such behavior observed during testing

---

### Future Safety Options (Not part of this PR)

If additional caution is desired later, possible refinements include:

1. Applying the shorter throttle only during keyboard input paths
2. Adjusting the limit to **300–500 ms** if needed
3. Instrumenting average refresh rate / current draw during stress testing

These are intentionally **not included** to keep this PR minimal and focused.

---

### Test Coverage

*  Tested on **LilyGo T-Deck Pro**
*  Not tested on other devices (unchanged code path)

---

##  Attestations

* [x] I have tested that my proposed changes behave as described.
* [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:

  * [x] Other: **LilyGo T-Deck Pro**