### PR TITLE
Revert "Fix/rak3401 button"

### DIFF
--- a/variants/nrf52840/rak3401_1watt/variant.h
+++ b/variants/nrf52840/rak3401_1watt/variant.h
@@ -53,12 +53,6 @@ extern "C" {
 #define LED_STATE_ON 1 // State when LED is litted
 
 /*
- * Buttons
- */
-#define PIN_BUTTON1 (9)
-#define BUTTON_NEED_PULLUP
-
-/*
  * Analog pins
  */
 #define PIN_A0 (5)


### PR DESCRIPTION
Reverts meshtastic/firmware#9668

This PR causes a regression where, if a button is not added, the pin experiences false positives causing random shutdowns:
`INFO  | 08:04:37 46 [UserButton] LONG PRESS RELEASE AFTER 42029 MILLIS`

Credit to @Xaositek for the report