### PR TITLE
Undefine LED_BUILTIN for Heltec v2 variant

### DIFF
--- a/variants/esp32/heltec_v2/platformio.ini
+++ b/variants/esp32/heltec_v2/platformio.ini
@@ -14,3 +14,4 @@ build_flags =
   ${esp32_base.build_flags}
   -D HELTEC_V2_0
   -I variants/esp32/heltec_v2
+  -ULED_BUILTIN


### PR DESCRIPTION
As a result of #8830, the Heltec v2 variant no longer compiles and throws the following error:

`<command-line>: error: expected unqualified-id before '-' token /Users/ebarch/.platformio/packages/framework-arduinoespressif32/variants/heltec_wifi_lora_32_V2/pins_arduino.h:10:22: note: in expansion of macro 'LED_BUILTIN'`

This undefines LED_BUILTIN for this variant which resolves the build error.

Probably not a super popular board, but still nice to be able to build for it.