### PR TITLE
Add support for Cardputer-Adv with Cap-Lora.

### DIFF
--- a/src/ST7789Spi.h
+++ b/src/ST7789Spi.h
@@ -1,0 +1,430 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by ThingPulse, Daniel Eichhorn
+ * Copyright (c) 2018 by Fabrice Weinberg
+ * Copyright (c) 2024 by Heltec AutoMation
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * ThingPulse invests considerable time and money to develop these open source libraries.
+ * Please support us by buying our products (and not the clones) from
+ * https://thingpulse.com
+ *
+ */
+
+#ifndef ST7789Spi_h
+#define ST7789Spi_h
+
+#include "OLEDDisplay.h"
+#include <SPI.h>
+
+
+#define ST_CMD_DELAY 0x80 // special signifier for command lists
+
+#define ST77XX_NOP 0x00
+#define ST77XX_SWRESET 0x01
+#define ST77XX_RDDID 0x04
+#define ST77XX_RDDST 0x09
+
+#define ST77XX_SLPIN 0x10
+#define ST77XX_SLPOUT 0x11
+#define ST77XX_PTLON 0x12
+#define ST77XX_NORON 0x13
+
+#define ST77XX_INVOFF 0x20
+#define ST77XX_INVON 0x21
+#define ST77XX_DISPOFF 0x28
+#define ST77XX_DISPON 0x29
+#define ST77XX_CASET 0x2A
+#define ST77XX_RASET 0x2B
+#define ST77XX_RAMWR 0x2C
+#define ST77XX_RAMRD 0x2E
+
+#define ST77XX_PTLAR 0x30
+#define ST77XX_TEOFF 0x34
+#define ST77XX_TEON 0x35
+#define ST77XX_MADCTL 0x36
+#define ST77XX_COLMOD 0x3A
+
+#define ST77XX_MADCTL_MY 0x80
+#define ST77XX_MADCTL_MX 0x40
+#define ST77XX_MADCTL_MV 0x20
+#define ST77XX_MADCTL_ML 0x10
+#define ST77XX_MADCTL_RGB 0x00
+
+#define ST77XX_RDID1 0xDA
+#define ST77XX_RDID2 0xDB
+#define ST77XX_RDID3 0xDC
+#define ST77XX_RDID4 0xDD
+
+// Some ready-made 16-bit ('565') color settings:
+#define ST77XX_BLACK 0x0000
+#define ST77XX_WHITE 0xFFFF
+#define ST77XX_RED 0xF800
+#define ST77XX_GREEN 0x07E0
+#define ST77XX_BLUE 0x001F
+#define ST77XX_CYAN 0x07FF
+#define ST77XX_MAGENTA 0xF81F
+#define ST77XX_YELLOW 0xFFE0
+#define ST77XX_ORANGE 0xFC00
+
+#define LED_A_ON LOW
+
+#ifdef ESP_PLATFORM
+#undef LED_A_ON
+#define LED_A_ON HIGH
+#define rtos_free free
+#define rtos_malloc malloc
+//SPIClass SPI1(HSPI);
+#endif
+class ST7789Spi : public OLEDDisplay {
+  private:
+      uint8_t             _rst;
+      uint8_t             _dc;
+      uint8_t             _cs;
+      uint8_t             _ledA;
+      int             _miso;
+      int             _mosi;
+      int             _clk;
+      SPIClass * _spi;
+      SPISettings 		    _spiSettings;
+      uint16_t            _RGB=0xFFFF;
+      uint8_t             _buffheight;
+
+      // Memory Data Access Control
+      // Meshtastic firmware flips displays by default (legacy of the T-Beam)
+      // Our default config here is "flipped" (relative to the bootloader screen), to counter this convention
+      uint8_t _MADCTL=ST77XX_MADCTL_RGB|ST77XX_MADCTL_MV|ST77XX_MADCTL_MY;
+
+  public:
+    /* pass _cs as -1 to indicate "do not use CS pin", for cases where it is hard wired low */
+    ST7789Spi(SPIClass *spiClass,uint8_t _rst, uint8_t _dc, uint8_t _cs, OLEDDISPLAY_GEOMETRY g = GEOMETRY_RAWMODE,uint16_t width=240,uint16_t height=135,int mosi=-1,int miso=-1,int clk=-1) {
+      this->_spi = spiClass;
+      this->_rst = _rst;
+      this->_dc  = _dc;
+      this->_cs  = _cs;
+      this->_mosi=mosi;
+      this->_miso=miso;
+      this->_clk=clk;
+      //this->_ledA  = _ledA;
+      _spiSettings = SPISettings(40000000, MSBFIRST, SPI_MODE0);
+      setGeometry(g,width,height);
+      setRGB(ST77XX_GREEN); // Default to Green, if color not explicity specified by Meshtastic firmware
+    }
+
+    bool connect(){
+      this->_buffheight=displayHeight / 8;
+      this->_buffheight+=displayHeight % 8 ? 1:0;
+      pinMode(_cs, OUTPUT);
+      pinMode(_dc, OUTPUT);
+      //pinMode(_ledA, OUTPUT);
+      if (_cs != (uint8_t) -1) {
+        pinMode(_cs, OUTPUT);
+      }  
+      pinMode(_rst, OUTPUT);
+
+#ifdef ESP_PLATFORM
+      _spi->begin(_clk,_miso,_mosi,-1);
+#else
+      _spi->begin();
+#endif
+      _spi->setClockDivider (SPI_CLOCK_DIV2);
+
+      // Pulse Reset low for 10ms
+      digitalWrite(_rst, HIGH);
+      delay(1);
+      digitalWrite(_rst, LOW);
+      delay(10);
+      digitalWrite(_rst, HIGH);
+      _spi->begin ();
+      //digitalWrite(_ledA, LED_A_ON);
+      return true;
+    }
+
+    void display(void) {
+    #ifdef OLEDDISPLAY_DOUBLE_BUFFER
+
+       uint16_t minBoundY = UINT16_MAX;
+       uint16_t maxBoundY = 0;
+
+       uint16_t minBoundX = UINT16_MAX;
+       uint16_t maxBoundX = 0;
+
+       uint16_t x, y;
+        
+       // Calculate the Y bounding box of changes
+       // and copy buffer[pos] to buffer_back[pos];
+       for (y = 0; y < _buffheight; y++) {
+         for (x = 0; x < displayWidth; x++) {
+          //Serial.printf("x  %d y %d\r\n",x,y);
+          uint16_t pos = x + y * displayWidth;
+          if (buffer[pos] != buffer_back[pos]) {
+            minBoundY = min(minBoundY, y);
+            maxBoundY = max(maxBoundY, y);
+            minBoundX = min(minBoundX, x);
+            maxBoundX = max(maxBoundX, x);
+          }
+          buffer_back[pos] = buffer[pos];
+        }
+        yield();
+       }
+
+       // If the minBoundY wasn't updated
+       // we can savely assume that buffer_back[pos] == buffer[pos]
+       // holdes true for all values of pos
+       if (minBoundY == UINT16_MAX) return;
+
+		  set_CS(LOW);
+		  _spi->beginTransaction(_spiSettings);
+
+          for (y = minBoundY; y <= maxBoundY; y++)
+          {
+            for(int temp = 0; temp<8;temp++)
+            {
+              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+              setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+              //setAddrWindow(y*8+temp,minBoundX,1,maxBoundX-minBoundX+1);
+              uint32_t const pixbufcount = maxBoundX-minBoundX+1;
+              uint16_t *pixbuf = (uint16_t *)rtos_malloc(2 * pixbufcount);
+              for (x = minBoundX; x <= maxBoundX; x++)
+              {
+                pixbuf[x-minBoundX] = ((buffer[x + y * displayWidth]>>temp)&0x01)==1?_RGB:0;
+              }
+#ifdef ESP_PLATFORM
+              _spi->transferBytes((uint8_t *)pixbuf, NULL, 2 * pixbufcount);
+#else
+              _spi->transfer(pixbuf, NULL, 2 * pixbufcount);
+#endif
+              rtos_free(pixbuf);
+            }
+          }
+	  _spi->endTransaction();
+	  set_CS(HIGH);
+
+     #else
+		  set_CS(LOW);
+		  _spi->beginTransaction(_spiSettings);
+		uint8_t x, y;
+          for (y = 0; y < _buffheight; y++)
+          {
+            for(int temp = 0; temp<8;temp++)
+            {
+              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+              setAddrWindow(y*8+temp,0,1,displayWidth);
+              uint32_t const pixbufcount = displayWidth;
+              uint16_t *pixbuf = (uint16_t *)rtos_malloc(2 * pixbufcount);
+              for (x = 0; x < displayWidth; x++)
+              {
+                pixbuf[x] = ((buffer[x + y * displayWidth]>>temp)&0x01)==1?_RGB:0;
+              }
+#ifdef ESP_PLATFORM
+              _spi->transferBytes((uint8_t *)pixbuf, NULL, 2 * pixbufcount);
+#else
+              _spi->transfer(pixbuf, NULL, 2 * pixbufcount);
+#endif
+              rtos_free(pixbuf);
+            }
+          }
+	  _spi->endTransaction();
+	  set_CS(HIGH);
+
+     #endif
+    }
+
+ virtual void resetOrientation() {
+	_MADCTL = ST77XX_MADCTL_RGB|ST77XX_MADCTL_MV|ST77XX_MADCTL_MY;
+	sendCommand(ST77XX_MADCTL);
+	WriteData(_MADCTL);
+	delay(10);
+  }
+  
+ virtual void flipScreenVertically() {
+	_MADCTL = ST77XX_MADCTL_RGB|ST77XX_MADCTL_MV|ST77XX_MADCTL_MX;
+	sendCommand(ST77XX_MADCTL);
+	WriteData(_MADCTL);
+	delay(10);
+  }
+  
+ virtual void mirrorScreen() {
+	_MADCTL = ST77XX_MADCTL_RGB|ST77XX_MADCTL_MV|ST77XX_MADCTL_MX|ST77XX_MADCTL_MY;
+	sendCommand(ST77XX_MADCTL);
+	WriteData(_MADCTL);
+	delay(10);
+  }
+
+  void setRGB(uint16_t c)
+  {
+
+    this->_RGB=0x00|c>>8|(c<<8&0xFF00);
+  }
+  
+  void displayOn(void) {
+  //sendCommand(DISPLAYON);
+  }
+
+  void displayOff(void) {
+  //sendCommand(DISPLAYOFF);
+  }
+  
+//#define ST77XX_MADCTL_MY 0x80
+//#define ST77XX_MADCTL_MX 0x40
+//#define ST77XX_MADCTL_MV 0x20
+//#define ST77XX_MADCTL_ML 0x10
+  protected:
+    // Send all the init commands
+    virtual void sendInitCommands()
+    {
+        sendCommand(ST77XX_SWRESET); //  1: Software reset, no args, w/delay
+        delay(150);
+
+        sendCommand(ST77XX_SLPOUT); //  2: Out of sleep mode, no args, w/delay
+        delay(10);
+
+        sendCommand(ST77XX_COLMOD); //  3: Set color mode, 16-bit color
+        WriteData(0x55); 
+        delay(10);
+        
+        sendCommand(ST77XX_MADCTL); //  4: Mem access ctrl (directions)
+        WriteData(_MADCTL); 
+        
+        sendCommand(ST77XX_CASET); //   5: Column addr set, 
+        WriteData(0x00); 
+        WriteData(0x00);         //    XSTART = 0
+        WriteData(0x00); 
+        WriteData(240);          //     XEND = 240
+        
+        sendCommand(ST77XX_RASET); //   6: Row addr set, 
+        WriteData(0x00); 
+        WriteData(0x00);         //    YSTART = 0
+        WriteData(320>>8); 
+        WriteData(320&0xFF);          //    YSTART = 320
+        
+        sendCommand(ST77XX_SLPOUT); //  7: hack
+        delay(10);
+        
+        sendCommand(ST77XX_NORON); //  8: Normal display on, no args, w/delay
+        delay(10);
+        
+        sendCommand(ST77XX_DISPON); //  9: Main screen turn on, no args, delay
+        delay(10);
+
+        sendCommand(ST77XX_INVON); //  10: invert
+        delay(10);
+    }
+
+
+  private:
+
+   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+    x += (320-displayWidth)/2;
+    y += (240-displayHeight)/2;
+    uint32_t xa = ((uint32_t)x << 16) | (x + w - 1);
+    uint32_t ya = ((uint32_t)y << 16) | (y + h - 1);
+
+    writeCommand(ST77XX_CASET); // Column addr set
+    SPI_WRITE32(xa);
+
+    writeCommand(ST77XX_RASET); // Row addr set
+    SPI_WRITE32(ya);
+
+    writeCommand(ST77XX_RAMWR); // write to RAM
+  }
+	int getBufferOffset(void) {
+		return 0;
+	}
+    inline void set_CS(bool level) {
+      if (_cs != (uint8_t) -1) {
+        digitalWrite(_cs, level);
+      }
+    };
+    inline void sendCommand(uint8_t com) __attribute__((always_inline)){
+      set_CS(HIGH);
+      digitalWrite(_dc, LOW);
+      set_CS(LOW);
+      _spi->beginTransaction(_spiSettings);
+      _spi->transfer(com);
+      _spi->endTransaction();
+      set_CS(HIGH);
+      digitalWrite(_dc, HIGH);
+    }
+    
+    inline void WriteData(uint8_t data) __attribute__((always_inline)){
+        digitalWrite(_cs, LOW);
+        _spi->beginTransaction(_spiSettings);
+        _spi->transfer(data);
+        _spi->endTransaction();
+        digitalWrite(_cs, HIGH);
+    }
+   void SPI_WRITE32(uint32_t l)
+   {
+      _spi->transfer(l >> 24);
+      _spi->transfer(l >> 16);
+      _spi->transfer(l >> 8);
+      _spi->transfer(l);
+   }
+  void writeCommand(uint8_t cmd) {
+    digitalWrite(_dc, LOW);
+    _spi->transfer(cmd);
+    digitalWrite(_dc, HIGH);
+  }
+
+// Private functions
+  void setGeometry(OLEDDISPLAY_GEOMETRY g, uint16_t width, uint16_t height) {
+    this->geometry = g;
+
+    switch (g) {
+      case GEOMETRY_128_128:
+        this->displayWidth = 128;
+        this->displayHeight = 128;
+        break;
+      case GEOMETRY_128_64:
+        this->displayWidth = 128;
+        this->displayHeight = 64;
+        break;
+      case GEOMETRY_128_32:
+        this->displayWidth = 128;
+        this->displayHeight = 32;
+        break;
+      case GEOMETRY_64_48:
+        this->displayWidth = 64;
+        this->displayHeight = 48;
+        break;
+      case GEOMETRY_64_32:
+        this->displayWidth = 64;
+        this->displayHeight = 32;
+        break;
+      case GEOMETRY_RAWMODE:
+        this->displayWidth = width > 0 ? width : 128;
+        this->displayHeight = height > 0 ? height : 64;
+        break;
+    }
+    uint8_t tmp=displayHeight % 8;
+    uint8_t _buffheight=displayHeight / 8;
+
+    if(tmp!=0)
+      _buffheight++;
+    this->displayBufferSize = displayWidth * _buffheight ;
+  }
+  
+
+
+};
+
+#endif

