### PR TITLE
meshtasticd: Add Luckfox Lyra Hat pinmaps

### DIFF
--- a/bin/config.d/lora-lyra-ultra_1w.yaml
+++ b/bin/config.d/lora-lyra-ultra_1w.yaml
@@ -1,0 +1,16 @@
+# For use with Armbian luckfox-lyra-ultra-w
+# Enable overlay 'luckfox-lyra-ultra-w-spi0-cs0-spidev' with armbian-config
+# https://github.com/wehooper4/Meshtastic-Hardware/tree/main/Luckfox%20Ultra%20Hat
+# 1 Watt Lyra Ultra hat
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  CS: 10
+  IRQ: 5
+  Busy: 11
+  Reset: 9
+  RXen: 14
+
+  spidev: spidev0.0 #pins are (CS=10, CLK=8, MOSI=6, MISO=7)
+  spiSpeed: 2000000

--- a/bin/config.d/lora-lyra-ultra_2w.yaml
+++ b/bin/config.d/lora-lyra-ultra_2w.yaml
@@ -1,0 +1,17 @@
+# For use with Armbian luckfox-lyra-ultra-w
+# Enable overlay 'luckfox-lyra-ultra-w-spi0-cs0-spidev' with armbian-config
+# https://github.com/wehooper4/Meshtastic-Hardware/tree/main/Luckfox%20Ultra%20Hat
+# 2 Watt Lyra Ultra hat
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  SX126X_MAX_POWER: 8
+  CS: 10
+  IRQ: 5
+  Busy: 11
+  Reset: 9
+  RXen: 14
+
+  spidev: spidev0.0 #pins are (CS=10, CLK=8, MOSI=6, MISO=7)
+  spiSpeed: 2000000

--- a/bin/config.d/lora-lyra-ws-raspberry-pi-pico-hat.yaml
+++ b/bin/config.d/lora-lyra-ws-raspberry-pi-pico-hat.yaml
@@ -1,0 +1,25 @@
+# For use with Armbian luckfox-lyra // luckfox-lyra-plus
+# Enable overlay 'luckfox-lyra-plus-spi0-cs0_rmio13-spidev' with armbian-config
+# Waveshare LoRa HAT for Raspberry Pi Pico
+# https://www.waveshare.com/wiki/Pico-LoRa-SX1262
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: spidev0.0
+  CS: # GPIO0_B5
+    pin: 13
+    gpiochip: 0
+    line: 13
+  IRQ: # GPIO1_C2
+    pin: 50
+    gpiochip: 1
+    line: 18
+  Busy: # GPIO0_B4
+    pin: 12
+    gpiochip: 0
+    line: 12
+  Reset: # GPIO0_A2
+    pin: 2
+    gpiochip: 0
+    line: 2


### PR DESCRIPTION
Add new meshtasticd pinmaps for Luckfox Lyra (Plus, Ultra) running Armbian (mPWRD-OS).

Luckfox Lyra Plus + Waveshare Pi Pico Hat
Luckfox Lyra Ultra + wehooper4's "Luckfox Ultra" hat

Configs are tested/working with meshtasticd 2.7.15.