### PR TITLE
Implement optional AES-CCM support for channels

### DIFF
--- a/src/mesh/Channels.cpp
+++ b/src/mesh/Channels.cpp
@@ -460,3 +460,14 @@ int16_t Channels::setActiveByIndex(ChannelIndex channelIndex)
 {
     return setCrypto(channelIndex);
 }
+
+bool Channels::isAeadEnabled(ChannelIndex chIndex)
+{
+#if !(MESHTASTIC_EXCLUDE_PKI)
+    meshtastic_Channel &ch = getByIndex(chIndex);
+    return ch.has_settings && ch.settings.aead_enabled;
+#else
+    (void)chIndex;
+    return false;
+#endif
+}

--- a/src/mesh/Channels.h
+++ b/src/mesh/Channels.h
@@ -98,6 +98,10 @@ class Channels
 
     int16_t getHash(ChannelIndex i) { return hashes[i]; }
 
+    /** Returns true if the specified channel has AEAD (AES-CCM) encryption enabled.
+     * Always returns false when PKI is excluded from the build. */
+    bool isAeadEnabled(ChannelIndex chIndex);
+
   private:
     /** Given a channel index, change to use the crypto key specified by that index
      *

--- a/src/mesh/CryptoEngine.h
+++ b/src/mesh/CryptoEngine.h
@@ -71,6 +71,26 @@ class CryptoEngine
     virtual void encryptPacket(uint32_t fromNode, uint64_t packetId, size_t numBytes, uint8_t *bytes);
     virtual void decrypt(uint32_t fromNode, uint64_t packetId, size_t numBytes, uint8_t *bytes);
     virtual void encryptAESCtr(CryptoKey key, uint8_t *nonce, size_t numBytes, uint8_t *bytes);
+
+#if !(MESHTASTIC_EXCLUDE_PKI)
+    /** Bytes appended by AES-CCM authenticated encryption on channel packets (8-byte tag). */
+#define MESHTASTIC_CHANNEL_AEAD_OVERHEAD 8
+
+    /**
+     * Encrypt a channel packet with AES-CCM (authenticated encryption).
+     * Writes ciphertext to bytesOut and appends an 8-byte auth tag.
+     * @return true on success.
+     */
+    bool encryptPacketAead(uint32_t fromNode, uint64_t packetId, size_t numBytes, const uint8_t *bytesIn, uint8_t *bytesOut);
+
+    /**
+     * Decrypt a channel packet with AES-CCM (authenticated decryption).
+     * Reads ciphertext+tag from bytesIn, writes plaintext to bytesOut.
+     * @return plaintext size on success, 0 on authentication failure.
+     */
+    size_t decryptPacketAead(uint32_t fromNode, uint64_t packetId, size_t rawSize, const uint8_t *bytesIn, uint8_t *bytesOut);
+#endif
+
 #ifndef PIO_UNIT_TESTING
   protected:
 #endif

--- a/src/mesh/generated/meshtastic/channel.pb.h
+++ b/src/mesh/generated/meshtastic/channel.pb.h
@@ -97,6 +97,9 @@ typedef struct _meshtastic_ChannelSettings {
     /* Per-channel module settings. */
     bool has_module_settings;
     meshtastic_ModuleSettings module_settings;
+    /* If true, packets on this channel use AES-CCM authenticated encryption
+     instead of plain AES-CTR. All nodes on the channel must agree on this setting. */
+    bool aead_enabled;
 } meshtastic_ChannelSettings;
 
 /* A pair of a channel number, mode and the (sharable) settings for that channel */