--- a/src/input/CardputerAdvKeyboard.cpp
+++ b/src/input/CardputerAdvKeyboard.cpp
@@ -1,0 +1,208 @@
+#if defined(M5STACK_CARDPUTER_ADV)
+
+#include "CardputerAdvKeyboard.h"
+#include "main.h"
+
+#define _TCA8418_COLS 8
+#define _TCA8418_ROWS 7
+#define _TCA8418_NUM_KEYS 56
+
+#define _TCA8418_MULTI_TAP_THRESHOLD 1500
+
+using Key = TCA8418KeyboardBase::TCA8418Key;
+
+constexpr uint8_t modifierShiftKey = 7 - 1; // keynum -1
+constexpr uint8_t modifierRightShift = 0b0001;
+
+constexpr uint8_t modifierFnKey = 3 - 1;
+constexpr uint8_t modifierFn = 0b0010;
+
+constexpr uint8_t modifierCtrlKey = 4 - 1;
+
+constexpr uint8_t modifierOptKey = 8 - 1;
+
+constexpr uint8_t modifierAltKey = 12 - 1;
+
+// Num chars per key, Modulus for rotating through characters
+// https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/1178/Sch_M5CardputerAdv_v1.0_2025_06_20_17_19_58_page_02.png
+static uint8_t CardputerAdvTapMod[_TCA8418_NUM_KEYS] = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+static unsigned char CardputerAdvTapMap[_TCA8418_NUM_KEYS][3] = {{'`', '~', Key::ESC},
+                                                                 {Key::TAB, 0x00, 0x00},
+                                                                 {0x00, 0x00, 0x00}, // Fn
+                                                                 {0x00, 0x00, 0x00}, // ctrl
+                                                                 {'1', '!', 0x00},
+                                                                 {'q', 'Q', Key::REBOOT},
+                                                                 {0x00, 0x00, 0x00}, // shift
+                                                                 {0x00, 0x00, 0x00}, // opt
+                                                                 {'2', '@', 0x00},
+                                                                 {'w', 'W', 0x00},
+                                                                 {'a', 'A', 0x00},
+                                                                 {0x00, 0x00, 0x00}, // alt
+                                                                 {'3', '#', 0x00},
+                                                                 {'e', 'E', 0x00},
+                                                                 {'s', 'S', 0x00},
+                                                                 {'z', 'Z', 0x00},
+                                                                 {'4', '$', 0x00},
+                                                                 {'r', 'R', 0x00},
+                                                                 {'d', 'D', 0x00},
+                                                                 {'x', 'X', 0x00},
+                                                                 {'5', '%', 0x00},
+                                                                 {'t', 'T', 0x00},
+                                                                 {'f', 'F', 0x00},
+                                                                 {'c', 'C', 0x00},
+                                                                 {'6', '^', 0x00},
+                                                                 {'y', 'Y', 0x00},
+                                                                 {'g', 'G', Key::GPS_TOGGLE},
+                                                                 {'v', 'V', 0x00},
+                                                                 {'7', '&', 0x00},
+                                                                 {'u', 'U', 0x00},
+                                                                 {'h', 'H', 0x00},
+                                                                 {'b', 'B', Key::BT_TOGGLE},
+                                                                 {'8', '*', 0x00},
+                                                                 {'i', 'I', 0x00},
+                                                                 {'j', 'J', 0x00},
+                                                                 {'n', 'N', 0x00},
+                                                                 {'9', '(', 0x00},
+                                                                 {'o', 'O', 0x00},
+                                                                 {'k', 'K', 0x00},
+                                                                 {'m', 'M', Key::MUTE_TOGGLE},
+                                                                 {'0', ')', 0x00},
+                                                                 {'p', 'P', Key::SEND_PING},
+                                                                 {'l', 'L', 0x00},
+                                                                 {',', '<', Key::LEFT},
+                                                                 {'_', '-', 0x00},
+                                                                 {'[', '{', 0x00},
+                                                                 {';', ':', Key::UP},
+                                                                 {'.', '>', Key::DOWN},
+                                                                 {'=', '+', 0x00},
+                                                                 {']', '}', 0x00},
+                                                                 {'\'', '"', 0x00},
+                                                                 {'/', '?', Key::RIGHT},
+                                                                 {Key::BSP, 0x00, 0x00},
+                                                                 {'\\', '|', 0x00},
+                                                                 {Key::SELECT, 0x00, 0x00}, // Enter
+                                                                 {' ', ' ', ' '}};          // Space
+
+CardputerAdvKeyboard::CardputerAdvKeyboard()
+    : TCA8418KeyboardBase(_TCA8418_ROWS, _TCA8418_COLS), modifierFlag(0), last_modifier_time(0), last_key(-1), next_key(-1),
+      last_tap(0L), char_idx(0), tap_interval(0)
+{
+    reset();
+}
+
+void CardputerAdvKeyboard::reset(void)
+{
+    TCA8418KeyboardBase::reset();
+}
+
+// handle multi-key presses (shift and alt)
+void CardputerAdvKeyboard::trigger()
+{
+    uint8_t count = keyCount();
+    if (count == 0)
+        return;
+    for (uint8_t i = 0; i < count; ++i) {
+        uint8_t k = readRegister(TCA8418_REG_KEY_EVENT_A + i);
+        uint8_t key = k & 0x7F;
+        if (k & 0x80) {
+            pressed(key);
+        } else {
+            released();
+            state = Idle;
+        }
+    }
+}
+
+void CardputerAdvKeyboard::pressed(uint8_t key)
+{
+    if (state == Init || state == Busy) {
+        return;
+    }
+
+    if (modifierFlag && (millis() - last_modifier_time > _TCA8418_MULTI_TAP_THRESHOLD)) {
+        modifierFlag = 0;
+    }
+
+    uint8_t next_key = 0;
+    int row = (key - 1) / 10;
+    int col = (key - 1) % 10;
+
+    if (row >= _TCA8418_ROWS || col >= _TCA8418_COLS) {
+        return; // Invalid key
+    }
+
+    next_key = row * _TCA8418_COLS + col;
+    state = Held;
+
+    uint32_t now = millis();
+    tap_interval = now - last_tap;
+
+    updateModifierFlag(next_key);
+    if (isModifierKey(next_key)) {
+        last_modifier_time = now;
+    }
+
+    if (tap_interval < 0) {
+        last_tap = 0;
+        state = Busy;
+        return;
+    }
+
+    if (next_key != last_key || tap_interval > _TCA8418_MULTI_TAP_THRESHOLD) {
+        char_idx = 0;
+    } else {
+        char_idx += 1;
+    }
+
+    last_key = next_key;
+    last_tap = now;
+}
+
+void CardputerAdvKeyboard::released()
+{
+    if (state != Held) {
+        return;
+    }
+
+    if (last_key < 0 || last_key >= _TCA8418_NUM_KEYS) {
+        last_key = -1;
+        state = Idle;
+        return;
+    }
+
+    uint32_t now = millis();
+    last_tap = now;
+
+    if (CardputerAdvTapMap[last_key][modifierFlag % CardputerAdvTapMod[last_key]] == Key::BL_TOGGLE) {
+        return;
+    }
+
+    queueEvent(CardputerAdvTapMap[last_key][modifierFlag % CardputerAdvTapMod[last_key]]);
+    if (isModifierKey(last_key) == false)
+        modifierFlag = 0;
+}
+
+void CardputerAdvKeyboard::updateModifierFlag(uint8_t key)
+{
+    if (key == modifierShiftKey) {
+        modifierFlag ^= modifierRightShift;
+    } else if (key == modifierFnKey) {
+        modifierFlag ^= modifierFn;
+    } else if (key == modifierCtrlKey) {
+        // modifierFlag ^= modifierCtrl;
+    } else if (key == modifierOptKey) {
+        // modifierFlag ^= modifierOpt;
+    } else if (key == modifierAltKey) {
+        // modifierFlag ^= modifierAlt;
+    }
+}
+
+bool CardputerAdvKeyboard::isModifierKey(uint8_t key)
+{
+    return (key == modifierShiftKey || key == modifierFnKey);
+}
+
+#endif

