### PR TITLE
fix: prevent router-like roles from auto-favoriting DM peers

### DIFF
--- a/src/modules/CannedMessageModule.cpp
+++ b/src/modules/CannedMessageModule.cpp
@@ -1072,12 +1072,14 @@ void CannedMessageModule::sendText(NodeNum dest, ChannelIndex channel, const cha
     } else {
         sm.dest = dest;
         sm.type = MessageType::DM_TO_US;
-        // Only add as favorite if our role is NOT CLIENT_BASE
-        if (config.device.role != 12) {
+        // Only add as favorite if our role is not router-like (ROUTER, ROUTER_LATE, CLIENT_BASE)
+        if (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER &&
+            config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER_LATE &&
+            config.device.role != meshtastic_Config_DeviceConfig_Role_CLIENT_BASE) {
             LOG_INFO("Proactively adding %x as favorite node", dest);
             nodeDB->set_favorite(true, dest);
         } else {
-            LOG_DEBUG("Not favoriting node %x as we are CLIENT_BASE role", dest);
+            LOG_DEBUG("Not favoriting node %x because role is router-like", dest);
         }
     }
     sm.ackStatus = AckStatus::NONE;


### PR DESCRIPTION
## Summary

Prevents `ROUTER` and `ROUTER_LATE` (in addition to existing `CLIENT_BASE`) from auto-favoriting DM peers in CannedMessageModule, and fixes the device.role (`12`) with the proper enum constant.

#### NOTE: This was assisted with the use of both Claude Opus 4.6 and GPT 5.3-Codex. The logic changes are all mine. 

## Changes

| File                                  | Line(s) | Before                                    | After                                                          | Effect                                                                              |
| ------------------------------------- | ------- | ----------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| `src/modules/CannedMessageModule.cpp` | 1076    | `role != 12` (magic number = CLIENT_BASE) | `role != ROUTER && role != ROUTER_LATE && role != CLIENT_BASE` | Router-like roles no longer auto-favorite DM peers; magic number replaced with enum |

## Rationale

Auto-favoriting on DM send is useful for client-style roles, but for infrastructure/relay roles it creates noisy and unintended favorite state. `ROUTER` and `ROUTER_LATE` are infrastructure nodes that should not accumulate favorites just by sending DMs. `CLIENT_BASE` was already excluded (via `12`). This change also fixes the magic number with the proper enum constant `meshtastic_Config_DeviceConfig_Role_CLIENT_BASE`.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
Heltec v4