### PR TITLE
Round telemetry precision

### DIFF
--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -10,6 +10,7 @@
 #include "PowerFSM.h"
 #include "RTC.h"
 #include "Router.h"
+#include "TelemetryPrecision.h"
 #include "UnitConversions.h"
 #include "graphics/ScreenFonts.h"
 #include "graphics/SharedUIDisplay.h"
@@ -295,6 +296,10 @@ bool AirQualityTelemetryModule::getAirQualityTelemetry(meshtastic_Telemetry *m)
         sensor_get = sensor->getMetrics(m);
         valid = valid || sensor_get;
         hasSensor = true;
+    }
+
+    if (valid) {
+        TelemetryPrecision::applyAirQualityMetrics(m->variant.air_quality_metrics);
     }
 
     return valid && hasSensor;

--- a/src/modules/Telemetry/DeviceTelemetry.cpp
+++ b/src/modules/Telemetry/DeviceTelemetry.cpp
@@ -6,6 +6,7 @@
 #include "PowerFSM.h"
 #include "RTC.h"
 #include "RadioLibInterface.h"
+#include "TelemetryPrecision.h"
 #include "Router.h"
 #include "configuration.h"
 #include "main.h"
@@ -103,6 +104,8 @@ meshtastic_Telemetry DeviceTelemetryModule::getDeviceTelemetry()
     t.variant.device_metrics.voltage = powerStatus->getBatteryVoltageMv() / 1000.0;
     t.variant.device_metrics.uptime_seconds = getUptimeSeconds();
 
+    TelemetryPrecision::applyDeviceMetrics(t.variant.device_metrics);
+
     return t;
 }
 
@@ -140,6 +143,8 @@ meshtastic_Telemetry DeviceTelemetryModule::getLocalStatsTelemetry()
         telemetry.variant.local_stats.num_rx_dupe = router->rxDupe;
         telemetry.variant.local_stats.num_tx_relay_canceled = router->txRelayCanceled;
     }
+
+    TelemetryPrecision::applyLocalStats(telemetry.variant.local_stats);
 
     LOG_INFO("Sending local stats: uptime=%i, channel_utilization=%f, air_util_tx=%f, num_online_nodes=%i, num_total_nodes=%i",
              telemetry.variant.local_stats.uptime_seconds, telemetry.variant.local_stats.channel_utilization,

--- a/src/modules/Telemetry/EnvironmentTelemetry.cpp
+++ b/src/modules/Telemetry/EnvironmentTelemetry.cpp
@@ -10,6 +10,7 @@
 #include "PowerFSM.h"
 #include "RTC.h"
 #include "Router.h"
+#include "TelemetryPrecision.h"
 #include "UnitConversions.h"
 #include "buzz.h"
 #include "graphics/SharedUIDisplay.h"
@@ -571,6 +572,10 @@ bool EnvironmentTelemetryModule::getEnvironmentTelemetry(meshtastic_Telemetry *m
     valid = valid || get_metrics;
     hasSensor = true;
 #endif
+    if (valid) {
+        TelemetryPrecision::applyEnvironmentMetrics(m->variant.environment_metrics);
+    }
+
     return valid && hasSensor;
 }
 

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -10,6 +10,7 @@
 #include "PowerTelemetry.h"
 #include "RTC.h"
 #include "Router.h"
+#include "TelemetryPrecision.h"
 #include "graphics/SharedUIDisplay.h"
 #include "main.h"
 #include "power.h"
@@ -210,6 +211,10 @@ bool PowerTelemetryModule::getPowerTelemetry(meshtastic_Telemetry *m)
     if (max17048Sensor.hasSensor())
         valid = max17048Sensor.getMetrics(m);
 #endif
+
+    if (valid) {
+        TelemetryPrecision::applyPowerMetrics(m->variant.power_metrics);
+    }
 
     return valid;
 }

