### PR TITLE
fix: add ROUTER_LATE  use the same rebroadcast rules as ROUTER

### DIFF
--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -87,7 +87,9 @@ int MeshService::handleFromRadio(const meshtastic_MeshPacket *mp)
     powerFSM.trigger(EVENT_PACKET_FOR_PHONE); // Possibly keep the node from sleeping
 
     nodeDB->updateFrom(*mp); // update our DB state based off sniffing every RX packet from the radio
-    bool isPreferredRebroadcaster = config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER;
+    bool isPreferredRebroadcaster =
+        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
+                  meshtastic_Config_DeviceConfig_Role_CLIENT_BASE);
     if (mp->which_payload_variant == meshtastic_MeshPacket_decoded_tag &&
         mp->decoded.portnum == meshtastic_PortNum_TELEMETRY_APP && mp->decoded.request_id > 0) {
         LOG_DEBUG("Received telemetry response. Skip sending our NodeInfo");

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -653,9 +653,10 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
         }
         config.device = c.payload_variant.device;
         if (config.device.rebroadcast_mode == meshtastic_Config_DeviceConfig_RebroadcastMode_NONE &&
-            config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER) {
+            (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
+             config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE)) {
             config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_ALL;
-            const char *warning = "Rebroadcast mode can't be set to NONE for a router";
+            const char *warning = "Rebroadcast mode can't be set to NONE for a router role";
             LOG_WARN(warning);
             sendWarning(warning);
         }


### PR DESCRIPTION
## Summary

Adds `ROUTER_LATE` (and `CLIENT_BASE`) to preferred rebroadcaster check and prevents `ROUTER_LATE` from setting rebroadcast mode to `NONE`, ensuring infrastructure relay roles maintain their rebroadcast function.

##NOTE: This was assisted with the use of both Claude Opus 4.6 and GPT 5.3-Codex. The logic changes are all mine. 

## Changes

| File                          | Line(s) | Before           | After                                               | Effect                                                                            |
| ----------------------------- | ------- | ---------------- | --------------------------------------------------- | --------------------------------------------------------------------------------- |
| `src/mesh/MeshService.cpp`    | 90      | `role == ROUTER` | `IS_ONE_OF(role, ROUTER, ROUTER_LATE, CLIENT_BASE)` | `ROUTER_LATE` and `CLIENT_BASE` skip unsolicited NodeInfo, reducing channel noise |
| `src/modules/AdminModule.cpp` | 654-655 | `role == ROUTER` | `role == ROUTER \|\| role == ROUTER_LATE`           | `ROUTER_LATE` now blocked from `NONE` rebroadcast mode, matching `ROUTER`         |

## Rationale

**MeshService preferred rebroadcaster:** When `isPreferredRebroadcaster` is true, the node skips sending its own NodeInfo in response to hearing a new unknown node. `ROUTER_LATE` shoudl be treated equally — it is `is_unmessagable = true` and has no reason to solicit NodeInfo exchanges. `CLIENT_BASE` acts as a relay for favorited nodes and also benefits from reduced unsolicited chatter.

**AdminModule rebroadcast mode:** A router-class node with rebroadcast mode set to `NONE` is a contradiction — it exists to relay packets. The validation guard preventing this misconfiguration should apply equally to `ROUTER_LATE`. Without this check, a user could accidentally disable relaying on a `ROUTER_LATE` node with no warning.


## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
Heltec V4