### PR TITLE
ignore .direnv/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ __pycache__
 *.swo
 *~
 
+.direnv/
 venv/
 release/
 .vscode/extensions.json


### PR DESCRIPTION
using direnv/.envrc pollutes this folder, it should be ignored

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
