### PR TITLE
Add phone API fanout for multiple clients

### DIFF
--- a/src/graphics/SharedUIDisplay.cpp
+++ b/src/graphics/SharedUIDisplay.cpp
@@ -427,7 +427,7 @@ const int *getTextPositions(OLEDDisplay *display)
 // *************************
 void drawCommonFooter(OLEDDisplay *display, int16_t x, int16_t y)
 {
-    if (!isAPIConnected(service->api_state))
+    if (!isAnyAPIConnected(service->api_state_mask))
         return;
 
     const int scale = (currentResolution == ScreenResolution::High) ? 2 : 1;

--- a/src/graphics/SharedUIDisplay.h
+++ b/src/graphics/SharedUIDisplay.h
@@ -77,4 +77,9 @@ static inline bool isAPIConnected(uint8_t state)
     return state < sizeof(connectedStates) ? connectedStates[state] : false;
 }
 
+static inline bool isAnyAPIConnected(uint32_t mask)
+{
+    return mask != 0;
+}
+
 } // namespace graphics

--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -681,18 +681,31 @@ void drawSystemScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x
         }
         snprintf(api_state, sizeof(api_state), "No %ss Connected", clientWord);
 
-        if (service->api_state == service->STATE_BLE) {
-            snprintf(api_state, sizeof(api_state), "%s Connected (BLE)", clientWord);
-        } else if (service->api_state == service->STATE_WIFI) {
-            snprintf(api_state, sizeof(api_state), "%s Connected (WiFi)", clientWord);
-        } else if (service->api_state == service->STATE_SERIAL) {
-            snprintf(api_state, sizeof(api_state), "%s Connected (Serial)", clientWord);
-        } else if (service->api_state == service->STATE_PACKET) {
-            snprintf(api_state, sizeof(api_state), "%s Connected (Internal)", clientWord);
-        } else if (service->api_state == service->STATE_HTTP) {
-            snprintf(api_state, sizeof(api_state), "%s Connected (HTTP)", clientWord);
-        } else if (service->api_state == service->STATE_ETH) {
-            snprintf(api_state, sizeof(api_state), "%s Connected (Ethernet)", clientWord);
+        if (service->api_state_mask != 0) {
+            char activeApis[64] = "";
+            auto appendApi = [&activeApis](const char *name) {
+                if (activeApis[0] != '\0') {
+                    strlcat(activeApis, "+", sizeof(activeApis));
+                }
+                strlcat(activeApis, name, sizeof(activeApis));
+            };
+
+            if (service->api_state_mask & MeshService::apiStateBit(MeshService::STATE_BLE))
+                appendApi("BLE");
+            if (service->api_state_mask & MeshService::apiStateBit(MeshService::STATE_WIFI))
+                appendApi("WiFi");
+            if (service->api_state_mask & MeshService::apiStateBit(MeshService::STATE_SERIAL))
+                appendApi("Serial");
+            if (service->api_state_mask & MeshService::apiStateBit(MeshService::STATE_PACKET))
+                appendApi("Internal");
+            if (service->api_state_mask & MeshService::apiStateBit(MeshService::STATE_HTTP))
+                appendApi("HTTP");
+            if (service->api_state_mask & MeshService::apiStateBit(MeshService::STATE_ETH))
+                appendApi("Ethernet");
+
+            if (activeApis[0] != '\0') {
+                snprintf(api_state, sizeof(api_state), "%s Connected (%s)", clientWord, activeApis);
+            }
         }
         if (api_state[0] != '\0') {
             display->drawString((SCREEN_WIDTH - display->getStringWidth(api_state)) / 2, getTextPositions(display)[line++],

--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -393,7 +393,8 @@ void UIRenderer::drawNodeInfo(OLEDDisplay *display, OLEDDisplayUiState *state, i
 
     // Add extra spacing on the left if we have an API connection to account for the common footer icons
     const char *leftSideSpacing =
-        graphics::isAPIConnected(service->api_state) ? (currentResolution == ScreenResolution::High ? "     " : "   ") : " ";
+        graphics::isAnyAPIConnected(service->api_state_mask) ? (currentResolution == ScreenResolution::High ? "     " : "   ")
+                                                              : " ";
 
     // --- Build the Signal/Hops line ---
     // Only show signal if we have valid SNR

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -9,11 +9,8 @@
 #include "MeshRadio.h"
 #include "MeshTypes.h"
 #include "Observer.h"
-#ifdef ARCH_PORTDUINO
-#include "PointerQueue.h"
-#else
+#include "concurrency/Lock.h"
 #include "StaticPointerQueue.h"
-#endif
 #include "mesh-pb-constants.h"
 #if defined(ARCH_PORTDUINO)
 #include "../platform/portduino/SimRadio.h"
@@ -28,56 +25,18 @@ extern Allocator<meshtastic_QueueStatus> &queueStatusPool;
 extern Allocator<meshtastic_MqttClientProxyMessage> &mqttClientProxyMessagePool;
 extern Allocator<meshtastic_ClientNotification> &clientNotificationPool;
 
+class PhoneAPI;
+
+#ifndef MAX_PHONE_API_CLIENTS
+#define MAX_PHONE_API_CLIENTS 8
+#endif
+
 /**
  * Top level app for this service.  keeps the mesh, the radio config and the queue of received packets.
  *
  */
 class MeshService
 {
-#if HAS_GPS
-    CallbackObserver<MeshService, const meshtastic::GPSStatus *> gpsObserver =
-        CallbackObserver<MeshService, const meshtastic::GPSStatus *>(this, &MeshService::onGPSChanged);
-#endif
-    /// received packets waiting for the phone to process them
-    /// FIXME, change to a DropOldestQueue and keep a count of the number of dropped packets to ensure
-    /// we never hang because android hasn't been there in a while
-    /// FIXME - save this to flash on deep sleep
-#ifdef ARCH_PORTDUINO
-    PointerQueue<meshtastic_MeshPacket> toPhoneQueue;
-#else
-    StaticPointerQueue<meshtastic_MeshPacket, MAX_RX_TOPHONE> toPhoneQueue;
-#endif
-
-    // keep list of QueueStatus packets to be send to the phone
-#ifdef ARCH_PORTDUINO
-    PointerQueue<meshtastic_QueueStatus> toPhoneQueueStatusQueue;
-#else
-    StaticPointerQueue<meshtastic_QueueStatus, MAX_RX_QUEUESTATUS_TOPHONE> toPhoneQueueStatusQueue;
-#endif
-
-    // keep list of MqttClientProxyMessages to be send to the client for delivery
-#ifdef ARCH_PORTDUINO
-    PointerQueue<meshtastic_MqttClientProxyMessage> toPhoneMqttProxyQueue;
-#else
-    StaticPointerQueue<meshtastic_MqttClientProxyMessage, MAX_RX_MQTTPROXY_TOPHONE> toPhoneMqttProxyQueue;
-#endif
-
-    // keep list of ClientNotifications to be send to the client (phone)
-#ifdef ARCH_PORTDUINO
-    PointerQueue<meshtastic_ClientNotification> toPhoneClientNotificationQueue;
-#else
-    StaticPointerQueue<meshtastic_ClientNotification, MAX_RX_NOTIFICATION_TOPHONE> toPhoneClientNotificationQueue;
-#endif
-
-    // This holds the last QueueStatus send
-    meshtastic_QueueStatus lastQueueStatus;
-
-    /// The current nonce for the newest packet which has been queued for the phone
-    uint32_t fromNum = 0;
-
-    /// Updated in loop() to detect when fromNum changes
-    uint32_t oldFromNum = 0;
-
   public:
     enum APIState {
         STATE_DISCONNECTED, // Initial state, no API is connected
@@ -89,7 +48,95 @@ class MeshService
         STATE_ETH
     };
 
+    static constexpr uint32_t apiStateBit(APIState s)
+    {
+        return (s == STATE_DISCONNECTED) ? 0u : (1u << (static_cast<uint32_t>(s) - 1u));
+    }
+
+  private:
+#if HAS_GPS
+    CallbackObserver<MeshService, const meshtastic::GPSStatus *> gpsObserver =
+        CallbackObserver<MeshService, const meshtastic::GPSStatus *>(this, &MeshService::onGPSChanged);
+#endif
+
+    struct PacketFanoutEntry {
+        meshtastic_MeshPacket *payload = nullptr;
+        uint8_t refcount = 0;
+    };
+
+    struct QueueStatusFanoutEntry {
+        meshtastic_QueueStatus *payload = nullptr;
+        uint8_t refcount = 0;
+    };
+
+    struct MqttProxyFanoutEntry {
+        meshtastic_MqttClientProxyMessage *payload = nullptr;
+        uint8_t refcount = 0;
+    };
+
+    struct ClientNotificationFanoutEntry {
+        meshtastic_ClientNotification *payload = nullptr;
+        uint8_t refcount = 0;
+    };
+
+    struct PhoneClientSlot {
+        PhoneAPI *client = nullptr;
+        APIState state = STATE_DISCONNECTED;
+        bool active = false;
+
+        StaticPointerQueue<PacketFanoutEntry, MAX_RX_TOPHONE> packetQueue;
+        StaticPointerQueue<QueueStatusFanoutEntry, MAX_RX_QUEUESTATUS_TOPHONE> queueStatusQueue;
+        StaticPointerQueue<MqttProxyFanoutEntry, MAX_RX_MQTTPROXY_TOPHONE> mqttProxyQueue;
+        StaticPointerQueue<ClientNotificationFanoutEntry, MAX_RX_NOTIFICATION_TOPHONE> clientNotificationQueue;
+
+        PacketFanoutEntry *packetInflight = nullptr;
+        QueueStatusFanoutEntry *queueStatusInflight = nullptr;
+        MqttProxyFanoutEntry *mqttProxyInflight = nullptr;
+        ClientNotificationFanoutEntry *clientNotificationInflight = nullptr;
+    };
+
+    MemoryPool<PacketFanoutEntry, MAX_PHONE_API_CLIENTS * MAX_RX_TOPHONE> packetFanoutPool;
+    MemoryPool<QueueStatusFanoutEntry, MAX_PHONE_API_CLIENTS * MAX_RX_QUEUESTATUS_TOPHONE> queueStatusFanoutPool;
+    MemoryPool<MqttProxyFanoutEntry, MAX_PHONE_API_CLIENTS * MAX_RX_MQTTPROXY_TOPHONE> mqttProxyFanoutPool;
+    MemoryPool<ClientNotificationFanoutEntry, MAX_PHONE_API_CLIENTS * MAX_RX_NOTIFICATION_TOPHONE>
+        clientNotificationFanoutPool;
+
+    PhoneClientSlot phoneClients[MAX_PHONE_API_CLIENTS];
+
+    /// Protects fanout client registry and all per-client fanout queues
+    concurrency::Lock phoneClientsLock;
+
+    /// Per APIState connected client counts
+    uint8_t apiStateCounts[STATE_ETH + 1] = {0};
+
+    // This holds the last QueueStatus send
+    meshtastic_QueueStatus lastQueueStatus;
+
+    /// The current nonce for the newest packet which has been queued for the phone
+    uint32_t fromNum = 0;
+
+    /// Updated in loop() to detect when fromNum changes
+    uint32_t oldFromNum = 0;
+
+    int findClientSlotByPtrLocked(const PhoneAPI *client) const;
+    int findClientSlotByPtrLocked(const PhoneAPI *client);
+    int findFreeClientSlotLocked() const;
+    void clearClientSlotLocked(PhoneClientSlot &slot);
+    void updateApiStateLocked(APIState preferred = STATE_DISCONNECTED);
+
+    void releasePacketFanoutEntryLocked(PacketFanoutEntry *entry);
+    void releaseQueueStatusFanoutEntryLocked(QueueStatusFanoutEntry *entry);
+    void releaseMqttProxyFanoutEntryLocked(MqttProxyFanoutEntry *entry);
+    void releaseClientNotificationFanoutEntryLocked(ClientNotificationFanoutEntry *entry);
+
+    bool enqueuePacketFanoutLocked(meshtastic_MeshPacket *p);
+    bool enqueueQueueStatusFanoutLocked(meshtastic_QueueStatus *qs);
+    bool enqueueMqttProxyFanoutLocked(meshtastic_MqttClientProxyMessage *m);
+    bool enqueueClientNotificationFanoutLocked(meshtastic_ClientNotification *cn);
+
+  public:
     APIState api_state = STATE_DISCONNECTED;
+    uint32_t api_state_mask = 0;
 
     static bool isTextPayload(const meshtastic_MeshPacket *p)
     {
@@ -113,21 +160,28 @@ class MeshService
     /// Do idle processing (mostly processing messages which have been queued from the radio)
     void loop();
 
-    /// Return the next packet destined to the phone.  FIXME, somehow use fromNum to allow the phone to retry the
-    /// last few packets if needs to.
-    meshtastic_MeshPacket *getForPhone() { return toPhoneQueue.dequeuePtr(0); }
+    bool registerPhoneClient(PhoneAPI *client, APIState state);
+    void unregisterPhoneClient(PhoneAPI *client);
 
-    /// Allows the bluetooth handler to free packets after they have been sent
+    /// Return the next packet destined to the specified phone client.
+    meshtastic_MeshPacket *getForPhone(PhoneAPI *client);
+
+    /// Allows handlers to free packets after they have been sent
     void releaseToPool(meshtastic_MeshPacket *p) { packetPool.release(p); }
 
-    /// Return the next QueueStatus packet destined to the phone.
-    meshtastic_QueueStatus *getQueueStatusForPhone() { return toPhoneQueueStatusQueue.dequeuePtr(0); }
+    /// Return the next QueueStatus packet destined to the specified phone client.
+    meshtastic_QueueStatus *getQueueStatusForPhone(PhoneAPI *client);
 
-    /// Return the next MqttClientProxyMessage packet destined to the phone.
-    meshtastic_MqttClientProxyMessage *getMqttClientProxyMessageForPhone() { return toPhoneMqttProxyQueue.dequeuePtr(0); }
+    /// Return the next MqttClientProxyMessage packet destined to the specified phone client.
+    meshtastic_MqttClientProxyMessage *getMqttClientProxyMessageForPhone(PhoneAPI *client);
 
-    /// Return the next ClientNotification packet destined to the phone.
-    meshtastic_ClientNotification *getClientNotificationForPhone() { return toPhoneClientNotificationQueue.dequeuePtr(0); }
+    /// Return the next ClientNotification packet destined to the specified phone client.
+    meshtastic_ClientNotification *getClientNotificationForPhone(PhoneAPI *client);
+
+    void releaseToPoolForPhone(PhoneAPI *client, meshtastic_MeshPacket *p);
+    void releaseQueueStatusToPoolForPhone(PhoneAPI *client, meshtastic_QueueStatus *p);
+    void releaseMqttClientProxyMessageToPoolForPhone(PhoneAPI *client, meshtastic_MqttClientProxyMessage *p);
+    void releaseClientNotificationToPoolForPhone(PhoneAPI *client, meshtastic_ClientNotification *p);
 
     // search the queue for a request id and return the matching nodenum
     NodeNum getNodenumFromRequestId(uint32_t request_id);
@@ -172,13 +226,13 @@ class MeshService
     /// Pull the latest power and time info into my nodeinfo
     meshtastic_NodeInfoLite *refreshLocalMeshNode();
 
-    /// Send a packet to the phone
+    /// Send a packet to active phone clients
     void sendToPhone(meshtastic_MeshPacket *p);
 
-    /// Send an MQTT message to the phone for client proxying
+    /// Send an MQTT message to active phone clients for client proxying
     virtual void sendMqttMessageToClientProxy(meshtastic_MqttClientProxyMessage *m);
 
-    /// Send a ClientNotification to the phone
+    /// Send a ClientNotification to active phone clients
     virtual void sendClientNotification(meshtastic_ClientNotification *cn);
 
     /// Send an error response to the phone

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -50,24 +50,31 @@ void PhoneAPI::handleStartConfig()
 {
     // Must be before setting state (because state is how we know !connected)
     if (!isConnected()) {
+        const char *apiTypeName = "UNKNOWN";
         MeshService::APIState clientState = MeshService::STATE_DISCONNECTED;
         switch (api_type) {
         case TYPE_BLE:
+            apiTypeName = "BLE";
             clientState = MeshService::STATE_BLE;
             break;
         case TYPE_WIFI:
+            apiTypeName = "WiFi";
             clientState = MeshService::STATE_WIFI;
             break;
         case TYPE_SERIAL:
+            apiTypeName = "Serial";
             clientState = MeshService::STATE_SERIAL;
             break;
         case TYPE_PACKET:
+            apiTypeName = "Internal";
             clientState = MeshService::STATE_PACKET;
             break;
         case TYPE_HTTP:
+            apiTypeName = "HTTP";
             clientState = MeshService::STATE_HTTP;
             break;
         case TYPE_ETH:
+            apiTypeName = "Ethernet";
             clientState = MeshService::STATE_ETH;
             break;
         default:
@@ -75,7 +82,8 @@ void PhoneAPI::handleStartConfig()
         }
 
         if (!service->registerPhoneClient(this, clientState)) {
-            LOG_ERROR("Failed to register phone client for fanout");
+            LOG_ERROR("Failed to register phone client for fanout (api_type=%s), aborting config start", apiTypeName);
+            return;
         }
         onConnectionChanged(true);
         observe(&service->fromNumChanged);

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -50,6 +50,33 @@ void PhoneAPI::handleStartConfig()
 {
     // Must be before setting state (because state is how we know !connected)
     if (!isConnected()) {
+        MeshService::APIState clientState = MeshService::STATE_DISCONNECTED;
+        switch (api_type) {
+        case TYPE_BLE:
+            clientState = MeshService::STATE_BLE;
+            break;
+        case TYPE_WIFI:
+            clientState = MeshService::STATE_WIFI;
+            break;
+        case TYPE_SERIAL:
+            clientState = MeshService::STATE_SERIAL;
+            break;
+        case TYPE_PACKET:
+            clientState = MeshService::STATE_PACKET;
+            break;
+        case TYPE_HTTP:
+            clientState = MeshService::STATE_HTTP;
+            break;
+        case TYPE_ETH:
+            clientState = MeshService::STATE_ETH;
+            break;
+        default:
+            break;
+        }
+
+        if (!service->registerPhoneClient(this, clientState)) {
+            LOG_ERROR("Failed to register phone client for fanout");
+        }
         onConnectionChanged(true);
         observe(&service->fromNumChanged);
 #ifdef FSCom
@@ -87,18 +114,6 @@ void PhoneAPI::handleStartConfig()
 void PhoneAPI::close()
 {
     LOG_DEBUG("PhoneAPI::close()");
-    if (service->api_state == service->STATE_BLE && api_type == TYPE_BLE)
-        service->api_state = service->STATE_DISCONNECTED;
-    else if (service->api_state == service->STATE_WIFI && api_type == TYPE_WIFI)
-        service->api_state = service->STATE_DISCONNECTED;
-    else if (service->api_state == service->STATE_SERIAL && api_type == TYPE_SERIAL)
-        service->api_state = service->STATE_DISCONNECTED;
-    else if (service->api_state == service->STATE_PACKET && api_type == TYPE_PACKET)
-        service->api_state = service->STATE_DISCONNECTED;
-    else if (service->api_state == service->STATE_HTTP && api_type == TYPE_HTTP)
-        service->api_state = service->STATE_DISCONNECTED;
-    else if (service->api_state == service->STATE_ETH && api_type == TYPE_ETH)
-        service->api_state = service->STATE_DISCONNECTED;
 
     if (state != STATE_SEND_NOTHING) {
         state = STATE_SEND_NOTHING;
@@ -111,6 +126,7 @@ void PhoneAPI::close()
         releaseQueueStatusPhonePacket();
         releaseMqttClientProxyPhonePacket();
         releaseClientNotification();
+        service->unregisterPhoneClient(this);
         onConnectionChanged(false);
         fromRadioScratch = {};
         toRadioScratch = {};
@@ -127,6 +143,8 @@ void PhoneAPI::close()
         config_state = 0;
         pauseBluetoothLogging = false;
         heartbeatReceived = false;
+    } else {
+        service->unregisterPhoneClient(this);
     }
 }
 
@@ -590,19 +608,6 @@ void PhoneAPI::sendConfigComplete()
     fromRadioScratch.config_complete_id = config_nonce;
     config_nonce = 0;
     state = STATE_SEND_PACKETS;
-    if (api_type == TYPE_BLE) {
-        service->api_state = service->STATE_BLE;
-    } else if (api_type == TYPE_WIFI) {
-        service->api_state = service->STATE_WIFI;
-    } else if (api_type == TYPE_SERIAL) {
-        service->api_state = service->STATE_SERIAL;
-    } else if (api_type == TYPE_PACKET) {
-        service->api_state = service->STATE_PACKET;
-    } else if (api_type == TYPE_HTTP) {
-        service->api_state = service->STATE_HTTP;
-    } else if (api_type == TYPE_ETH) {
-        service->api_state = service->STATE_ETH;
-    }
 
     // Allow subclasses to know we've entered steady-state so they can lower power consumption
     onConfigComplete();
@@ -613,7 +618,7 @@ void PhoneAPI::sendConfigComplete()
 void PhoneAPI::releasePhonePacket()
 {
     if (packetForPhone) {
-        service->releaseToPool(packetForPhone); // we just copied the bytes, so don't need this buffer anymore
+        service->releaseToPoolForPhone(this, packetForPhone); // we just copied the bytes, so don't need this buffer anymore
         packetForPhone = NULL;
     }
 }
@@ -621,7 +626,7 @@ void PhoneAPI::releasePhonePacket()
 void PhoneAPI::releaseQueueStatusPhonePacket()
 {
     if (queueStatusPacketForPhone) {
-        service->releaseQueueStatusToPool(queueStatusPacketForPhone);
+        service->releaseQueueStatusToPoolForPhone(this, queueStatusPacketForPhone);
         queueStatusPacketForPhone = NULL;
     }
 }
@@ -656,7 +661,7 @@ void PhoneAPI::prefetchNodeInfos()
 void PhoneAPI::releaseMqttClientProxyPhonePacket()
 {
     if (mqttClientProxyMessageForPhone) {
-        service->releaseMqttClientProxyMessageToPool(mqttClientProxyMessageForPhone);
+        service->releaseMqttClientProxyMessageToPoolForPhone(this, mqttClientProxyMessageForPhone);
         mqttClientProxyMessageForPhone = NULL;
     }
 }
@@ -664,7 +669,7 @@ void PhoneAPI::releaseMqttClientProxyPhonePacket()
 void PhoneAPI::releaseClientNotification()
 {
     if (clientNotification) {
-        service->releaseClientNotificationToPool(clientNotification);
+        service->releaseClientNotificationToPoolForPhone(this, clientNotification);
         clientNotification = NULL;
     }
 }
@@ -701,11 +706,11 @@ bool PhoneAPI::available()
         return true;
     case STATE_SEND_PACKETS: {
         if (!queueStatusPacketForPhone)
-            queueStatusPacketForPhone = service->getQueueStatusForPhone();
+            queueStatusPacketForPhone = service->getQueueStatusForPhone(this);
         if (!mqttClientProxyMessageForPhone)
-            mqttClientProxyMessageForPhone = service->getMqttClientProxyMessageForPhone();
+            mqttClientProxyMessageForPhone = service->getMqttClientProxyMessageForPhone(this);
         if (!clientNotification)
-            clientNotification = service->getClientNotificationForPhone();
+            clientNotification = service->getClientNotificationForPhone(this);
         bool hasPacket = !!queueStatusPacketForPhone || !!mqttClientProxyMessageForPhone || !!clientNotification;
         if (hasPacket)
             return true;
@@ -728,7 +733,7 @@ bool PhoneAPI::available()
 #endif
 
         if (!packetForPhone)
-            packetForPhone = service->getForPhone();
+            packetForPhone = service->getForPhone(this);
         hasPacket = !!packetForPhone;
         return hasPacket;
     }

--- a/src/mesh/http/ContentHandler.cpp
+++ b/src/mesh/http/ContentHandler.cpp
@@ -146,6 +146,7 @@ void handleAPIv1FromRadio(HTTPRequest *req, HTTPResponse *res)
 {
     if (webServerThread)
         webServerThread->markActivity();
+    webAPI.markActivity();
 
     LOG_DEBUG("webAPI handleAPIv1FromRadio");
 
@@ -168,6 +169,7 @@ void handleAPIv1FromRadio(HTTPRequest *req, HTTPResponse *res)
     res->setHeader("X-Protobuf-Schema", "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
 
     if (req->getMethod() == "OPTIONS") {
+        webAPI.markActivity();
         res->setStatusCode(204); // Success with no content
         res->print("");
         return;
@@ -204,6 +206,7 @@ void handleAPIv1FromRadio(HTTPRequest *req, HTTPResponse *res)
 void handleAPIv1ToRadio(HTTPRequest *req, HTTPResponse *res)
 {
     LOG_DEBUG("webAPI handleAPIv1ToRadio");
+    webAPI.markActivity();
 
     /*
         For documentation, see:
@@ -218,6 +221,7 @@ void handleAPIv1ToRadio(HTTPRequest *req, HTTPResponse *res)
     res->setHeader("X-Protobuf-Schema", "https://raw.githubusercontent.com/meshtastic/protobufs/master/meshtastic/mesh.proto");
 
     if (req->getMethod() == "OPTIONS") {
+        webAPI.markActivity();
         res->setStatusCode(204); // Success with no content
         res->print("");
         return;

--- a/src/mesh/http/ContentHandler.h
+++ b/src/mesh/http/ContentHandler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Arduino.h>
 void registerHandlers(HTTPServer *insecureServer, HTTPSServer *secureServer);
 
 // Declare some handler functions for the various URLs on the server
@@ -27,10 +28,18 @@ class HttpAPI : public PhoneAPI
   public:
     HttpAPI() { api_type = TYPE_HTTP; }
 
+    void markActivity() { lastActivityMsec = millis(); }
+
   private:
-    // Nothing here yet
+    uint32_t lastActivityMsec = 0;
+    static constexpr uint32_t HTTP_ACTIVITY_TIMEOUT_MS = 30 * 1000UL;
 
   protected:
     /// Check the current underlying physical link to see if the client is currently connected
-    virtual bool checkIsConnected() override { return true; } // FIXME, be smarter about this
+    virtual bool checkIsConnected() override
+    {
+        if (lastActivityMsec == 0)
+            return false;
+        return (millis() - lastActivityMsec) <= HTTP_ACTIVITY_TIMEOUT_MS;
+    }
 };

--- a/test/test_api_fanout/Fanout.cpp
+++ b/test/test_api_fanout/Fanout.cpp
@@ -1,0 +1,176 @@
+#include "DebugConfiguration.h"
+#include "MeshService.h"
+#include "TestUtil.h"
+#include <unity.h>
+
+namespace
+{
+
+struct DummyClientToken {
+    uint8_t value = 0;
+};
+
+static PhoneAPI *asClient(DummyClientToken &token)
+{
+    return reinterpret_cast<PhoneAPI *>(&token);
+}
+
+static meshtastic_MeshPacket *allocDecodedPacket(uint32_t id, NodeNum to = 0)
+{
+    meshtastic_MeshPacket *p = packetPool.allocZeroed();
+    TEST_ASSERT_NOT_NULL(p);
+    p->id = id;
+    p->to = to;
+    p->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+    p->decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;
+    return p;
+}
+
+void test_fanout_packet_delivered_to_all_active_clients_once(void)
+{
+    MeshService meshService;
+    DummyClientToken c1, c2, c3;
+    PhoneAPI *client1 = asClient(c1);
+    PhoneAPI *client2 = asClient(c2);
+    PhoneAPI *client3 = asClient(c3);
+
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(client1, MeshService::STATE_SERIAL));
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(client2, MeshService::STATE_BLE));
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(client3, MeshService::STATE_WIFI));
+
+    meshService.sendToPhone(allocDecodedPacket(101, 0x1001));
+
+    meshtastic_MeshPacket *p1 = meshService.getForPhone(client1);
+    meshtastic_MeshPacket *p2 = meshService.getForPhone(client2);
+    meshtastic_MeshPacket *p3 = meshService.getForPhone(client3);
+
+    TEST_ASSERT_NOT_NULL(p1);
+    TEST_ASSERT_NOT_NULL(p2);
+    TEST_ASSERT_NOT_NULL(p3);
+    TEST_ASSERT_EQUAL_UINT32(101, p1->id);
+    TEST_ASSERT_EQUAL_UINT32(101, p2->id);
+    TEST_ASSERT_EQUAL_UINT32(101, p3->id);
+
+    meshService.releaseToPoolForPhone(client1, p1);
+    meshService.releaseToPoolForPhone(client2, p2);
+    meshService.releaseToPoolForPhone(client3, p3);
+
+    TEST_ASSERT_NULL(meshService.getForPhone(client1));
+    TEST_ASSERT_NULL(meshService.getForPhone(client2));
+    TEST_ASSERT_NULL(meshService.getForPhone(client3));
+}
+
+void test_slow_client_drop_oldest_fast_client_continuous_delivery(void)
+{
+    MeshService meshService;
+    DummyClientToken fastToken, slowToken;
+    PhoneAPI *fastClient = asClient(fastToken);
+    PhoneAPI *slowClient = asClient(slowToken);
+
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(fastClient, MeshService::STATE_SERIAL));
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(slowClient, MeshService::STATE_WIFI));
+
+    const uint32_t totalPackets = MAX_RX_TOPHONE + 4;
+    for (uint32_t i = 1; i <= totalPackets; i++) {
+        meshService.sendToPhone(allocDecodedPacket(i, i));
+
+        meshtastic_MeshPacket *fastPacket = meshService.getForPhone(fastClient);
+        TEST_ASSERT_NOT_NULL(fastPacket);
+        TEST_ASSERT_EQUAL_UINT32(i, fastPacket->id);
+        meshService.releaseToPoolForPhone(fastClient, fastPacket);
+    }
+
+    const uint32_t firstExpected = totalPackets - MAX_RX_TOPHONE + 1;
+    for (uint32_t expectedId = firstExpected; expectedId <= totalPackets; expectedId++) {
+        meshtastic_MeshPacket *slowPacket = meshService.getForPhone(slowClient);
+        TEST_ASSERT_NOT_NULL(slowPacket);
+        TEST_ASSERT_EQUAL_UINT32(expectedId, slowPacket->id);
+        meshService.releaseToPoolForPhone(slowClient, slowPacket);
+    }
+
+    TEST_ASSERT_NULL(meshService.getForPhone(slowClient));
+}
+
+void test_disconnect_cleans_pending_and_inflight_without_breaking_other_clients(void)
+{
+    MeshService meshService;
+    DummyClientToken firstToken, secondToken;
+    PhoneAPI *firstClient = asClient(firstToken);
+    PhoneAPI *secondClient = asClient(secondToken);
+
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(firstClient, MeshService::STATE_BLE));
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(secondClient, MeshService::STATE_WIFI));
+
+    meshService.sendToPhone(allocDecodedPacket(201, 0x2001));
+    meshtastic_MeshPacket *firstInflight = meshService.getForPhone(firstClient);
+    TEST_ASSERT_NOT_NULL(firstInflight);
+    TEST_ASSERT_EQUAL_UINT32(201, firstInflight->id);
+
+    meshService.unregisterPhoneClient(firstClient);
+
+    meshtastic_MeshPacket *secondPacket = meshService.getForPhone(secondClient);
+    TEST_ASSERT_NOT_NULL(secondPacket);
+    TEST_ASSERT_EQUAL_UINT32(201, secondPacket->id);
+    meshService.releaseToPoolForPhone(secondClient, secondPacket);
+
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(firstClient, MeshService::STATE_BLE));
+    meshService.sendToPhone(allocDecodedPacket(202, 0x2002));
+    meshService.unregisterPhoneClient(firstClient); // pending packet for firstClient is dropped on unregister
+
+    meshtastic_MeshPacket *secondPacket2 = meshService.getForPhone(secondClient);
+    TEST_ASSERT_NOT_NULL(secondPacket2);
+    TEST_ASSERT_EQUAL_UINT32(202, secondPacket2->id);
+    meshService.releaseToPoolForPhone(secondClient, secondPacket2);
+}
+
+void test_no_active_clients_does_not_buffer_packets(void)
+{
+    MeshService meshService;
+    meshService.sendToPhone(allocDecodedPacket(301, 0x3001));
+
+    DummyClientToken token;
+    PhoneAPI *client = asClient(token);
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(client, MeshService::STATE_SERIAL));
+    TEST_ASSERT_NULL(meshService.getForPhone(client));
+}
+
+void test_api_state_mask_refcount_for_same_state_clients(void)
+{
+    MeshService meshService;
+    DummyClientToken firstToken, secondToken;
+    PhoneAPI *firstClient = asClient(firstToken);
+    PhoneAPI *secondClient = asClient(secondToken);
+
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(firstClient, MeshService::STATE_SERIAL));
+    TEST_ASSERT_TRUE((meshService.api_state_mask & MeshService::apiStateBit(MeshService::STATE_SERIAL)) != 0u);
+
+    TEST_ASSERT_TRUE(meshService.registerPhoneClient(secondClient, MeshService::STATE_SERIAL));
+    TEST_ASSERT_TRUE((meshService.api_state_mask & MeshService::apiStateBit(MeshService::STATE_SERIAL)) != 0u);
+
+    meshService.unregisterPhoneClient(firstClient);
+    TEST_ASSERT_TRUE((meshService.api_state_mask & MeshService::apiStateBit(MeshService::STATE_SERIAL)) != 0u);
+
+    meshService.unregisterPhoneClient(secondClient);
+    TEST_ASSERT_EQUAL_UINT32(0u, meshService.api_state_mask);
+    TEST_ASSERT_EQUAL(MeshService::STATE_DISCONNECTED, meshService.api_state);
+}
+
+} // namespace
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup()
+{
+    initializeTestEnvironment();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_fanout_packet_delivered_to_all_active_clients_once);
+    RUN_TEST(test_slow_client_drop_oldest_fast_client_continuous_delivery);
+    RUN_TEST(test_disconnect_cleans_pending_and_inflight_without_breaking_other_clients);
+    RUN_TEST(test_no_active_clients_does_not_buffer_packets);
+    RUN_TEST(test_api_state_mask_refcount_for_same_state_clients);
+    exit(UNITY_END());
+}
+
+void loop() {}


### PR DESCRIPTION
Replace single to-phone queues with per-client fanout queues and pools so multiple PhoneAPI clients (BLE/WiFi/Serial/HTTP/Ethernet/etc.) can be served concurrently. Introduces PhoneClientSlot, per-client StaticPointerQueues, fanout entry pools, and a phoneClientsLock to protect registration and queue operations. Adds register/unregister APIs, enqueue/get/release helpers for packets, queue statuses, MQTT proxy messages and notifications, and implements refcounted release semantics and drop-oldest behavior for full client queues. Tracks active APIs with api_state_mask and per-state counts, updates api_state selection logic, and updates UI/debug rendering to show combined active APIs. Also: add HTTP activity tracking to HttpAPI/ContentHandler and unit tests (test_api_fanout) to validate fanout behavior and API state mask. Misc: small headers/includes and utility functions added.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] DIY esp32s3 e22
  - [x] seeed xiao s3