### PR TITLE
Remove unused global rIf that shadows locals and fails cppcheck

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,7 +246,6 @@ uint32_t timeLastPowered = 0;
 static OSThread *powerFSMthread;
 OSThread *ambientLightingThread;
 
-RadioInterface *rIf = NULL;
 RadioLibHal *RadioLibHAL = NULL;
 
 /**


### PR DESCRIPTION
I noticed because my PR failed
