### PR TITLE
envrc: use flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use nix
+use flake


### PR DESCRIPTION
nix flake is the successor of legacy nix

similarly `use flake` can be seen as a successor to `use nix`

the main benefit is that everyone (using direnv) get the exact same versions of platformIO and python etc

with the old approach the system nix is used, which in my case was broken and did not work

when using flakes, if it works on one machine it basically works everywhere, reliably

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
