### PR TITLE
pioarduino: use legacy esptoolpy naming (forward-compatible)

### DIFF
--- a/extra_scripts/esp32_extra.py
+++ b/extra_scripts/esp32_extra.py
@@ -43,14 +43,14 @@ def esp32_create_combined_bin(source, target, env):
     cmd = [
         "--chip",
         chip,
-        "merge-bin",
+        "merge_bin",
         "-o",
         new_file_name,
-        "--flash-mode",
+        "--flash_mode",
         flash_mode,
-        "--flash-freq",
+        "--flash_freq",
         flash_freq,
-        "--flash-size",
+        "--flash_size",
         flash_size,
     ]
 


### PR DESCRIPTION
New naming breaks esptoolpy inherited from upwards (e.g. distro packaging)