### PR TITLE
Nodes Rendering - Cache/page based rendering

### DIFF
--- a/src/graphics/draw/NodeListRenderer.cpp
+++ b/src/graphics/draw/NodeListRenderer.cpp
@@ -564,12 +564,6 @@ void drawNodeListScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t
                 continue;
             if (locationScreen && !n->has_position)
                 continue;
-            if (!n)
-                continue;
-            if (n->num == nodeDB->getNodeNum())
-                continue;
-            if (locationScreen && !n->has_position)
-                continue;
 
             cachedFilteredNodesList.push_back(n->num);
         }
@@ -634,8 +628,6 @@ void drawNodeListScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t
         // Scroll Popup Overlay
         if (millis() - popupTime < POPUP_DURATION_MS) {
             popupTotal = totalEntries;
-
-            int perPage = visibleNodeRows * totalColumns;
 
             popupStart = startIndex + 1;
             popupEnd = std::min(startIndex + perPage, totalEntries);


### PR DESCRIPTION
I’ve redesigned the way nodes are displayed on the nodes page in MUI to enhance the overall experience.

Instead of continuously updating a list of every node, the system now creates a cache that gets refreshed every 10 seconds. This cache is then used to render pages with a limited number of note buffers. The idea is to render a single page at a time, rather than rendering multiple pages simultaneously. This approach allows for a smoother flow between pages and improves performance.

I’ve tested this system with a few others, and they’ve confirmed that it indeed improves performance. While it may not provide a high frame rate experience, it makes browsing through a node list of up to 250 nodes much more efficient.

It’s worth noting that the nodes page may be slow for the first minute after booting up. However, it becomes much quicker after that initial period.

To be clear most of this code was done vibe coding. 
## 🤝 Attestations

- [Y] I have tested that my proposed changes behave as described.
- [Y] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [X] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
