### PR TITLE
workaround NCP5623 and LP5562 I2C builds

### DIFF
--- a/src/AmbientLightingThread.h
+++ b/src/AmbientLightingThread.h
@@ -7,6 +7,8 @@
 #include "sleep.h"
 
 #ifdef HAS_NCP5623
+#include <Wire.h>
+
 #include <NCP5623.h>
 #endif
 

--- a/src/graphics/NomadStarLED.h
+++ b/src/graphics/NomadStarLED.h
@@ -1,4 +1,6 @@
 #ifdef HAS_LP5562
+#include <Wire.h>
+
 #include <LP5562.h>
 extern LP5562 rgbw;
 


### PR DESCRIPTION
Theses two appear to be buggy on r1-neo and nomadstar meteor pro, they rely on Wire.h being included previously to their import.

Idk why other platforms using the same smart LEDs are working while theses ones don't.

This should make CI green on the dev branch.
