### PR TITLE
Prefer EXT_PWR_DETECT pin over chargingVolt to detect power unplugged

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -459,6 +459,8 @@ class AnalogBatteryLevel : public HasBatteryLevel
         }
         // if it's not HIGH - check the battery
 #endif
+        // If we have an EXT_PWR_DETECT pin and it indicates no external power, believe it.
+        return false;
 
 // technically speaking this should work for all(?) NRF52 boards
 // but needs testing across multiple devices. NRF52 USB would not even work if


### PR DESCRIPTION
This seems very straightforward, but I'm not sure if there are any edge cases to be aware of.