### PR TITLE
Add APIPort to native config

### DIFF
--- a/bin/config-dist.yaml
+++ b/bin/config-dist.yaml
@@ -215,3 +215,4 @@ General:
   AvailableDirectory: /etc/meshtasticd/available.d/
 #  MACAddress: AA:BB:CC:DD:EE:FF
 #  MACAddressSource: eth0
+#  APIPort: 4403


### PR DESCRIPTION
This PR adds the field APIPort to the General section of config.yaml.

Since https://github.com/meshtastic/firmware/pull/8435 we are able to specify the API port in our config.  Adding the default as a comment shows that this configuration is accessible.