--- a/src/input/CardputerAdvKeyboard.h
+++ b/src/input/CardputerAdvKeyboard.h
@@ -1,0 +1,26 @@
+#include "TCA8418KeyboardBase.h"
+
+class CardputerAdvKeyboard : public TCA8418KeyboardBase
+{
+  public:
+    CardputerAdvKeyboard();
+    void reset(void);
+    void trigger(void) override;
+    virtual ~CardputerAdvKeyboard() {}
+
+  protected:
+    void pressed(uint8_t key) override;
+    void released(void) override;
+
+    void updateModifierFlag(uint8_t key);
+    bool isModifierKey(uint8_t key);
+
+  private:
+    uint8_t modifierFlag;        // Flag to indicate if a modifier key is pressed
+    uint32_t last_modifier_time; // Timestamp of the last modifier key press
+    int8_t last_key;
+    int8_t next_key;
+    uint32_t last_tap;
+    uint8_t char_idx;
+    int32_t tap_interval;
+};

--- a/src/input/kbI2cBase.cpp
+++ b/src/input/kbI2cBase.cpp
@@ -9,6 +9,8 @@
 #include "TLoraPagerKeyboard.h"
 #elif defined(HACKADAY_COMMUNICATOR)
 #include "HackadayCommunicatorKeyboard.h"
