### PR TITLE
Filter BLE updates that don't change pairing status

### DIFF
--- a/src/modules/StatusLEDModule.cpp
+++ b/src/modules/StatusLEDModule.cpp
@@ -50,9 +50,10 @@ int StatusLEDModule::handleStatusUpdate(const meshtastic::Status *arg)
             break;
         }
         case meshtastic::BluetoothStatus::ConnectionState::CONNECTED: {
-            ble_state = connected;
-            PAIRING_LED_starttime = millis();
-            break;
+            if (ble_state != connected) {
+                ble_state = connected;
+                PAIRING_LED_starttime = millis();
+            }
         }
         }
 


### PR DESCRIPTION
An edge case may trigger the BLE connected LED even when already connected. Filter for this.