### PR TITLE
Deb: Handle offline builds more gracefully

### DIFF
--- a/.github/workflows/package_pio_deps.yml
+++ b/.github/workflows/package_pio_deps.yml
@@ -54,6 +54,16 @@ jobs:
           PLATFORMIO_LIBDEPS_DIR: pio/libdeps
           PLATFORMIO_PACKAGES_DIR: pio/packages
           PLATFORMIO_CORE_DIR: pio/core
+          PLATFORMIO_SETTING_ENABLE_TELEMETRY: 0
+          PLATFORMIO_SETTING_CHECK_PLATFORMIO_INTERVAL: 3650
+          PLATFORMIO_SETTING_CHECK_PRUNE_SYSTEM_THRESHOLD: 10240
+
+      - name: Mangle platformio cache
+        # Add "1" to epoch-timestamps of all downloads in the cache.
+        # This is a hack to prevent internet access at build-time.
+        run: |
+          cp pio/core/.cache/downloads/usage.db pio/core/.cache/downloads/usage.db.bak
+          jq -c 'with_entries(.value |= (. | tostring + "1" | tonumber))' pio/core/.cache/downloads/usage.db.bak > pio/core/.cache/downloads/usage.db
 
       - name: Store binaries as an artifact
         uses: actions/upload-artifact@v6

--- a/debian/ci_pack_sdeb.sh
+++ b/debian/ci_pack_sdeb.sh
@@ -3,6 +3,9 @@ export DEBEMAIL="jbennett@incomsystems.biz"
 export PLATFORMIO_LIBDEPS_DIR=pio/libdeps
 export PLATFORMIO_PACKAGES_DIR=pio/packages
 export PLATFORMIO_CORE_DIR=pio/core
+export PLATFORMIO_SETTING_ENABLE_TELEMETRY=0
+export PLATFORMIO_SETTING_CHECK_PLATFORMIO_INTERVAL=3650
+export PLATFORMIO_SETTING_CHECK_PRUNE_SYSTEM_THRESHOLD=10240
 
 # Download libraries to `pio`
 platformio pkg install -e native-tft

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,10 @@
 PIO_ENV:=\
 	PLATFORMIO_CORE_DIR=pio/core \
 	PLATFORMIO_LIBDEPS_DIR=pio/libdeps \
-	PLATFORMIO_PACKAGES_DIR=pio/packages
+	PLATFORMIO_PACKAGES_DIR=pio/packages \
+	PLATFORMIO_SETTING_ENABLE_TELEMETRY=0 \
+	PLATFORMIO_SETTING_CHECK_PLATFORMIO_INTERVAL=3650 \
+	PLATFORMIO_SETTING_CHECK_PRUNE_SYSTEM_THRESHOLD=10240
 
 # Raspbian armhf builds should be compatible with armv6-hardfloat
 # https://www.valvers.com/open-software/raspberry-pi/bare-metal-programming-in-c-part-1/#rpi1-compiler-flags


### PR DESCRIPTION
We're *trying* to build debs offline here! (PPA, OBS). Currently rebuilds on OBS/PPA fail after some time (they attempt to update libs).

- Check for platformio updates (including library updates) every 10 years :zany_face: (not every 7 days)
- Increase prune limit from 1GB to 10GB (don't prune)
- Disable PlatformIO telemetry

Docs:
- https://docs.platformio.org/en/latest/core/userguide/cmd_settings.html#settings
- https://docs.platformio.org/en/latest/envvars.html#settings