### PR TITLE
Don't double-blink Thinknode-M1 Power LED while charging

### DIFF
--- a/src/platform/nrf52/architecture.h
+++ b/src/platform/nrf52/architecture.h
@@ -157,7 +157,7 @@
 
 #endif
 
-#ifdef PIN_LED1
+#if defined(PIN_LED1) && !defined(LED_POWER)
 #define LED_POWER PIN_LED1 // LED1 on nrf52840-DK
 #endif
 

--- a/variants/esp32s3/ELECROW-ThinkNode-M2/variant.h
+++ b/variants/esp32s3/ELECROW-ThinkNode-M2/variant.h
@@ -1,6 +1,3 @@
-// Status
-#define LED_POWER 1
-
 #define PIN_BUTTON1 47 // 功能键
 #define PIN_BUTTON2 4  // 电源键
 #define ALT_BUTTON_PIN PIN_BUTTON2

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/variant.cpp
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/variant.cpp
@@ -32,8 +32,8 @@ const uint32_t g_ADigitalPinMap[] = {
 
 void initVariant()
 {
-    pinMode(PIN_LED1, OUTPUT);
-    ledOff(PIN_LED1);
+    // pinMode(PIN_LED1, OUTPUT);
+    // ledOff(PIN_LED1);
 }
 
 void variant_shutdown()

--- a/variants/nrf52840/ELECROW-ThinkNode-M1/variant.h
+++ b/variants/nrf52840/ELECROW-ThinkNode-M1/variant.h
@@ -42,15 +42,17 @@ extern "C" {
 #define NUM_ANALOG_OUTPUTS (0)
 
 // LED
-#define PIN_LED1 (32 + 6) // red
-#define LED_POWER (32 + 4)
+// #define PIN_LED1 (32 + 6)
+#define LED_POWER (32 + 4)        // red
 #define LED_NOTIFICATION (0 + 13) // green
+#define POWER_LED_HARDWARE_BLINKS_WHILE_CHARGING
+
 // USB_CHECK
 #define EXT_PWR_DETECT (32 + 3)
 #define ADC_V (0 + 8)
 
-#define LED_BLUE PIN_LED1
-#define LED_STATE_ON 0 // State when LED is lit  // LED灯亮时的状态
+// #define LED_BLUE PIN_LED1
+#define LED_STATE_ON 1 // State when LED is lit  // LED灯亮时的状态
 #define PIN_BUZZER (0 + 6)
 /*
  * Buttons


### PR DESCRIPTION
Working through ThinkNode devices and fixing minor issues.