### PR TITLE
Fix config.display.use_long_node_name not saving

### DIFF
--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -1498,6 +1498,7 @@ void menuHandler::nodeNameLengthMenu()
 
                                                        config.display.use_long_node_name = option.value;
                                                        saveUIConfig();
+                                                       service->reloadConfig(SEGMENT_CONFIG);
                                                        LOG_INFO("Setting names to %s", option.value ? "long" : "short");
                                                    });
 


### PR DESCRIPTION
After forgetting about this for some time, I realized we missed a line in the save which kept config.display.use_long_node_name from saving properly.