### PR TITLE
Update built-in documentation for current method of implementation

### DIFF
--- a/src/modules/ReplyBotModule.cpp
+++ b/src/modules/ReplyBotModule.cpp
@@ -9,8 +9,8 @@
  * received the bot responds with a short status message that includes the hop count
  * (minimum number of relays), RSSI and SNR of the received packet.  To avoid spamming
  * the network it enforces a per‑sender cooldown between responses.  By default the
- * module is enabled; define MESHTASTIC_EXCLUDE_REPLYBOT at build time to exclude it
- * entirely.  See the official firmware documentation for guidance on adding modules.
+ * module is disabled. See the official firmware documentation for guidance on adding modules.
+ * To enable this module, set `#undef MESHTASTIC_EXCLUDE_REPLYBOT` in your variant.h file.
  */
 
 #include "Channels.h"


### PR DESCRIPTION
We changed this to be default disabled, but the documentation specified it was enabled. This PR fixes this.