### PR TITLE
fix(power): reset LPF when adc_multiplier_override changes at runtime

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -314,6 +314,13 @@ class AnalogBatteryLevel : public HasBatteryLevel
         // Override variant or default ADC_MULTIPLIER if we have the override pref
         float operativeAdcMultiplier =
             config.power.adc_multiplier_override > 0 ? config.power.adc_multiplier_override : ADC_MULTIPLIER;
+
+        // Reset filter if multiplier changed (allows runtime calibration to take effect immediately)
+        if (last_adc_multiplier != operativeAdcMultiplier) {
+            initial_read_done = false;
+            last_adc_multiplier = operativeAdcMultiplier;
+        }
+
         // Do not call analogRead() often.
         const uint32_t min_read_interval = 5000;
         if (!initial_read_done || !Throttle::isWithinTimespanMs(last_read_time_ms, min_read_interval)) {
@@ -520,6 +527,8 @@ class AnalogBatteryLevel : public HasBatteryLevel
     bool initial_read_done = false;
     float last_read_value = (OCV[NUM_OCV_POINTS - 1] * NUM_CELLS);
     uint32_t last_read_time_ms = 0;
+    // Track last used ADC multiplier to reset filter when config changes at runtime
+    float last_adc_multiplier = 0;
 
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && defined(HAS_RAKPROT)
 


### PR DESCRIPTION
## Summary

- Reset the Low Pass Filter when `power.adc_multiplier_override` changes at runtime
- Track last used ADC multiplier value and reset `initial_read_done` flag when it changes
- Allows runtime calibration to take effect immediately instead of waiting for slow LPF convergence

## Problem

When changing `power.adc_multiplier_override` at runtime, the new value is saved but has no visible effect on battery voltage readings for 1-2 minutes due to the LPF slowly converging to the new value.

The LPF uses a cached `last_read_value` calculated with the old multiplier, and the `initial_read_done` flag (set on first reading) prevents immediate application of the new multiplier.

## Solution

Add a member variable to track the last used multiplier. When the multiplier changes, reset `initial_read_done` to `false`, causing the next ADC reading to initialize the filter directly with the new scaled value.

## Test plan

- [ ] Set `power.adc_multiplier_override` via CLI
- [ ] Verify voltage reading updates immediately (within one ADC read cycle, ~5 seconds)
- [ ] Change multiplier again, verify immediate effect
- [ ] Reboot device, verify multiplier is still applied correctly

Fixes #9508