### PR TITLE
Add missing openocd_target to custom nrf52 boards

### DIFF
--- a/boards/me25ls01-4y10td.json
+++ b/boards/me25ls01-4y10td.json
@@ -32,7 +32,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "Minesemi ME25LS01",

--- a/boards/meshlink.json
+++ b/boards/meshlink.json
@@ -33,7 +33,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "MeshLink",

--- a/boards/minimesh_lite.json
+++ b/boards/minimesh_lite.json
@@ -31,7 +31,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "Minimesh Lite",

--- a/boards/ms24sf1.json
+++ b/boards/ms24sf1.json
@@ -32,7 +32,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "MINEWSEMI_MS24SF1_SX1262",

--- a/boards/nano-g2-ultra.json
+++ b/boards/nano-g2-ultra.json
@@ -32,7 +32,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "BQ nRF52840",

--- a/boards/promicro-nrf52840.json
+++ b/boards/promicro-nrf52840.json
@@ -33,7 +33,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "ProMicro compatible nRF52840",

--- a/boards/tracker-t1000-e.json
+++ b/boards/tracker-t1000-e.json
@@ -33,7 +33,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "Seeed T1000-E",

--- a/boards/wio-sdk-wm1110.json
+++ b/boards/wio-sdk-wm1110.json
@@ -25,7 +25,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino", "freertos"],
   "name": "Seeed WIO WM1110",

--- a/boards/wio-t1000-s.json
+++ b/boards/wio-t1000-s.json
@@ -32,7 +32,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "Seeed WIO WM1110",

--- a/boards/wio-tracker-wm1110.json
+++ b/boards/wio-tracker-wm1110.json
@@ -32,7 +32,8 @@
   "connectivity": ["bluetooth"],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
   },
   "frameworks": ["arduino"],
   "name": "Seeed WIO WM1110",


### PR DESCRIPTION
This stops platformio complaining about `Missing target configuration for me25ls01-4y10td` etc when trying to flash with nrfutil. No code changes.