### PR TITLE
convert `GPS*` global and some new in gps.cpp to `unique_ptr<GPS>`

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -52,7 +52,7 @@ SerialUART *GPS::_serial_gps = &GPS_SERIAL_PORT;
 HardwareSerial *GPS::_serial_gps = nullptr;
 #endif
 
-GPS *gps = nullptr;
+std::unique_ptr<GPS> gps = nullptr;
 
 static GPSUpdateScheduling scheduling;
 
@@ -127,7 +127,7 @@ static int32_t gpsSwitch()
     return 1000;
 }
 
-static concurrency::Periodic *gpsPeriodic;
+static str::unique_ptr<concurrency::Periodic> gpsPeriodic;
 #endif
 
 static void UBXChecksum(uint8_t *message, size_t length)
@@ -1485,7 +1485,7 @@ GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipI
     if (bufferSize > 2048)
         bufferSize = 2048;
 
-    char *response = new char[bufferSize](); // Dynamically allocate based on baud rate
+    auto response = std::unique_ptr<char[]>(new char[bufferSize]); // Dynamically allocate based on baud rate
     uint16_t responseLen = 0;
     unsigned long start = millis();
     while (millis() - start < timeout) {
@@ -1501,19 +1501,18 @@ GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipI
             if (c == ',' || (responseLen >= 2 && response[responseLen - 2] == '\r' && response[responseLen - 1] == '\n')) {
                 // check if we can see our chips
                 for (const auto &chipInfo : responseMap) {
-                    if (strstr(response, chipInfo.detectionString.c_str()) != nullptr) {
+                    if (strstr(response.get(), chipInfo.detectionString.c_str()) != nullptr) {
 #ifdef GPS_DEBUG
-                        LOG_DEBUG(response);
+                        LOG_DEBUG(response.get());
 #endif
                         LOG_INFO("%s detected", chipInfo.chipName.c_str());
-                        delete[] response; // Cleanup before return
                         return chipInfo.driver;
                     }
                 }
             }
             if (responseLen >= 2 && response[responseLen - 2] == '\r' && response[responseLen - 1] == '\n') {
 #ifdef GPS_DEBUG
-                LOG_DEBUG(response);
+                LOG_DEBUG(response.get());
 #endif
                 // Reset the response buffer for the next potential message
                 responseLen = 0;
@@ -1522,13 +1521,12 @@ GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipI
         }
     }
 #ifdef GPS_DEBUG
-    LOG_DEBUG(response);
+    LOG_DEBUG(response.get());
 #endif
-    delete[] response;         // Cleanup before return
     return GNSS_MODEL_UNKNOWN; // Return unknown on timeout
 }
 
-GPS *GPS::createGps()
+std::unique_ptr<GPS> GPS::createGps()
 {
     int8_t _rx_gpio = config.position.rx_gpio;
     int8_t _tx_gpio = config.position.tx_gpio;
@@ -1553,7 +1551,7 @@ GPS *GPS::createGps()
     if (!_rx_gpio || !_serial_gps) // Configured to have no GPS at all
         return nullptr;
 
-    GPS *new_gps = new GPS;
+    auto new_gps = std::unique_ptr<GPS>(new GPS());
     new_gps->rx_gpio = _rx_gpio;
     new_gps->tx_gpio = _tx_gpio;
 
@@ -1581,7 +1579,7 @@ GPS *GPS::createGps()
 #ifdef PIN_GPS_SWITCH
     // toggle GPS via external GPIO switch
     pinMode(PIN_GPS_SWITCH, INPUT);
-    gpsPeriodic = new concurrency::Periodic("GPSSwitch", gpsSwitch);
+    gpsPeriodic = std::unique_ptr<concurrency::Periodic>(new concurrency::Periodic("GPSSwitch", gpsSwitch));
 #endif
 
 // Currently disabled per issue #525 (TinyGPS++ crash bug)

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -2,6 +2,8 @@
 #include "configuration.h"
 #if !MESHTASTIC_EXCLUDE_GPS
 
+#include <memory>
+
 #include "GPSStatus.h"
 #include "GpioLogic.h"
 #include "Observer.h"
@@ -118,7 +120,7 @@ class GPS : private concurrency::OSThread
 
     // Creates an instance of the GPS class.
     // Returns the new instance or null if the GPS is not present.
-    static GPS *createGps();
+    static std::unique_ptr<GPS> createGps();
 
     // Wake the GPS hardware - ready for an update
     void up();
@@ -256,5 +258,5 @@ class GPS : private concurrency::OSThread
     uint8_t fixeddelayCtr = 0;
 };
 
-extern GPS *gps;
+extern std::unique_ptr<GPS> gps;
 #endif // Exclude GPS


### PR DESCRIPTION
Trying this to see if anything bad happen if I were to replace most raw pointers with unique_ptr.

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
