### PR TITLE
enhancement(mesh): remove late packets from tx queue when full

### DIFF
--- a/src/mesh/MeshPacketQueue.cpp
+++ b/src/mesh/MeshPacketQueue.cpp
@@ -188,15 +188,16 @@ bool MeshPacketQueue::replaceLowerPriorityPacket(meshtastic_MeshPacket *p)
         // Check if there's a late packet at the queue end
         auto now = millis();
         if (backPacket->tx_after < now && (!p->tx_after || backPacket->tx_after > p->tx_after)) {
+            int32_t dt = (int32_t)(backPacket->tx_after - now);
             if (p->tx_after) {
                 LOG_WARN("Dropping late packet 0x%08x with TX delay %dms to make room in the TX queue for packet 0x%08x with "
                          "TX delay %ums",
-                         backPacket->id, backPacket->tx_after - now, p->id, p->tx_after - now);
+                         backPacket->id, dt, p->id, p->tx_after - now);
 
             } else {
                 LOG_WARN("Dropping late packet 0x%08x with TX delay %dms to make room in the TX queue for packet 0x%08x "
                          "with no TX delay",
-                         backPacket->id, backPacket->tx_after - now, p->id);
+                         backPacket->id, dt, p->id);
             }
             queue.pop_back();
             packetPool.release(backPacket);


### PR DESCRIPTION
In busy environments, especially when operating in the `ROUTER_LATE` role, the TX queue fills up very quickly. As a result, delayed packets become stale, while newly received packets that require retransmission cannot be added to the TX queue because older packets remain there for an extended period (sometimes a minute or more).

This change modifies the queue handling logic to prioritize new packets over stale ones. If the TX queue is full, a late packet from the back of the queue will be removed to make room for a new packet. This ensures that fresh transmissions are not blocked by outdated packets and improves overall network responsiveness in busy environments - especially when node holds `ROUTER_LATE` role.

A more aggressive approach would be to remove a packet even if it is not yet late, but has a higher TX delay than the packet being enqueued. I successfully tested this behavior on my own node. However, the currently proposed implementation appears to be a reasonable compromise between improving responsiveness and avoiding overly aggressive packet drops.

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