@@ -128,10 +131,10 @@ extern "C" {
 
 
 /* Initializer values for message structs */
-#define meshtastic_ChannelSettings_init_default  {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_default}
+#define meshtastic_ChannelSettings_init_default  {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_default, 0}
 #define meshtastic_ModuleSettings_init_default   {0, 0}
 #define meshtastic_Channel_init_default          {0, false, meshtastic_ChannelSettings_init_default, _meshtastic_Channel_Role_MIN}
-#define meshtastic_ChannelSettings_init_zero     {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_zero}
+#define meshtastic_ChannelSettings_init_zero     {0, {0, {0}}, "", 0, 0, 0, false, meshtastic_ModuleSettings_init_zero, 0}
 #define meshtastic_ModuleSettings_init_zero      {0, 0}
 #define meshtastic_Channel_init_zero             {0, false, meshtastic_ChannelSettings_init_zero, _meshtastic_Channel_Role_MIN}
 
@@ -145,6 +148,7 @@ extern "C" {
 #define meshtastic_ChannelSettings_uplink_enabled_tag 5
 #define meshtastic_ChannelSettings_downlink_enabled_tag 6
 #define meshtastic_ChannelSettings_module_settings_tag 7
+#define meshtastic_ChannelSettings_aead_enabled_tag 8
 #define meshtastic_Channel_index_tag             1
 #define meshtastic_Channel_settings_tag          2
 #define meshtastic_Channel_role_tag              3
@@ -157,7 +161,8 @@ X(a, STATIC,   SINGULAR, STRING,   name,              3) \
 X(a, STATIC,   SINGULAR, FIXED32,  id,                4) \
 X(a, STATIC,   SINGULAR, BOOL,     uplink_enabled,    5) \
 X(a, STATIC,   SINGULAR, BOOL,     downlink_enabled,   6) \
-X(a, STATIC,   OPTIONAL, MESSAGE,  module_settings,   7)
+X(a, STATIC,   OPTIONAL, MESSAGE,  module_settings,   7) \
+X(a, STATIC,   SINGULAR, BOOL,     aead_enabled,      8)
 #define meshtastic_ChannelSettings_CALLBACK NULL
 #define meshtastic_ChannelSettings_DEFAULT NULL
 #define meshtastic_ChannelSettings_module_settings_MSGTYPE meshtastic_ModuleSettings
@@ -187,8 +192,8 @@ extern const pb_msgdesc_t meshtastic_Channel_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_CHANNEL_PB_H_MAX_SIZE meshtastic_Channel_size
-#define meshtastic_ChannelSettings_size          72
-#define meshtastic_Channel_size                  87
+#define meshtastic_ChannelSettings_size          74
+#define meshtastic_Channel_size                  89
 #define meshtastic_ModuleSettings_size           8
 
 #ifdef __cplusplus


### PR DESCRIPTION
Currently, messages to channels are only encrypted using AES-CTR. This ensures nobody can read your messages. However, people can still modify your messages because there is no way of knowing if the content being sent was what was originally sent. Let me give an example with rot13 encryption. In rot 13, 'abc' transforms to 'nop', but there is no way of knowing an attacker has maybe modified the original message to be adc, which would still perfectly well translate to 'nqp'. As long as the protobuf parsing goes well, we do not know if messages are modified. There was already AES-CCM support for private messaging, it adds a tag to the message that makes sure messages aren't altered without knowing the key.

This commit adds support for AES-CCM at the channel level, it will need everyone in the channel to agree on using it though, so it's disabled by default. This change will need app level support before being practically used by users.

supersedes #9602

Details:

- Reuses existing AES-CCM (aes_ccm_ae/aes_ccm_ad) — no new cipher added, same one used for private messaging                                                                                
- 8-byte authentication tag — matches DM tag size                        
- Per-channel runtime boolean (aead_enabled in ChannelSettings) — no recompilation needed, configurable per channel from the app
- No silent fallback — returns TOO_LARGE error if payload + 8-byte tag exceeds LoRa max; AEAD channels reject packets that fail tag verification
- backwards compatible — disabled by default, nothing changes if you do not enable this
- max payload reduces from 239 to 231 bytes when enabled on a channel

What needs to happen upstream

- Proto file in meshtastic/protobufs needs the matching bool aead_enabled = 8 field added to ChannelSettings
- Client apps need UI support to toggle the setting per channel