--- a/src/modules/Telemetry/TelemetryPrecision.h
+++ b/src/modules/Telemetry/TelemetryPrecision.h
@@ -1,0 +1,215 @@
+#pragma once
+
+#include <math.h>
+
+#include "mesh/generated/meshtastic/telemetry.pb.h"
+
+namespace TelemetryPrecision
+{
+constexpr uint8_t kDefaultDecimals = 2;
+constexpr uint8_t kVoltageDecimals = 3;
+constexpr uint8_t kPressureDecimals = 1;
+
+inline float roundTo(float value, uint8_t decimals)
+{
+    if (!isfinite(value)) {
+        return value;
+    }
+
+    float scale = 1.0f;
+    for (uint8_t i = 0; i < decimals; ++i) {
+        scale *= 10.0f;
+    }
+
+    return roundf(value * scale) / scale;
+}
+
+inline void applyDeviceMetrics(meshtastic_DeviceMetrics &metrics)
+{
+    if (metrics.has_voltage) {
+        metrics.voltage = roundTo(metrics.voltage, kVoltageDecimals);
+    }
+    if (metrics.has_channel_utilization) {
+        metrics.channel_utilization = roundTo(metrics.channel_utilization, kDefaultDecimals);
+    }
+    if (metrics.has_air_util_tx) {
+        metrics.air_util_tx = roundTo(metrics.air_util_tx, kDefaultDecimals);
+    }
+}
+
+inline void applyEnvironmentMetrics(meshtastic_EnvironmentMetrics &metrics)
+{
+    if (metrics.has_temperature) {
+        metrics.temperature = roundTo(metrics.temperature, kDefaultDecimals);
+    }
+    if (metrics.has_relative_humidity) {
+        metrics.relative_humidity = roundTo(metrics.relative_humidity, kDefaultDecimals);
+    }
+    if (metrics.has_barometric_pressure) {
+        metrics.barometric_pressure = roundTo(metrics.barometric_pressure, kPressureDecimals);
+    }
+    if (metrics.has_gas_resistance) {
+        metrics.gas_resistance = roundTo(metrics.gas_resistance, kDefaultDecimals);
+    }
+    if (metrics.has_voltage) {
+        metrics.voltage = roundTo(metrics.voltage, kVoltageDecimals);
+    }
+    if (metrics.has_current) {
+        metrics.current = roundTo(metrics.current, kDefaultDecimals);
+    }
+    if (metrics.has_distance) {
+        metrics.distance = roundTo(metrics.distance, kDefaultDecimals);
+    }
+    if (metrics.has_lux) {
+        metrics.lux = roundTo(metrics.lux, kDefaultDecimals);
+    }
+    if (metrics.has_white_lux) {
+        metrics.white_lux = roundTo(metrics.white_lux, kDefaultDecimals);
+    }
+    if (metrics.has_ir_lux) {
+        metrics.ir_lux = roundTo(metrics.ir_lux, kDefaultDecimals);
+    }
+    if (metrics.has_uv_lux) {
+        metrics.uv_lux = roundTo(metrics.uv_lux, kDefaultDecimals);
+    }
+    if (metrics.has_wind_speed) {
+        metrics.wind_speed = roundTo(metrics.wind_speed, kDefaultDecimals);
+    }
+    if (metrics.has_weight) {
+        metrics.weight = roundTo(metrics.weight, kDefaultDecimals);
+    }
+    if (metrics.has_wind_gust) {
+        metrics.wind_gust = roundTo(metrics.wind_gust, kDefaultDecimals);
+    }
+    if (metrics.has_wind_lull) {
+        metrics.wind_lull = roundTo(metrics.wind_lull, kDefaultDecimals);
+    }
+    if (metrics.has_radiation) {
+        metrics.radiation = roundTo(metrics.radiation, kDefaultDecimals);
+    }
+    if (metrics.has_rainfall_1h) {
+        metrics.rainfall_1h = roundTo(metrics.rainfall_1h, kDefaultDecimals);
+    }
+    if (metrics.has_rainfall_24h) {
+        metrics.rainfall_24h = roundTo(metrics.rainfall_24h, kDefaultDecimals);
+    }
+    if (metrics.has_soil_temperature) {
+        metrics.soil_temperature = roundTo(metrics.soil_temperature, kDefaultDecimals);
+    }
+}
+
+inline void applyPowerMetrics(meshtastic_PowerMetrics &metrics)
+{
+    if (metrics.has_ch1_voltage) {
+        metrics.ch1_voltage = roundTo(metrics.ch1_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch1_current) {
+        metrics.ch1_current = roundTo(metrics.ch1_current, kDefaultDecimals);
+    }
+    if (metrics.has_ch2_voltage) {
+        metrics.ch2_voltage = roundTo(metrics.ch2_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch2_current) {
+        metrics.ch2_current = roundTo(metrics.ch2_current, kDefaultDecimals);
+    }
+    if (metrics.has_ch3_voltage) {
+        metrics.ch3_voltage = roundTo(metrics.ch3_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch3_current) {
+        metrics.ch3_current = roundTo(metrics.ch3_current, kDefaultDecimals);
+    }
+    if (metrics.has_ch4_voltage) {
+        metrics.ch4_voltage = roundTo(metrics.ch4_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch4_current) {
+        metrics.ch4_current = roundTo(metrics.ch4_current, kDefaultDecimals);
+    }
+    if (metrics.has_ch5_voltage) {
+        metrics.ch5_voltage = roundTo(metrics.ch5_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch5_current) {
+        metrics.ch5_current = roundTo(metrics.ch5_current, kDefaultDecimals);
+    }
+    if (metrics.has_ch6_voltage) {
+        metrics.ch6_voltage = roundTo(metrics.ch6_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch6_current) {
+        metrics.ch6_current = roundTo(metrics.ch6_current, kDefaultDecimals);
+    }
+    if (metrics.has_ch7_voltage) {
+        metrics.ch7_voltage = roundTo(metrics.ch7_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch7_current) {
+        metrics.ch7_current = roundTo(metrics.ch7_current, kDefaultDecimals);
+    }
+    if (metrics.has_ch8_voltage) {
+        metrics.ch8_voltage = roundTo(metrics.ch8_voltage, kVoltageDecimals);
+    }
+    if (metrics.has_ch8_current) {
+        metrics.ch8_current = roundTo(metrics.ch8_current, kDefaultDecimals);
+    }
+}
+
+inline void applyAirQualityMetrics(meshtastic_AirQualityMetrics &metrics)
+{
+    if (metrics.has_co2_temperature) {
+        metrics.co2_temperature = roundTo(metrics.co2_temperature, kDefaultDecimals);
+    }
+    if (metrics.has_co2_humidity) {
+        metrics.co2_humidity = roundTo(metrics.co2_humidity, kDefaultDecimals);
+    }
+    if (metrics.has_form_formaldehyde) {
+        metrics.form_formaldehyde = roundTo(metrics.form_formaldehyde, kDefaultDecimals);
+    }
+    if (metrics.has_form_humidity) {
+        metrics.form_humidity = roundTo(metrics.form_humidity, kDefaultDecimals);
+    }
+    if (metrics.has_form_temperature) {
+        metrics.form_temperature = roundTo(metrics.form_temperature, kDefaultDecimals);
+    }
+    if (metrics.has_pm_temperature) {
+        metrics.pm_temperature = roundTo(metrics.pm_temperature, kDefaultDecimals);
+    }
+    if (metrics.has_pm_humidity) {
+        metrics.pm_humidity = roundTo(metrics.pm_humidity, kDefaultDecimals);
+    }
+    if (metrics.has_pm_voc_idx) {
+        metrics.pm_voc_idx = roundTo(metrics.pm_voc_idx, kDefaultDecimals);
+    }
+    if (metrics.has_pm_nox_idx) {
+        metrics.pm_nox_idx = roundTo(metrics.pm_nox_idx, kDefaultDecimals);
+    }
+    if (metrics.has_particles_tps) {
+        metrics.particles_tps = roundTo(metrics.particles_tps, kDefaultDecimals);
+    }
+}
+
+inline void applyLocalStats(meshtastic_LocalStats &stats)
+{
+    stats.channel_utilization = roundTo(stats.channel_utilization, kDefaultDecimals);
+    stats.air_util_tx = roundTo(stats.air_util_tx, kDefaultDecimals);
+}
+
+inline void applyTelemetry(meshtastic_Telemetry &telemetry)
+{
+    switch (telemetry.which_variant) {
+    case meshtastic_Telemetry_device_metrics_tag:
+        applyDeviceMetrics(telemetry.variant.device_metrics);
+        break;
+    case meshtastic_Telemetry_environment_metrics_tag:
+        applyEnvironmentMetrics(telemetry.variant.environment_metrics);
+        break;
+    case meshtastic_Telemetry_air_quality_metrics_tag:
+        applyAirQualityMetrics(telemetry.variant.air_quality_metrics);
+        break;
+    case meshtastic_Telemetry_power_metrics_tag:
+        applyPowerMetrics(telemetry.variant.power_metrics);
+        break;
+    case meshtastic_Telemetry_local_stats_tag:
+        applyLocalStats(telemetry.variant.local_stats);
+        break;
+    default:
+        break;
+    }
+}
+} // namespace TelemetryPrecision

--- a/src/serialization/MeshPacketSerializer.cpp
+++ b/src/serialization/MeshPacketSerializer.cpp
@@ -5,6 +5,7 @@
 #include "mesh/generated/meshtastic/mqtt.pb.h"
 #include "mesh/generated/meshtastic/telemetry.pb.h"
 #include "modules/RoutingModule.h"
+#include "modules/Telemetry/TelemetryPrecision.h"
 #include <DebugConfiguration.h>
 #include <mesh-pb-constants.h>
 #if defined(ARCH_ESP32)
@@ -60,6 +61,7 @@ std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp,
             memset(&scratch, 0, sizeof(scratch));
             if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_Telemetry_msg, &scratch)) {
                 decoded = &scratch;
+                TelemetryPrecision::applyTelemetry(*decoded);
                 if (decoded->which_variant == meshtastic_Telemetry_device_metrics_tag) {
                     // If battery is present, encode the battery level value
                     // TODO - Add a condition to send a code for a non-present value

--- a/test/test_meshpacket_serializer/ports/test_telemetry.cpp
+++ b/test/test_meshpacket_serializer/ports/test_telemetry.cpp
@@ -8,11 +8,11 @@ static size_t encode_telemetry_device_metrics(uint8_t *buffer, size_t buffer_siz
     telemetry.which_variant = meshtastic_Telemetry_device_metrics_tag;
     telemetry.variant.device_metrics.battery_level = 85;
     telemetry.variant.device_metrics.has_battery_level = true;
-    telemetry.variant.device_metrics.voltage = 3.72f;
+    telemetry.variant.device_metrics.voltage = 3.72654f;
     telemetry.variant.device_metrics.has_voltage = true;
-    telemetry.variant.device_metrics.channel_utilization = 15.56f;
+    telemetry.variant.device_metrics.channel_utilization = 15.56789f;
     telemetry.variant.device_metrics.has_channel_utilization = true;
-    telemetry.variant.device_metrics.air_util_tx = 8.23f;
+    telemetry.variant.device_metrics.air_util_tx = 8.23456f;
     telemetry.variant.device_metrics.has_air_util_tx = true;
     telemetry.variant.device_metrics.uptime_seconds = 12345;
     telemetry.variant.device_metrics.has_uptime_seconds = true;
@@ -46,9 +46,9 @@ static size_t encode_telemetry_environment_metrics_all_fields(uint8_t *buffer, s
     telemetry.which_variant = meshtastic_Telemetry_environment_metrics_tag;
 
     // Basic environment metrics
-    telemetry.variant.environment_metrics.temperature = 23.56f;
+    telemetry.variant.environment_metrics.temperature = 23.5678f;
     telemetry.variant.environment_metrics.has_temperature = true;
-    telemetry.variant.environment_metrics.relative_humidity = 65.43f;
+    telemetry.variant.environment_metrics.relative_humidity = 65.4367f;
     telemetry.variant.environment_metrics.has_relative_humidity = true;
     telemetry.variant.environment_metrics.barometric_pressure = 1013.27f;
     telemetry.variant.environment_metrics.has_barometric_pressure = true;
@@ -125,9 +125,9 @@ static size_t encode_telemetry_environment_metrics(uint8_t *buffer, size_t buffe
     telemetry.which_variant = meshtastic_Telemetry_environment_metrics_tag;
 
     // Basic environment metrics
-    telemetry.variant.environment_metrics.temperature = 23.56f;
+    telemetry.variant.environment_metrics.temperature = 23.5678f;
     telemetry.variant.environment_metrics.has_temperature = true;
-    telemetry.variant.environment_metrics.relative_humidity = 65.43f;
+    telemetry.variant.environment_metrics.relative_humidity = 65.4367f;
     telemetry.variant.environment_metrics.has_relative_humidity = true;
     telemetry.variant.environment_metrics.barometric_pressure = 1013.27f;
     telemetry.variant.environment_metrics.has_barometric_pressure = true;
@@ -225,10 +225,13 @@ void test_telemetry_device_metrics_serialization()
     TEST_ASSERT_EQUAL(85, (int)payload["battery_level"]->AsNumber());
 
     TEST_ASSERT_TRUE(payload.find("voltage") != payload.end());
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 3.72f, payload["voltage"]->AsNumber());
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 3.727f, payload["voltage"]->AsNumber());
 
     TEST_ASSERT_TRUE(payload.find("channel_utilization") != payload.end());
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 15.56f, payload["channel_utilization"]->AsNumber());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 15.57f, payload["channel_utilization"]->AsNumber());
+
+    TEST_ASSERT_TRUE(payload.find("air_util_tx") != payload.end());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 8.23f, payload["air_util_tx"]->AsNumber());
 
     TEST_ASSERT_TRUE(payload.find("uptime_seconds") != payload.end());
     TEST_ASSERT_EQUAL(12345, (int)payload["uptime_seconds"]->AsNumber());
@@ -264,10 +267,10 @@ void test_telemetry_environment_metrics_serialization()
 
     // Test key fields that should be present in the serializer
     TEST_ASSERT_TRUE(payload.find("temperature") != payload.end());
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 23.56f, payload["temperature"]->AsNumber());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 23.57f, payload["temperature"]->AsNumber());
 
     TEST_ASSERT_TRUE(payload.find("relative_humidity") != payload.end());
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 65.43f, payload["relative_humidity"]->AsNumber());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 65.44f, payload["relative_humidity"]->AsNumber());
 
     TEST_ASSERT_TRUE(payload.find("distance") != payload.end());
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 150.29f, payload["distance"]->AsNumber());
@@ -403,11 +406,11 @@ void test_telemetry_environment_metrics_complete_coverage()
 
     // Basic environment (3 fields)
     TEST_ASSERT_TRUE(payload.find("temperature") != payload.end());
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 23.56f, payload["temperature"]->AsNumber());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 23.57f, payload["temperature"]->AsNumber());
     TEST_ASSERT_TRUE(payload.find("relative_humidity") != payload.end());
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 65.43f, payload["relative_humidity"]->AsNumber());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 65.44f, payload["relative_humidity"]->AsNumber());
     TEST_ASSERT_TRUE(payload.find("barometric_pressure") != payload.end());
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 1013.27f, payload["barometric_pressure"]->AsNumber());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 1013.3f, payload["barometric_pressure"]->AsNumber());
 
     // Gas and air quality (2 fields)
     TEST_ASSERT_TRUE(payload.find("gas_resistance") != payload.end());


### PR DESCRIPTION
## Summary
- round telemetry float values to fixed precision before send/serialize
- add shared telemetry precision helper
- update telemetry serializer tests for rounded values

## Testing
- pio test -e native -f test_meshpacket_serializer (fails: pio not installed)

Co-Authored-By: Warp <agent@warp.dev>