### PR TITLE
Log `rxBad` PacketHeaders with more info (`id`, `relay_node`) like `printPacket`

### DIFF
--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -453,8 +453,11 @@ void RadioLibInterface::handleReceiveInterrupt()
     }
 #endif
     if (state != RADIOLIB_ERR_NONE) {
-        LOG_ERROR("Ignore received packet due to error=%d (maybe to=0x%08x, from=0x%08x, flags=0x%02x)", state,
-                  radioBuffer.header.to, radioBuffer.header.from, radioBuffer.header.flags);
+        // Log PacketHeader similar to RadioInterface::printPacket so we can try to match RX errors to other packets in the logs.
+        LOG_ERROR("Ignore received packet due to error=%d (maybe id=0x%08x fr=0x%08x to=0x%08x flags=0x%02x rxSNR=%g rxRSSI=%i "
+                  "nextHop=0x%x relay=0x%x)",
+                  state, radioBuffer.header.id, radioBuffer.header.from, radioBuffer.header.to, radioBuffer.header.flags,
+                  iface->getSNR(), lround(iface->getRSSI()), radioBuffer.header.next_hop, radioBuffer.header.relay_node);
         rxBad++;
 
         airTime->logAirtime(RX_ALL_LOG, rxMsec);


### PR DESCRIPTION
Logging changes only.

I'm trying to track down why I'm seeing a lot of `Ignore received packet due to error=-7` error messages, and hopefully this info will make it easier to see what's going on, if they're from one specific relay, etc.

The goal is to try to match RX errors (specifically `error=-7`) to other packets in the logs. This PR changes the `rxBad` `Ignore received packet due to error` line to be much more like `RadioInterface::printPacket`.

Specifically, having the (possibly corrupted) packet `id` makes it easy to see if we're seeing a (corrupted) retransmitted version of a packet we've already seen (or soon will), and the `relay` makes it possible to figure out who is retransmitting.

> Error -7:
> https://radiolib-org.github.io/status_decoder/decode.html#statusValue=-7
> RADIOLIB_ERR_CRC_MISMATCH
> The calculated and expected CRCs of received packet do not match. This means that the packet was damaged during transmission and should be sent again.

**BEFORE THIS PR:**

> ERROR | 22:38:22 518 [RadioIf] Ignore received packet due to error=-7 (maybe to=0xe51c0eda, from=0x04c5aa94, flags=0xee)

**AFTER THIS PR:**

> ERROR | 22:38:22 518 [RadioIf] Ignore received packet due to error=-7 (maybe id=0xbcd1d4d0 fr=0x04c5aa94 to=0xe51c0eda flags=0xee rxSNR=-19.75 rxRSSI=-109 nextHop=0xa3 relay=0x70)

Tested and working on Heltec V4.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V4