### PR TITLE
Heltec v4.3: enable LNA by default

### DIFF
--- a/src/mesh/LoRaFEMInterface.cpp
+++ b/src/mesh/LoRaFEMInterface.cpp
@@ -25,7 +25,7 @@ void LoRaFEMInterface::init(void)
         pinMode(LORA_KCT8103L_PA_CSD, OUTPUT);
         digitalWrite(LORA_KCT8103L_PA_CSD, HIGH);
         pinMode(LORA_KCT8103L_PA_CTX, OUTPUT);
-        digitalWrite(LORA_KCT8103L_PA_CTX, HIGH);
+        digitalWrite(LORA_KCT8103L_PA_CTX, LOW); // LNA enabled by default
         setLnaCanControl(true);
     } else if (digitalRead(LORA_KCT8103L_PA_CSD) == LOW) {
         // FEM is GC1109
@@ -66,7 +66,7 @@ void LoRaFEMInterface::init(void)
     pinMode(LORA_KCT8103L_PA_CSD, OUTPUT);
     digitalWrite(LORA_KCT8103L_PA_CSD, HIGH);
     pinMode(LORA_KCT8103L_PA_CTX, OUTPUT);
-    digitalWrite(LORA_KCT8103L_PA_CTX, HIGH);
+    digitalWrite(LORA_KCT8103L_PA_CTX, LOW); // LNA enabled by default
     setLnaCanControl(true);
 #endif
 }

--- a/src/mesh/LoRaFEMInterface.h
+++ b/src/mesh/LoRaFEMInterface.h
@@ -22,7 +22,7 @@ class LoRaFEMInterface
 
   private:
     LoRaFEMType fem_type;
-    bool lna_enabled = false;
+    bool lna_enabled = true;
     bool lna_can_control = false;
 };
 extern LoRaFEMInterface loraFEMInterface;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -569,7 +569,7 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     config.lora.override_duty_cycle = false;
     config.lora.config_ok_to_mqtt = false;
 #if HAS_LORA_FEM
-    config.lora.fem_lna_mode = meshtastic_Config_LoRaConfig_FEM_LNA_Mode_DISABLED;
+    config.lora.fem_lna_mode = meshtastic_Config_LoRaConfig_FEM_LNA_Mode_ENABLED;
 #else
     config.lora.fem_lna_mode = meshtastic_Config_LoRaConfig_FEM_LNA_Mode_NOT_PRESENT;
 #endif

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -60,7 +60,7 @@ template <typename T> bool SX126xInterface<T>::init()
     loraFEMInterface.init();
     // Apply saved FEM LNA mode from config
     if (loraFEMInterface.isLnaCanControl()) {
-        loraFEMInterface.setLNAEnable(config.lora.fem_lna_mode == meshtastic_Config_LoRaConfig_FEM_LNA_Mode_ENABLED);
+        loraFEMInterface.setLNAEnable(config.lora.fem_lna_mode != meshtastic_Config_LoRaConfig_FEM_LNA_Mode_DISABLED);
     }
 #endif
 

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -800,7 +800,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
 #if HAS_LORA_FEM
         // Apply FEM LNA mode from config (only meaningful on hardware that supports it)
         if (loraFEMInterface.isLnaCanControl()) {
-            loraFEMInterface.setLNAEnable(config.lora.fem_lna_mode == meshtastic_Config_LoRaConfig_FEM_LNA_Mode_ENABLED);
+            loraFEMInterface.setLNAEnable(config.lora.fem_lna_mode != meshtastic_Config_LoRaConfig_FEM_LNA_Mode_DISABLED);
         } else if (config.lora.fem_lna_mode != meshtastic_Config_LoRaConfig_FEM_LNA_Mode_NOT_PRESENT) {
             // Hardware FEM does not support LNA control; normalize stored config to match actual capability
             LOG_WARN("FEM LNA mode configured but current FEM does not support LNA control; normalizing to NOT_PRESENT");


### PR DESCRIPTION
It should only be disabled by users that have problems with it. Anyone using Heltec v4.3 and not setting it explicitly will have bad RX.

Get firmware here:

- [UPDATE BIN](https://x230.weebl.me/public/firmware-heltec-v4-2.7.21.ce37a6e.bin)
- [FACTORY ERASE BIN](https://x230.weebl.me/public/firmware-heltec-v4-2.7.21.ce37a6e.factory.bin)