### PR TITLE
re-enable RTC support on THINKNODE M3 and M6

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -276,7 +276,6 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
         settimeofday(tv, NULL);
 #endif
 
-        // nrf52 doesn't have a readable RTC (yet - software not written)
 #if HAS_RTC
         readFromRTC();
 #endif

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/platformio.ini
@@ -25,4 +25,4 @@ lib_deps =
   # renovate: datasource=custom.pio depName=nRF52_PWM packageName=khoih-prog/library/nRF52_PWM
   khoih-prog/nRF52_PWM@1.0.1
   ; # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  ; lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.3.4

--- a/variants/nrf52840/ELECROW-ThinkNode-M3/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M3/variant.h
@@ -115,8 +115,8 @@ extern "C" {
 #define SERIAL_PRINT_PORT 0
 
 // PCF8563 RTC Module
-// REVISIT https://github.com/meshtastic/firmware/pull/9084
-// #define PCF8563_RTC 0x51
+#define PCF8563_RTC 0x51
+#define HAS_RTC 1
 
 #ifdef __cplusplus
 }

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/platformio.ini
@@ -22,4 +22,4 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW
 lib_deps =
   ${nrf52840_base.lib_deps}
   ; # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
-  ; lewisxhe/SensorLib@0.3.4
+  lewisxhe/SensorLib@0.3.4

--- a/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M6/variant.h
@@ -120,8 +120,8 @@ static const uint8_t A0 = PIN_A0;
 #define PIN_SERIAL2_TX (24)
 
 // PCF8563 RTC Module
-// REVISIT https://github.com/meshtastic/firmware/pull/9084
-// #define PCF8563_RTC 0x51
+#define PCF8563_RTC 0x51
+#define HAS_RTC 1
 
 // SPI
 #define SPI_INTERFACES_COUNT 1


### PR DESCRIPTION
M3 and M6 RTC support was pulled due to the ambiguity around how HAS_RTC works. These devices do have a working RTC, so re-adding the defines.