### PR TITLE
Log incoming client IP addresses for API connections

### DIFF
--- a/src/mesh/api/ServerAPI.cpp
+++ b/src/mesh/api/ServerAPI.cpp
@@ -5,7 +5,8 @@
 template <typename T>
 ServerAPI<T>::ServerAPI(T &_client) : StreamAPI(&client), concurrency::OSThread("ServerAPI"), client(_client)
 {
-    LOG_INFO("Incoming API connection");
+    auto ip = client.remoteIP();
+    LOG_INFO("Incoming API connection from %u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
 }
 
 template <typename T> ServerAPI<T>::~ServerAPI()

--- a/src/mesh/api/WiFiServerAPI.cpp
+++ b/src/mesh/api/WiFiServerAPI.cpp
@@ -26,7 +26,8 @@ void deInitApiServer()
 WiFiServerAPI::WiFiServerAPI(WiFiClient &_client) : ServerAPI(_client)
 {
     api_type = TYPE_WIFI;
-    LOG_INFO("Incoming wifi connection");
+    auto ip = _client.remoteIP();
+    LOG_INFO("Incoming wifi connection from %u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
 }
 
 WiFiServerPort::WiFiServerPort(int port) : APIServerPort(port) {}

--- a/src/mesh/api/ethServerAPI.cpp
+++ b/src/mesh/api/ethServerAPI.cpp
@@ -19,7 +19,8 @@ void initApiServer(int port)
 
 ethServerAPI::ethServerAPI(EthernetClient &_client) : ServerAPI(_client)
 {
-    LOG_INFO("Incoming ethernet connection");
+    auto ip = _client.remoteIP();
+    LOG_INFO("Incoming ethernet connection from %u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
     api_type = TYPE_ETH;
 }
 


### PR DESCRIPTION
## Problem

Currently, only a single client can connect at once to the ApiServer. When multiple clients (e.g., mobile app, web interface, CLI tool) attempt to connect simultaneously, they will compete for the connection, often resulting in confusing disconnection issues. The existing logs only show "Incoming API connection" without identifying which client is connecting, making it difficult to troubleshoot these scenarios.

## Solution

This PR modifies the connection logging in three API server implementations to include the remote client's IP address.

By adding this logging it makes for **easier troubleshooting** to quickly identify which client is connecting or causing connection conflicts.

### Before
```
INFO  | Incoming API connection
INFO  | Incoming wifi connection
INFO  | Incoming ethernet connection
```

### After
```
INFO  | Incoming API connection from 192.168.1.100
INFO  | Incoming wifi connection from 192.168.1.100
INFO  | Incoming ethernet connection from 192.168.1.100
```

## Testing

**Note:**
I do not have an ipv6 network to test with and I am unsure what this would do in that situation. This is UNTESTED with ipv6. Also, meshtastic does not currently support IPV6.

I have tested these changes on the following hardware:
- ✅ M5Stack Cardputer ADV (ESP32-S3)
- ✅ Portduino

Minimal testing, but it worked and I didn't see anything wrong.
- ✅ Heltec V3 (minimal testing)
- ✅ Xiao nRF kit (minimal testing)

All devices correctly log the connecting client's IP address when API connections are established via WiFi and Ethernet interfaces.

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [x] RAK WisBlock 4631 (Xiao nRF kit)
  - [x] Other: M5Stack Cardputer ADV (ESP32-S3), Portduino
