### PR TITLE
meshtasticd: Fix install on Fedora 43

### DIFF
--- a/meshtasticd.spec.rpkg
+++ b/meshtasticd.spec.rpkg
@@ -59,8 +59,14 @@ BuildRequires: pkgconfig(libbsd-overlay)
 
 Requires:      systemd-udev
 
+# Declare that this package provides the user/group it creates in %pre
+# Required for Fedora 43+ which tracks users/groups as RPM dependencies
+Provides:      user(%{meshtasticd_user})
+Provides:      group(%{meshtasticd_user})
+Provides:      group(spi)
+
 %description
-Meshtastic daemon for controlling Meshtastic devices. Meshtastic is an off-grid
+Meshtastic daemon. Meshtastic is an off-grid
 text communication platform that uses inexpensive LoRa radios.
 
 %prep


### PR DESCRIPTION
On Fedora 43+ `meshtasticd` fails to install with this error:

```
Problem: conflicting requests
  - nothing provides group(meshtasticd) needed by meshtasticd-2.7.15-12176.beta.git567b8ea1c.fc43.x86_64 from copr:copr.fedorainfracloud.org:group_meshtastic:beta
  - nothing provides user(meshtasticd) needed by meshtasticd-2.7.15-12176.beta.git567b8ea1c.fc43.x86_64 from copr:copr.fedorainfracloud.org:group_meshtastic:beta
```

This PR addresses the issue by declaring that the package provides these users/groups.