### PR TITLE
Don't launch canned message when waking screen or silencing notification

### DIFF
--- a/src/input/InputBroker.cpp
+++ b/src/input/InputBroker.cpp
@@ -100,7 +100,7 @@ void InputBroker::processInputEventQueue()
 
 int InputBroker::handleInputEvent(const InputEvent *event)
 {
-#ifdef HAS_SCREEN
+#if HAS_SCREEN
     bool screenWasOff = false;
     if (screen) {
         screenWasOff = !screen->isScreenOn();
@@ -115,7 +115,7 @@ int InputBroker::handleInputEvent(const InputEvent *event)
         return 0;
     }
 
-#ifdef HAS_SCREEN
+#if HAS_SCREEN
     if (screen && screenWasOff) {
         // If the screen was off, it is in the process of turning on, and we just drop the event
         return 0;


### PR DESCRIPTION
Particularly devices with keyboards have an obnoxious behavior, where pressing a key to silence the notification or wake the screen will launch canned messages. This change ignores that first keystroke.