+#elif defined(M5STACK_CARDPUTER_ADV)
+#include "CardputerAdvKeyboard.h"
 #else
 #include "TCA8418Keyboard.h"
 #endif
@@ -24,6 +26,8 @@ KbI2cBase::KbI2cBase(const char *name)
       TCAKeyboard(*(new TLoraPagerKeyboard()))
 #elif defined(HACKADAY_COMMUNICATOR)
       TCAKeyboard(*(new HackadayCommunicatorKeyboard()))
+#elif defined(M5STACK_CARDPUTER_ADV)
+      TCAKeyboard(*(new CardputerAdvKeyboard()))
 #else
       TCAKeyboard(*(new TCA8418Keyboard()))
 #endif
@@ -321,26 +325,28 @@ int32_t KbI2cBase::runOnce()
                 e.inputEvent = INPUT_BROKER_ANYKEY;
                 e.kbchar = INPUT_BROKER_MSG_TAB;
                 break;
-            case TCA8418KeyboardBase::FUNCTION_F1:
-                e.inputEvent = INPUT_BROKER_FN_F1;
-                e.kbchar = 0x00;
+#ifndef M5STACK_CARDPUTER_ADV                
+            case TCA8418KeyboardBase::FUNCTION_F1: 		
+                e.inputEvent = INPUT_BROKER_FN_F1; 		
+                e.kbchar = 0x00; 		
+                break; 		
+            case TCA8418KeyboardBase::FUNCTION_F2: 		
+                e.inputEvent = INPUT_BROKER_FN_F2; 		
+                e.kbchar = 0x00; 		
+                break; 		
+            case TCA8418KeyboardBase::FUNCTION_F3: 		
+                e.inputEvent = INPUT_BROKER_FN_F3; 		
+                e.kbchar = 0x00; 		
+                break; 		
+            case TCA8418KeyboardBase::FUNCTION_F4: 		
+                e.inputEvent = INPUT_BROKER_FN_F4; 		
+                e.kbchar = 0x00; 		
+                break; 		
+            case TCA8418KeyboardBase::FUNCTION_F5: 		
+                e.inputEvent = INPUT_BROKER_FN_F5; 		
+                e.kbchar = 0x00; 		
                 break;
