### PR TITLE
Turn off Radio prior to doDeepSleep

### DIFF
--- a/src/PowerFSM.cpp
+++ b/src/PowerFSM.cpp
@@ -18,7 +18,7 @@
 #include "main.h"
 #include "sleep.h"
 #include "target_specific.h"
-
+#include "mesh/RadioInterface.h"
 extern RadioInterface *rIf;
 
 #if HAS_WIFI && !defined(ARCH_PORTDUINO) || defined(MESHTASTIC_EXCLUDE_WIFI)


### PR DESCRIPTION
Added external RadioInterface pointer and updated sleep calls.

Minimal changes to make it simple.
Need test on wide harware fleet.
Tested on private repo, shuld work on public but need double check - need volunteers or will rely on test cases.