### PR TITLE
To fix the gps power rail issue on RAK 19007 when RAK12023+RAK12035 is installed

### DIFF
--- a/src/modules/Telemetry/Sensor/RAK12035Sensor.cpp
+++ b/src/modules/Telemetry/Sensor/RAK12035Sensor.cpp
@@ -22,7 +22,6 @@ bool RAK12035Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
     delay(100);
     sensor.begin(dev->address.address);
 
-    // Get sensor firmware version
     uint8_t data = 0;
     sensor.get_sensor_version(&data);
     if (data != 0) {
@@ -47,8 +46,6 @@ bool RAK12035Sensor::initDevice(TwoWire *bus, ScanI2C::FoundDevice *dev)
 
 void RAK12035Sensor::setup()
 {
-    // Set the calibration values
-    // Reading the saved calibration values from the sensor.
     // TODO:: Check for and run calibration check for up to 2 additional sensors if present.
     uint16_t zero_val = 0;
     uint16_t hundred_val = 0;
@@ -80,7 +77,7 @@ void RAK12035Sensor::setup()
         LOG_INFO("Wet calibration reset complete. New value is %d", hundred_val);
     }
     sensor.sensor_sleep();
-    RESTORE_3V3_POWER(); // Restore power after sensor_sleep() turns off WB_IO2
+    RESTORE_3V3_POWER();
     delay(200);
     LOG_INFO("Dry calibration value is %d", zero_val);
     LOG_INFO("Wet calibration value is %d", hundred_val);
@@ -89,10 +86,6 @@ void RAK12035Sensor::setup()
 bool RAK12035Sensor::getMetrics(meshtastic_Telemetry *measurement)
 {
     // TODO:: read and send metrics for up to 2 additional soil monitors if present.
-    //  -- how to do this.. this could get a little complex..
-    //     ie - 1> we combine them into an average and send that, 2> we send them as separate metrics
-    //      ^-- these scenarios would require different handling of the metrics in the receiving end and maybe a setting in the
-    //      device ui and an additional proto for that?
     measurement->variant.environment_metrics.has_soil_temperature = true;
     measurement->variant.environment_metrics.has_soil_moisture = true;
 
@@ -107,7 +100,7 @@ bool RAK12035Sensor::getMetrics(meshtastic_Telemetry *measurement)
     success &= sensor.get_sensor_temperature(&temp);
     delay(200);
     sensor.sensor_sleep();
-    RESTORE_3V3_POWER(); // Restore power after sensor_sleep() turns off WB_IO2
+    RESTORE_3V3_POWER();
 
     if (success == false) {
         LOG_ERROR("Failed to read sensor data");


### PR DESCRIPTION
…se.. this fixes the gps when both the RAK12500 GPS module and the RAK12035 soil sensor modules are being used.

fixes bug#9408

via claude code prompts... 

log snippet from RAK 4631 w/ RAK12023+RAK12035+RAK12500
...
DEBUG | 16:58:46 4314 [Router] Incoming msg was filtered from 0xf5032f44
INFO  | 16:58:57 4325 [GPS] GPS power state move from SOFTSLEEP to ACTIVE
DEBUG | 16:59:02 4330 [Power] Battery: usbPower=1, isCharging=1, batMv=4168, batPct=98
DEBUG | 16:59:24 4351 [GPS] Publish pos@6973a8eb:2, hasVal=1, Sats=9, GPSlock=1
DEBUG | 16:59:24 4351 [GPS] New GPS pos@6973a8eb:3 lat=45.989371 lon=-112.489421 alt=1702 pdop=1.38 track=32.67 speed=0.00 sats=9
DEBUG | 16:59:24 4351 [GPS] onGPSChanged() pos@6973a8eb time=1769187564 lat=459893706 lon=-1124894206 alt=1702
INFO  | 16:59:24 4351 [GPS] updatePosition LOCAL pos@6973a8eb time=1769187564 lat=459893706 lon=-1124894206 alt=1702
DEBUG | 16:59:24 4351 [GPS] Set local position: lat=459893706 lon=-1124894206 time=1769187564 timestamp=1769187563
DEBUG | 16:59:24 4351 [GPS] Node status update: 2 online, 3 total
DEBUG | 16:59:24 4351 [GPS] Took 26s to get lock
DEBUG | 16:59:24 4351 [GPS] Predict 29s to get next lock
DEBUG | 16:59:24 4351 [GPS] 90s until next search
DEBUG | 16:59:24 4351 [GPS] gps_update_interval >= 167s needed to justify hardsleep
INFO  | 16:59:24 4351 [GPS] GPS power state move from ACTIVE to SOFTSLEEP
INFO  | 16:59:44 4372 [EnvironmentTelemetry] Send: barometric_pressure=0.000000, current=0.000000, gas_resistance=0.000000, relative_humidity=0.000000, temperature=0.000000
INFO  | 16:59:44 4372 [EnvironmentTelemetry] Send: voltage=0.000000, IAQ=0, distance=0.000000, lux=0.000000
INFO  | 16:59:44 4372 [EnvironmentTelemetry] Send: wind speed=0.000000m/s, direction=0 degrees, weight=0.000000kg
INFO  | 16:59:44 4372 [EnvironmentTelemetry] Send: radiation=0.000000##R/h
INFO  | 16:59:44 4372 [EnvironmentTelemetry] Send: soil_temperature=16.000000, soil_moisture=0
DEBUG | 16:59:44 4372 [EnvironmentTelemetry] Partially randomized packet id 4060719558
INFO  | 16:59:44 4372 [EnvironmentTelemetry] Send packet to mesh
DEBUG | 16:59:44 4372 [EnvironmentTelemetry] Ignore update from self
DEBUG | 16:59:44 4372 [EnvironmentTelemetry] handleReceived(LOCAL) (id=0xf209a9c6 fr=0xf5032f44 to=0xffffffff, transport = 0, WantAck=0, HopLim=6 Ch=0x0 Portnum=67 rxtime=1769187584 priority=70)
DEBUG | 16:59:44 4372 [EnvironmentTelemetry] No modules interested in portnum=67, src=LOCAL
INFO  | 16:59:44 4372 [EnvironmentTelemetry] Packet History - insert: Using new slot @uptime 4372.457s TRACE NEW
DEBUG | 16:59:44 4372 [EnvironmentTelemetry] Use AES256 key!
...

***

<img src="https://github.com/user-attachments/assets/34655f94-4e63-4e1c-bb5b-30943384be1c" width="500" />

***

<img src="https://github.com/user-attachments/assets/b5155934-6313-4421-8484-e5e36e704749" width="500" />

***

<img src="https://github.com/user-attachments/assets/407e0ffe-1c1b-439b-9fd1-4c7022d6a397" width="500" />

***

<img src="https://github.com/user-attachments/assets/b812bab6-e7c2-41f6-bd2c-b9eca1633d3c" width="500" />

***

<img src="https://github.com/user-attachments/assets/768d9928-2306-445f-8bb5-acef2bd1e243" width="500" />

***


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