-            case TCA8418KeyboardBase::FUNCTION_F2:
-                e.inputEvent = INPUT_BROKER_FN_F2;
-                e.kbchar = 0x00;
-                break;
-            case TCA8418KeyboardBase::FUNCTION_F3:
-                e.inputEvent = INPUT_BROKER_FN_F3;
-                e.kbchar = 0x00;
-                break;
-            case TCA8418KeyboardBase::FUNCTION_F4:
-                e.inputEvent = INPUT_BROKER_FN_F4;
-                e.kbchar = 0x00;
-                break;
-            case TCA8418KeyboardBase::FUNCTION_F5:
-                e.inputEvent = INPUT_BROKER_FN_F5;
-                e.kbchar = 0x00;
-                break;
+#endif
             default:
                 if (nextEvent > 127) {
                     e.inputEvent = INPUT_BROKER_NONE;

--- a/src/platform/esp32/architecture.h
+++ b/src/platform/esp32/architecture.h
@@ -202,6 +202,8 @@
 #define HW_VENDOR meshtastic_HardwareModel_M5STACK_C6L
 #elif defined(HELTEC_WIRELESS_TRACKER_V2)
 #define HW_VENDOR meshtastic_HardwareModel_HELTEC_WIRELESS_TRACKER_V2
+#elif defined(M5STACK_CARDPUTER_ADV)
+#define HW_VENDOR meshtastic_HardwareModel_M5STACK_CARDPUTER_ADV
 #else
 #define HW_VENDOR meshtastic_HardwareModel_PRIVATE_HW
 #endif

--- a/variants/esp32s3/m5stack_cardputer_adv/pins_arduino.h
+++ b/variants/esp32s3/m5stack_cardputer_adv/pins_arduino.h
@@ -1,0 +1,20 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+#define USB_VID 0x303a // USB JTAG/serial debug unit ID
+#define USB_PID 0x1001 // USB JTAG/serial debug unit ID
+
+static const uint8_t SS = 5;
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+static const uint8_t ADC = 10;
+static const uint8_t TXD2 = 13;
+static const uint8_t MOSI = 14;
+static const uint8_t RXD2 = 15;
+static const uint8_t MISO = 39;
+static const uint8_t SCK = 40;
+
+#endif

--- a/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
+++ b/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
@@ -1,0 +1,20 @@
+[env:m5stack-cardputer-adv]
+board = m5stack-stamps3
+extends = esp32s3_base
+board_build.partitions = partition-table-8MB.csv
+upload_protocol = esptool
+monitor_speed = 115200
+
+build_flags = 
+  ${esp32_base.build_flags} 
+  -D M5STACK_CARDPUTER_ADV
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D MESHTASTIC_EXCLUDE_WEBSERVER=1 
+  -I variants/esp32s3/m5stack_cardputer_adv
+lib_deps = ${esp32_base.lib_deps}
+  adafruit/Adafruit NeoPixel @ ^1.12.0
+  m5stack/M5Cardputer@^1.1.1 
+
+platform_packages =
+	platformio/tool-mklittlefs@^1.203.210628
+

--- a/variants/esp32s3/m5stack_cardputer_adv/variant.h
+++ b/variants/esp32s3/m5stack_cardputer_adv/variant.h
@@ -1,0 +1,94 @@
+// I2C
+#define I2C_SDA SDA
+#define I2C_SCL SCL
+
+// Custom port I2C1 or UART
+#define G1 1
+#define G2 2
+
+// Neopixel LED, PWR_EN Pin same as TFT Backlight GPIO38
+#define HAS_NEOPIXEL                         
+#define NEOPIXEL_COUNT 1                     
+#define NEOPIXEL_DATA 21                     
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800)
+
+// Button
+#define BUTTON_PIN 0
+
+// Battery
+#define BATTERY_PIN 10
+#define ADC_CHANNEL ADC1_GPIO10_CHANNEL
+
+// IR LED
+#define IR_LED 44 
+
+// TCA8418 keyboard
+#define TCA8418_INT 11
+#define I2C_NO_RESCAN
+#define KB_INT TCA8418_INT
+
+// GPS
+#define HAS_GPS 1
+#define GPS_RX_PIN RXD2
+#define GPS_TX_PIN TXD2
+#define GPS_BAUDRATE 115200
+
+// BMI270
+#define USE_BMI270 // INFO  | ??:??:?? 0 BMX160 found at address 0x69
+
+// SD CARD
+#undef HAS_SDCARD // device UI doesn't support SD card
+// #define SPI_MOSI MOSI
+// #define SPI_SCK SCK
+// #define SPI_MISO MISO
+// #define SPI_CS 12
+// #define SDCARD_CS SPI_CS
+// #define SD_SPI_FREQUENCY 75000000U
+
+// // audio codec ES8311
+#undef HAS_I2S // dependencies take up 15% of RAM
+// #define DAC_I2S_BCK 41
+// #define DAC_I2S_WS 43
+// #define DAC_I2S_DOUT 46
+// #define DAC_I2S_DIN 42
+// #define DAC_I2S_MCLK -1 //???
+
+
+#define TFT_MESH_OVERRIDE COLOR565(204, 0, 204)
+
+// ST7789 LCD
+#define USE_ST7789
+#define ST7789_NSS 37
+#define ST7789_RS 34  // DC
+#define ST7789_SDA 35 // MOSI
+#define ST7789_SCK 36
+#define ST7789_RESET 33
+#define ST7789_MISO -1
+#define ST7789_BUSY -1
+#define VTFT_CTRL 38
+#define VTFT_LEDA 38
+#define TFT_BACKLIGHT_ON HIGH
+#define ST7789_SPI_HOST SPI2_HOST
+#define SPI_FREQUENCY 40000000
+#define SPI_READ_FREQUENCY 16000000
+#define TFT_HEIGHT 135
+#define TFT_WIDTH 240
+#define TFT_OFFSET_X 0
+#define TFT_OFFSET_Y 0
+#define BRIGHTNESS_DEFAULT 180
+
+// LoRa
+#define USE_SX1262
+#define LORA_SCK SCK
+#define LORA_MISO MISO
+#define LORA_MOSI MOSI
+#define LORA_CS SS
+#define LORA_DIO1 4
+#define LORA_DIO2 6
+#define LORA_RESET 3
+#define SX126X_CS LORA_CS
+#define SX126X_DIO1 LORA_DIO1
+#define SX126X_BUSY LORA_DIO2
+#define SX126X_RESET LORA_RESET
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 3.3 //M5stack reference code uses this.


### PR DESCRIPTION
Cardputer docs: https://docs.m5stack.com/en/core/Cardputer-Adv (ST7789 display, TCA8418 keyboard)

Cap-Lora docs: https://docs.m5stack.com/en/cap/Cap_LoRa-1262 (SX1262)

This branch includes work from @WillyJL and @Szetya (https://github.com/meshtastic/firmware/pull/8010) and this Reddit thread: https://www.reddit.com/r/CardPuter/comments/1pxjryj/working_meshtastic_firmware_for_the_cardputer_adv/

This PR adds those changes, reduces RAM usage, sets the correct device type and documents the variant.h file better.

It was also extensively tested on the device itself.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] Heltec Mesh Node T114
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
  - [x] Cardputer ADV with Cap-Lora
