### PR TITLE
RPM: Include meshtasticd-start.sh

### DIFF
--- a/meshtasticd.spec.rpkg
+++ b/meshtasticd.spec.rpkg
@@ -157,6 +157,7 @@ fi
 %license LICENSE
 %doc README.md
 %{_bindir}/meshtasticd
+%{_bindir}/meshtasticd-start.sh
 %dir %{_localstatedir}/lib/meshtasticd
 %{_udevrulesdir}/99-meshtasticd-udev.rules
 %dir %{_sysconfdir}/meshtasticd


### PR DESCRIPTION
Fix small RPM packaging regression added in #8676 

```
error: Installed (but unpackaged) file(s) found:
   /usr/bin/meshtasticd-start.sh
```