### PR TITLE
Fix heltec v4 tft dependency

### DIFF
--- a/variants/esp32s3/heltec_v4/platformio.ini
+++ b/variants/esp32s3/heltec_v4/platformio.ini
@@ -124,11 +124,8 @@ build_flags =
   -D SCREEN_TOUCH_RST=TOUCH_RST_PIN
 
 lib_deps = ${heltec_v4_base.lib_deps}
-  ; ${device-ui_base.lib_deps}
+  ${device-ui_base.lib_deps}
   # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
   lovyan03/LovyanGFX@1.2.19
   # renovate: datasource=git-refs depName=Quency-D_chsc6x packageName=https://github.com/Quency-D/chsc6x gitBranch=master
   https://github.com/Quency-D/chsc6x/archive/5cbead829d6b432a8d621ed1aafd4eb474fd4f27.zip
-  ; TODO revert to official device-ui (when merged)
-  # renovate: datasource=git-refs depName=Quency-D_device-ui packageName=https://github.com/Quency-D/device-ui gitBranch=heltec-v4-tft
-  https://github.com/Quency-D/device-ui/archive/7c9870b8016641190b059bdd90fe16c1012a39eb.zip


### PR DESCRIPTION
The device-ui code has been merged into v4-tft, and dependency links will now be fixed.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] Heltec (Lora32) V4-TFT