### PR TITLE
Caching flash stats on ESP32 to speed up System menu rendering

### DIFF
--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -514,7 +514,7 @@ void drawLoRaFocused(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x,
 // ****************************
 // *      System Screen       *
 // ****************************
-#if ESP32
+#ifdef ESP32
 static uint32_t lastFlashCheck = 0;
 static uint32_t cachedFlashUsed = 0;
 static uint32_t cachedFlashTotal = 0;
@@ -590,7 +590,7 @@ void drawSystemScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x
     uint32_t heapUsed = memGet.getHeapSize() - memGet.getFreeHeap();
     uint32_t heapTotal = memGet.getHeapSize();
 
-#if ESP32
+#ifdef ESP32
     uint32_t psramUsed = memGet.getPsramSize() - memGet.getFreePsram();
     uint32_t psramTotal = memGet.getPsramSize();
 

--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -514,6 +514,12 @@ void drawLoRaFocused(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x,
 // ****************************
 // *      System Screen       *
 // ****************************
+#if ESP32
+static uint32_t lastFlashCheck = 0;
+static uint32_t cachedFlashUsed = 0;
+static uint32_t cachedFlashTotal = 0;
+#endif
+
 void drawSystemScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y)
 {
     display->clear();
@@ -584,13 +590,18 @@ void drawSystemScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x
     uint32_t heapUsed = memGet.getHeapSize() - memGet.getFreeHeap();
     uint32_t heapTotal = memGet.getHeapSize();
 
+#if ESP32
     uint32_t psramUsed = memGet.getPsramSize() - memGet.getFreePsram();
     uint32_t psramTotal = memGet.getPsramSize();
 
-    uint32_t flashUsed = 0, flashTotal = 0;
-#ifdef ESP32
-    flashUsed = FSCom.usedBytes();
-    flashTotal = FSCom.totalBytes();
+    // Cache flash usage to speed up menu rendering
+    if (millis() - lastFlashCheck > 10000 || lastFlashCheck == 0) {
+        cachedFlashUsed = FSCom.usedBytes();
+        cachedFlashTotal = FSCom.totalBytes();
+        lastFlashCheck = millis();
+    }
+    uint32_t flashUsed = cachedFlashUsed;
+    uint32_t flashTotal = cachedFlashTotal;
 #endif
 
     uint32_t sdUsed = 0, sdTotal = 0;

--- a/src/graphics/draw/DebugRenderer.cpp
+++ b/src/graphics/draw/DebugRenderer.cpp
@@ -514,7 +514,7 @@ void drawLoRaFocused(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x,
 // ****************************
 // *      System Screen       *
 // ****************************
-#ifdef ESP32
+#ifdef ARCH_ESP32
 static uint32_t lastFlashCheck = 0;
 static uint32_t cachedFlashUsed = 0;
 static uint32_t cachedFlashTotal = 0;
@@ -590,7 +590,7 @@ void drawSystemScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x
     uint32_t heapUsed = memGet.getHeapSize() - memGet.getFreeHeap();
     uint32_t heapTotal = memGet.getHeapSize();
 
-#ifdef ESP32
+#ifdef ARCH_ESP32
     uint32_t psramUsed = memGet.getPsramSize() - memGet.getFreePsram();
     uint32_t psramTotal = memGet.getPsramSize();
 
@@ -617,7 +617,7 @@ void drawSystemScreen(OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x
     */
     // === Draw memory rows
     drawUsageRow("Heap:", heapUsed, heapTotal, true);
-#ifdef ESP32
+#ifdef ARCH_ESP32
     if (psramUsed > 0) {
         line += 1;
         drawUsageRow("PSRAM:", psramUsed, psramTotal);


### PR DESCRIPTION
## Caching flash stats on ESP32 to speed up System menu rendering ##
Calling _FSCom.usedBytes()_ and _FSCom.totalBytes()_ on every frame render cause "System" menu panel to render slowly (2-3 fps) on ESP32.

- Added static variables to store cached values of flashUsed and flashTotal.
- Implemented **periodic checking** and caching of used and total flash (at **system start** or when **10 seconds** have passed since last check, when rendering "System" panel)
- Changed #ifdef ESP32 to #ifdef ARCH_ESP32 to follow convention
- Checking PSRAM stats only #ifdef ARCH_ESP32

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3