### PR TITLE
Add custom ringtone definition for RAK4631 and enable buzzer pin

### DIFF
--- a/variants/nrf52840/rak4631/variant.h
+++ b/variants/nrf52840/rak4631/variant.h
@@ -252,8 +252,12 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #define RV3028_RTC (uint8_t)0b1010010
 
 // RAK18001 Buzzer in Slot C
-// #define PIN_BUZZER 21 // IO3 is PWM2
+#define PIN_BUZZER 21 // IO3 is PWM2
 // NEW: set this via protobuf instead!
+
+// RAK4631 custom ringtone
+#undef USERPREFS_RINGTONE_RTTTL
+#define USERPREFS_RINGTONE_RTTTL "Rak:d=32,o=5,b=200:b7,p,b7,4p,p"
 
 // Battery
 // The battery sense is hooked to pin A0 (5)


### PR DESCRIPTION
This *shouldn't* interfere with anything as far as I can tell. Credit to @tropho23 for the ringtone RTTL which works on the resonant frequency for the RAK wisblock buzzer and doesn't get the buzzer HOT!