### PR TITLE
Undefine LED_BUILTIN for 9m2ibr_aprs_lora_tracker

### DIFF
--- a/variants/esp32/diy/9m2ibr_aprs_lora_tracker/platformio.ini
+++ b/variants/esp32/diy/9m2ibr_aprs_lora_tracker/platformio.ini
@@ -10,6 +10,7 @@ build_flags =
   -D EBYTE_E22
   -D EBYTE_E22_900M30S ; Assume Tx power curve is identical to 900M30S as there is no documentation
   -I variants/esp32/diy/9m2ibr_aprs_lora_tracker
+  -ULED_BUILTIN
 build_src_filter =
   ${esp32_base.build_src_filter}
   +<../variants/esp32/diy/9m2ibr_aprs_lora_tracker>


### PR DESCRIPTION
Hi!
Keep in sync another one variant with current codebase.
Undefine LED_BUILTIN for 9m2ibr_aprs_lora_tracker


- [x] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
