### PR TITLE
feat: add ROUTER_LATE to infrastructure init and config preservation

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -672,7 +672,8 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
 #endif
     config.position.broadcast_smart_minimum_distance = 100;
     config.position.broadcast_smart_minimum_interval_secs = default_broadcast_smart_minimum_interval_secs;
-    if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER)
+    if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER &&
+        config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER_LATE)
         config.device.node_info_broadcast_secs = default_node_info_broadcast_secs;
     config.security.serial_enabled = true;
     config.security.admin_channel_enabled = false;

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -588,7 +588,8 @@ StoreForwardModule::StoreForwardModule()
     if (moduleConfig.store_forward.enabled) {
 
         // Router
-        if ((config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER || moduleConfig.store_forward.is_server)) {
+        if ((config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
+             config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE || moduleConfig.store_forward.is_server)) {
             LOG_INFO("Init Store & Forward Module in Server mode");
             if (memGet.getPsramSize() > 0) {
                 if (memGet.getFreePsram() >= 1024 * 1024) {


### PR DESCRIPTION
## Summary

Adds `ROUTER_LATE` to NodeDB factory reset config preservation and Store & Forward server auto-enable, so `ROUTER_LATE` behaves as infrastructure like `ROUTER` during initialization.

### NOTE: This was assisted with the use of both Claude Opus 4.6 and GPT 5.3-Codex. The logic changes are all mine. 

## Changes

| File                                 | Line(s) | Before           | After                                     | Effect                                                                  |
| ------------------------------------ | ------- | ---------------- | ----------------------------------------- | ----------------------------------------------------------------------- |
| `src/mesh/NodeDB.cpp`                | 670     | `role != ROUTER` | `role != ROUTER && role != ROUTER_LATE`   | `ROUTER_LATE` preserves `node_info_broadcast_secs` during factory reset |
| `src/modules/StoreForwardModule.cpp` | 591     | `role == ROUTER` | `role == ROUTER \|\| role == ROUTER_LATE` | `ROUTER_LATE` auto-enables S&F server when S&F is enabled               |

## Rationale

**NodeDB factory reset:** During `installDefaultConfig()`, `node_info_broadcast_secs` is overwritten to the default value for all roles except `ROUTER`. `ROUTER_LATE` is an infrastructure role that sets `device_update_interval = ONE_DAY` in `installRoleDefaults` — it should also preserve its node info broadcast configuration. Without this, a factory reset silently reverts to client-class NodeInfo broadcast frequency.

**Store & Forward:** `ROUTER_LATE` has the same deployment profile as `ROUTER` — always-on, with PSRAM available for S&F history. If Store & Forward is enabled on a `ROUTER_LATE` node, it should auto-enter server mode just like `ROUTER`. The `|| moduleConfig.store_forward.is_server` fallback remains, so any role can still explicitly opt in.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
Heltec V4