### PR TITLE
fix(t1000e): reclassify P0.04 as sensor power enable GPIO

### DIFF
--- a/src/modules/Telemetry/Sensor/T1000xSensor.cpp
+++ b/src/modules/Telemetry/Sensor/T1000xSensor.cpp
@@ -73,11 +73,15 @@ float T1000xSensor::getTemp()
     float Vout = 0, Rt = 0, temp = 0;
     float Temp = 0;
 
+    // P0.4 is a sensor power enable GPIO, not a VCC ADC pin.
+    // Read BATTERY_PIN (with voltage divider) and cap at NTC_REF_VCC to estimate the sensor rail voltage.
     for (uint32_t i = 0; i < T1000X_SENSE_SAMPLES; i++) {
-        vcc_vot += analogRead(T1000X_VCC_PIN);
+        vcc_vot += analogRead(BATTERY_PIN);
     }
     vcc_vot = vcc_vot / T1000X_SENSE_SAMPLES;
-    vcc_vot = 2 * ((1000 * AREF_VOLTAGE) / pow(2, BATTERY_SENSE_RESOLUTION_BITS)) * vcc_vot;
+    vcc_vot = ADC_MULTIPLIER * ((1000 * AREF_VOLTAGE) / pow(2, BATTERY_SENSE_RESOLUTION_BITS)) * vcc_vot;
+    if (vcc_vot > NTC_REF_VCC)
+        vcc_vot = NTC_REF_VCC;
 
     for (uint32_t i = 0; i < T1000X_SENSE_SAMPLES; i++) {
         ntc_vot += analogRead(T1000X_NTC_PIN);

--- a/variants/nrf52840/tracker-t1000-e/variant.cpp
+++ b/variants/nrf52840/tracker-t1000-e/variant.cpp
@@ -38,6 +38,9 @@ void initVariant()
     pinMode(PIN_3V3_ACC_EN, OUTPUT);
     digitalWrite(PIN_3V3_ACC_EN, HIGH);
 
+    pinMode(T1000X_SENSOR_EN_PIN, OUTPUT);
+    digitalWrite(T1000X_SENSOR_EN_PIN, HIGH);
+
     pinMode(BUZZER_EN_PIN, OUTPUT);
     digitalWrite(BUZZER_EN_PIN, HIGH);
 

--- a/variants/nrf52840/tracker-t1000-e/variant.h
+++ b/variants/nrf52840/tracker-t1000-e/variant.h
@@ -126,7 +126,7 @@ extern "C" {
 #define BATTERY_PIN 2 // P0.02/AIN0, BAT_ADC
 #define BATTERY_IMMUTABLE
 #define ADC_MULTIPLIER (2.0F)
-// P0.04/AIN2 is VCC_ADC, P0.05/AIN3 is CHARGER_DET, P1.03 is CHARGE_STA, P1.04 is CHARGE_DONE
+// P0.04 is sensor power enable, P0.05/AIN3 is CHARGER_DET, P1.03 is CHARGE_STA, P1.04 is CHARGE_DONE
 
 #define EXT_CHRG_DETECT (32 + 3) // P1.03
 #define EXT_CHRG_DETECT_VALUE LOW
@@ -148,9 +148,9 @@ extern "C" {
 #define PIN_BUZZER (0 + 25)    // P0.25, pwm output
 
 #define T1000X_SENSOR_EN
-#define T1000X_VCC_PIN (0 + 4)  // P0.4
-#define T1000X_NTC_PIN (0 + 31) // P0.31/AIN7
-#define T1000X_LUX_PIN (0 + 29) // P0.29/AIN5
+#define T1000X_SENSOR_EN_PIN (0 + 4) // P0.4, Power to Sensor (GPIO, not ADC)
+#define T1000X_NTC_PIN (0 + 31)      // P0.31/AIN7
+#define T1000X_LUX_PIN (0 + 29)      // P0.29/AIN5
 
 #define HAS_SCREEN 0
 

--- a/variants/nrf52840/wio-t1000-s/variant.cpp
+++ b/variants/nrf52840/wio-t1000-s/variant.cpp
@@ -38,6 +38,9 @@ void initVariant()
     pinMode(PIN_3V3_ACC_EN, OUTPUT);
     digitalWrite(PIN_3V3_ACC_EN, LOW);
 
+    pinMode(T1000X_SENSOR_EN_PIN, OUTPUT);
+    digitalWrite(T1000X_SENSOR_EN_PIN, HIGH);
+
     pinMode(BUZZER_EN_PIN, OUTPUT);
     digitalWrite(BUZZER_EN_PIN, HIGH);
 

--- a/variants/nrf52840/wio-t1000-s/variant.h
+++ b/variants/nrf52840/wio-t1000-s/variant.h
@@ -143,9 +143,9 @@ extern "C" {
 #define PIN_BUZZER (0 + 25)    // P0.25, pwm output
 
 #define T1000X_SENSOR_EN
-#define T1000X_VCC_PIN (0 + 4)  // P0.4
-#define T1000X_NTC_PIN (0 + 31) // P0.31
-#define T1000X_LUX_PIN (0 + 29) // P0.29
+#define T1000X_SENSOR_EN_PIN (0 + 4) // P0.4, Power to Sensor (GPIO, not ADC)
+#define T1000X_NTC_PIN (0 + 31)      // P0.31
+#define T1000X_LUX_PIN (0 + 29)      // P0.29
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
P0.04 is a digital power-enable pin for the NTC/LUX sensors, not an ADC input. The old code was calling analogRead() on a floating GPIO that happened to read ~mid-rail, coincidentally producing reasonable temperature values.

- Rename T1000X_VCC_PIN to T1000X_SENSOR_EN_PIN and drive it HIGH in initVariant() for both T1000-E and T1000-S variants
- Read BATTERY_PIN (with ADC_MULTIPLIER) instead, clamped to the 3.0V LDO output (NTC_REF_VCC) for the NTC resistance calculation

Tested on T1000e tracker, temperature works all the same.

![PXL_20260305_143611604](https://github.com/user-attachments/assets/0cb34668-8ee5-41ca-ae5a-92db67f34998)
![PXL_20260305_143619550](https://github.com/user-attachments/assets/e7a7e5e9-532e-44b6-b389-ee8e7b1c9ad4)


![Screenshot_20260305-154502~2](https://github.com/user-attachments/assets/716a4d6b-8fc9-4c0a-839c-80a388788654)
before temp with 2.7.19 was 25.0

<img width="923" height="683" alt="image" src="https://github.com/user-attachments/assets/b9c71a0d-c118-4177-8ec1-7af580c826a5" />

