### PR TITLE
Add LDO startup delay before GC1109 chip enable

### DIFF
--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -6,6 +6,9 @@
 #ifdef ARCH_PORTDUINO
 #include "PortduinoGlue.h"
 #endif
+#if defined(USE_GC1109_PA) && defined(ARCH_ESP32)
+#include "esp_sleep.h"
+#endif
 
 #include "Throttle.h"
 
@@ -59,6 +62,14 @@ template <typename T> bool SX126xInterface<T>::init()
     // VFEM_Ctrl (LORA_PA_POWER): Power enable for GC1109 LDO (always on)
     pinMode(LORA_PA_POWER, OUTPUT);
     digitalWrite(LORA_PA_POWER, HIGH);
+
+    // TLV75733P LDO has ~550us startup time (datasheet tSTR). On cold boot, wait
+    // for VBAT to stabilise before driving CSD/CPS, per GC1109 requirement:
+    // "VBAT must be prior to CSD/CPS/CTX for the power on sequence"
+    // On deep sleep wake the LDO was held on via RTC latch, so no delay needed.
+    if (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_UNDEFINED) {
+        delayMicroseconds(1000);
+    }
 
     // CSD (LORA_PA_EN): Chip enable - must be HIGH to enable GC1109 for both RX and TX
     pinMode(LORA_PA_EN, OUTPUT);


### PR DESCRIPTION
## Summary

- Add 1ms delay between enabling PA_POWER (LDO) and PA_EN (CSD) during GC1109 initialization
- Ensures VBAT is stable before chip enable, per GC1109 power-on sequence requirements

## Background

The Heltec V4 and Wireless Tracker V2 use a TLV75733P LDO (controlled by `LORA_PA_POWER` / GPIO7) to power the GC1109 FEM. The TLV757P datasheet specifies a startup time (tSTR) of ~550us.

The GC1109 datasheet requires:
> "VBAT must be prior to CSD/CPS/CTX for the power on sequence"
> "CSD/CPS/CTX voltage level must not exceed VBAT voltage"

Oscilloscope measurements by @ascendr showed CSD (`LORA_PA_EN`) going HIGH only ~12.5us after PA_POWER — well before the LDO output stabilises. @compumike identified the TLV757P startup time as the likely cause.

This only affects cold boot initialization. During normal operation the LDO stays on (it is intentionally not powered off during sleep), so `setTransmitEnable()` does not need a delay.

Reference: https://github.com/meshtastic/firmware/pull/9029 (comments by @compumike, @ascendr, @lindorffs)

## Test plan

- [ ] Flash Heltec V4, verify normal RX/TX operation
- [ ] Confirm no regression in boot time (1ms delay is negligible)