### PR TITLE
BUGNUM-9406: Decreased text size for the Heltec E213

### DIFF
--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -13,7 +13,7 @@ if [[ $# -gt 0 ]]; then
 	# can override which environment by passing arg
 	BOARDS="$@"
 else
-	BOARDS="tlora-v2 tlora-v1 tlora_v1_3 tlora-v2-1-1.6 tbeam heltec-v2.0 heltec-v2.1 tbeam0.7 meshtastic-diy-v1 rak4631 rak4631_eink rak11200 t-echo canaryone pca10059_diy_eink"
+	BOARDS="tlora-v2 tlora-v1 tlora_v1_3 tlora-v2-1-1_6 tbeam heltec-v2_0 heltec-v2_1 tbeam0_7 meshtastic-diy-v1 rak4631 rak4631_eink rak11200 t-echo canaryone pca10059_diy_eink"
 fi
 
 echo "BOARDS:${BOARDS}"

--- a/src/graphics/niche/InkHUD/docs/README.md
+++ b/src/graphics/niche/InkHUD/docs/README.md
@@ -326,6 +326,8 @@ InkHUD::Applet::fontSmall = FREESANS_6PT_WIN1252;
 
 Any generic AdafruitGFX font may be used, but the fonts which are bundled with InkHUD have been customized with extended-ASCII character sets and emoji.
 
+Some small displays may choose smaller sizes; for example, the Heltec Vision Master E213 uses 9pt/6pt/6pt to reduce text density on-screen.
+
 ### Parsing Unicode Text
 
 Text received by the firmware is encoded as UTF-8.

--- a/test/test_mqtt/MQTT.cpp
+++ b/test/test_mqtt/MQTT.cpp
@@ -333,8 +333,12 @@ void setUp(void)
     channelFile.channels_count = 1;
     owner = meshtastic_User{.id = "!12345678"};
     myNodeInfo = meshtastic_MyNodeInfo{.my_node_num = 0x12345678}; // Match the expected gateway ID in topic
-    localPosition =
-        meshtastic_Position{.has_latitude_i = true, .latitude_i = 7 * 1e7, .has_longitude_i = true, .longitude_i = 3 * 1e7};
+    localPosition = meshtastic_Position{
+        .has_latitude_i = true,
+        .latitude_i = 7 * 10000000,
+        .has_longitude_i = true,
+        .longitude_i = 3 * 10000000,
+    };
 
     router = mockRouter = new MockRouter();
     service = mockMeshService = new MockMeshService();

--- a/variants/esp32s3/heltec_vision_master_e213/nicheGraphics.h
+++ b/variants/esp32s3/heltec_vision_master_e213/nicheGraphics.h
@@ -69,9 +69,9 @@ void setupNicheGraphics()
     else if (displayModel == EInkDetectionResult::E0213A367) // V1.1
         inkhud->setDisplayResilience(15, 3);
 
-    // Select fonts
-    InkHUD::Applet::fontLarge = FREESANS_12PT_WIN1252;
-    InkHUD::Applet::fontMedium = FREESANS_9PT_WIN1252;
+    // Select fonts (reduced by one size step for E213)
+    InkHUD::Applet::fontLarge = FREESANS_9PT_WIN1252;
+    InkHUD::Applet::fontMedium = FREESANS_6PT_WIN1252;
     InkHUD::Applet::fontSmall = FREESANS_6PT_WIN1252;
 
     // Customize default settings

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -2,6 +2,7 @@
 extends = portduino_base
 build_flags = ${portduino_base.build_flags} -I variants/native/portduino
   -I /usr/include
+  -I /opt/homebrew/include
 board = cross_platform
 board_level = extra
 lib_deps = 


### PR DESCRIPTION
Problem Statement:

Bug Number [#9406](https://github.com/meshtastic/firmware/issues/9406) mentioned an issue with text size being too large on the Heltec E213.  This PR is my attempt at fixing that issue.  I unfortunately don't have the affected hardware to test my code changes, so please keep that in mind.  I chose to take the font size one step down, in hopes of alleviating this issue without being too heavy-handed about my choice.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
