### PR TITLE
fix: zero entire public key array instead of only first byte

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1772,7 +1772,7 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
         info->has_device_metrics = false;
         info->has_position = false;
         info->user.public_key.size = 0;
-        info->user.public_key.bytes[0] = 0;
+        memset(info->user.public_key.bytes, 0, sizeof(info->user.public_key.bytes));
     } else {
         /* Clients are sending add_contact before every text message DM (because clients may hold a larger node database with
          * public keys than the radio holds). However, we don't want to update last_heard just because we sent someone a DM!

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -391,7 +391,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
             node->has_device_metrics = false;
             node->has_position = false;
             node->user.public_key.size = 0;
-            node->user.public_key.bytes[0] = 0;
+            memset(node->user.public_key.bytes, 0, sizeof(node->user.public_key.bytes));
             saveChanges(SEGMENT_NODEDATABASE, false);
         }
         break;

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -148,7 +148,7 @@ meshtastic_MeshPacket *NodeInfoModule::allocReply()
 
         // Strip the public key if the user is licensed
         if (u.is_licensed && u.public_key.size > 0) {
-            u.public_key.bytes[0] = 0;
+            memset(u.public_key.bytes, 0, sizeof(u.public_key.bytes));
             u.public_key.size = 0;
         }
 


### PR DESCRIPTION
Zero all bytes using memcp, not just the first.