### PR TITLE
Allow ICM20948 IMU to sleep

### DIFF
--- a/src/motion/ICM20948Sensor.cpp
+++ b/src/motion/ICM20948Sensor.cpp
@@ -47,7 +47,6 @@ int32_t ICM20948Sensor::runOnce()
 int32_t ICM20948Sensor::runOnce()
 {
 #if !defined(MESHTASTIC_EXCLUDE_SCREEN) && HAS_SCREEN
-#if defined(MUZI_BASE) // temporarily gated to single device due to feature freeze
     if (screen && !screen->isScreenOn() && !config.display.wake_on_tap_or_motion && !config.device.double_tap_as_button_press) {
         if (!isAsleep) {
             LOG_DEBUG("sleeping IMU");
@@ -60,7 +59,6 @@ int32_t ICM20948Sensor::runOnce()
         sensor->sleep(false);
         isAsleep = false;
     }
-#endif
 
     float magX = 0, magY = 0, magZ = 0;
     if (sensor->dataReady()) {

--- a/src/motion/ICM20948Sensor.h
+++ b/src/motion/ICM20948Sensor.h
@@ -82,8 +82,8 @@ class ICM20948Sensor : public MotionSensor
   private:
     ICM20948Singleton *sensor = nullptr;
     bool showingScreen = false;
-#ifdef MUZI_BASE
     bool isAsleep = false;
+#ifdef MUZI_BASE
     float highestX = 449.000000, lowestX = -140.000000, highestY = 422.000000, lowestY = -232.000000, highestZ = 749.000000,
           lowestZ = 98.000000;
 #else


### PR DESCRIPTION
This PR allows all nodes with the ICM20948 IMU board to sleep when the screen is off.