### PR TITLE
Implement graduated scaling for NodeInfo send timeout based on active mesh size

### DIFF
--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -132,7 +132,7 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
     }
 
     // Use graduated scaling based on active mesh size (10 minute base, scales with congestion coefficient)
-    uint32_t timeoutMs = Default::getConfiguredOrDefaultMsScaled(0, 10 * 60, nodeStatus->getNumOnline()) * 1000;
+    uint32_t timeoutMs = Default::getConfiguredOrDefaultMsScaled(0, 10 * 60, nodeStatus->getNumOnline());
     if (!shorterTimeout && lastSentToMesh && Throttle::isWithinTimespanMs(lastSentToMesh, timeoutMs)) {
         LOG_DEBUG("Skip send NodeInfo since we sent it <%us ago", timeoutMs / 1000);
         ignoreRequest = true; // Mark it as ignored for MeshModule


### PR DESCRIPTION
**Improvements to NodeInfo throttling:**

* Replaced fixed timeouts (5 minutes) for sending NodeInfo with a dynamically calculated timeout that scales with the number of online nodes, using `Default::getConfiguredOrDefaultMsScaled` and `nodeStatus->getNumOnline()` in `NodeInfoModule.cpp`.
