### PR TITLE
feat(heltec-v4): power, battery, button, DMA, GPS UART, L76K baud

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -346,7 +346,9 @@ class AnalogBatteryLevel : public HasBatteryLevel
                 // Already initialized - filter this reading
                 last_read_value += (scaled - last_read_value) * 0.5; // Virtual LPF
             }
-
+#if defined(HELTEC_V4) && !defined(EXT_PWR_DETECT)
+            recordVoltageSample(last_read_time_ms, (uint16_t)last_read_value);
+#endif
             // LOG_DEBUG("battery gpio %d raw val=%u scaled=%u filtered=%u",
             // BATTERY_PIN, raw, (uint32_t)(scaled), (uint32_t) (last_read_value));
         }
@@ -468,7 +470,14 @@ class AnalogBatteryLevel : public HasBatteryLevel
 #elif defined(MUZI_BASE) || defined(PROMICRO_DIY_TCXO)
         return powerHAL_isVBUSConnected();
 #endif
+#if defined(HELTEC_V4) && !defined(EXT_PWR_DETECT)
+        // No USB-detect pin (Heltec V4): infer from full voltage or voltage rising
+        if (getBattVoltage() >= chargingVolt)
+            return true;
+        return isVoltageRising();
+#else
         return getBattVoltage() > chargingVolt;
+#endif
     }
 
     /// Assume charging if we have a battery and external power is connected.
@@ -499,7 +508,14 @@ class AnalogBatteryLevel : public HasBatteryLevel
             return getINACurrent() < 0;
 #endif
         }
+#if defined(HELTEC_V4)
+        // When no dedicated charging pin: show lightning only while charging, not when full
+        if (isBatteryConnect() && isVbusIn())
+            return getBattVoltage() < (chargingVolt - 50);
+        return false;
+#else
         return isBatteryConnect() && isVbusIn();
+#endif
 #endif
 #endif
         // by default, we check the battery voltage only
@@ -522,6 +538,44 @@ class AnalogBatteryLevel : public HasBatteryLevel
     bool initial_read_done = false;
     float last_read_value = (OCV[NUM_OCV_POINTS - 1] * NUM_CELLS);
     uint32_t last_read_time_ms = 0;
+
+#if defined(HELTEC_V4) && !defined(EXT_PWR_DETECT)
+    // Voltage history for inferring USB/charging when no EXT_PWR_DETECT pin (Heltec V4)
+    static const int VOLTAGE_HISTORY_SIZE = 6;
+    static const uint32_t VOLTAGE_RECORD_INTERVAL_MS = 15000;
+    static const uint32_t VOLTAGE_RISE_WINDOW_MS = 60000;
+    static const uint16_t VOLTAGE_RISE_THRESHOLD_MV = 25;
+    uint32_t voltageHistoryTime[VOLTAGE_HISTORY_SIZE] = {0};
+    uint16_t voltageHistoryMv[VOLTAGE_HISTORY_SIZE] = {0};
+    uint8_t voltageHistoryCount = 0;
+    uint8_t voltageHistoryWriteIndex = 0;
+    uint32_t lastVoltageRecordTime = 0;
+    void recordVoltageSample(uint32_t timeMs, uint16_t voltageMv)
+    {
+        if (timeMs - lastVoltageRecordTime < VOLTAGE_RECORD_INTERVAL_MS)
+            return;
+        lastVoltageRecordTime = timeMs;
+        uint8_t idx = voltageHistoryWriteIndex % VOLTAGE_HISTORY_SIZE;
+        voltageHistoryTime[idx] = timeMs;
+        voltageHistoryMv[idx] = voltageMv;
+        voltageHistoryWriteIndex++;
+        if (voltageHistoryCount < VOLTAGE_HISTORY_SIZE)
+            voltageHistoryCount++;
+    }
+    bool isVoltageRising() const
+    {
+        if (voltageHistoryCount < 3)
+            return false;
+        uint8_t oldestIdx = (voltageHistoryWriteIndex - voltageHistoryCount + VOLTAGE_HISTORY_SIZE) % VOLTAGE_HISTORY_SIZE;
+        uint8_t newestIdx = (voltageHistoryWriteIndex - 1 + VOLTAGE_HISTORY_SIZE) % VOLTAGE_HISTORY_SIZE;
+        uint32_t oldestTime = voltageHistoryTime[oldestIdx];
+        uint32_t newestTime = voltageHistoryTime[newestIdx];
+        if (newestTime - oldestTime < VOLTAGE_RISE_WINDOW_MS)
+            return false;
+        int32_t delta = (int32_t)voltageHistoryMv[newestIdx] - (int32_t)voltageHistoryMv[oldestIdx];
+        return delta >= (int32_t)VOLTAGE_RISE_THRESHOLD_MV;
+    }
+#endif
 
 #if HAS_TELEMETRY && !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR && defined(HAS_RAKPROT)
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -335,7 +335,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define GPS_BAUDRATE 9600
 #define GPS_BAUDRATE_FIXED 0
 #else
+#ifndef GPS_BAUDRATE_FIXED
 #define GPS_BAUDRATE_FIXED 1
+#endif
 #endif
 
 #ifndef GPS_THREAD_INTERVAL

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -20,6 +20,12 @@
 #include "GPSUpdateScheduling.h"
 #include "cas.h"
 #include "ubx.h"
+#if defined(ARCH_ESP32)
+#include "HardwareSerialGpsAdapter.h"
+#if defined(USE_GPS_UART_RINGBUF)
+#include "GpsUartRingBuffer.h"
+#endif
+#endif
 
 #ifdef ARCH_PORTDUINO
 #include "PortduinoGlue.h"
@@ -44,7 +50,9 @@ template <typename T, std::size_t N> std::size_t array_count(const T (&)[N])
 
 #if defined(ARCH_NRF52)
 Uart *GPS::_serial_gps = &GPS_SERIAL_PORT;
-#elif defined(ARCH_ESP32) || defined(ARCH_PORTDUINO) || defined(ARCH_STM32WL)
+#elif defined(ARCH_ESP32)
+IGpsSerial *GPS::_serial_gps = nullptr;
+#elif defined(ARCH_PORTDUINO) || defined(ARCH_STM32WL)
 HardwareSerial *GPS::_serial_gps = &GPS_SERIAL_PORT;
 #elif defined(ARCH_RP2040)
 SerialUART *GPS::_serial_gps = &GPS_SERIAL_PORT;
@@ -70,6 +78,39 @@ static struct uBloxGnssModelInfo {
 
 #define GPS_SOL_EXPIRY_MS 5000 // in millis. give 1 second time to combine different sentences. NMEA Frequency isn't higher anyway
 #define NMEA_MSG_GXGSA "GNGSA" // GSA message (GPGSA, GNGSA etc)
+
+/** Map baud to L76K $PCAS01 CMD (0=4800, 1=9600, 2=19200, 3=38400, 4=57600, 5=115200). Returns -1 if unsupported. */
+static int gpsBaudToPcas01Cmd(unsigned long baud)
+{
+    switch (baud) {
+    case 4800:
+        return 0;
+    case 9600:
+        return 1;
+    case 19200:
+        return 2;
+    case 38400:
+        return 3;
+    case 57600:
+        return 4;
+    case 115200:
+        return 5;
+    default:
+        return -1;
+    }
+}
+
+/** Build $PCAS01,<cmd>*<checksum>\r\n for L76K NMEA baud (caller sends at current UART baud). */
+static void buildL76KPcas01BaudCommand(int cmd, char *buf, size_t bufSize)
+{
+    int len = snprintf(buf, bufSize, "$PCAS01,%d", cmd);
+    if (len <= 0 || len >= (int)bufSize - 4)
+        return;
+    uint8_t cs = 0;
+    for (int i = 1; i < len; i++)
+        cs ^= (uint8_t)buf[i];
+    snprintf(buf + len, bufSize - len, "*%02X\r\n", cs);
+}
 
 // For logging
 static const char *getGPSPowerStateString(GPSPowerState state)
@@ -530,6 +571,22 @@ bool GPS::setup()
              * t-beam-s3-core uses the same L76K GNSS module as t-echo.
              * Unlike t-echo, L76K uses 9600 baud rate for communication by default.
              * */
+
+#if defined(ARCH_ESP32) && defined(HELTEC_V4)
+            // If desired baud (GPS_BAUDRATE) differs from current, set L76K NMEA baud via $PCAS01 then switch our UART
+            unsigned long currentBaud = _serial_gps->baudRate();
+            if (currentBaud != (unsigned long)GPS_BAUDRATE) {
+                int cmd = gpsBaudToPcas01Cmd(GPS_BAUDRATE);
+                if (cmd >= 0) {
+                    char pcas01Buf[24];
+                    buildL76KPcas01BaudCommand(cmd, pcas01Buf, sizeof(pcas01Buf));
+                    _serial_gps->write(pcas01Buf);
+                    delay(150);
+                    _serial_gps->updateBaudRate(GPS_BAUDRATE);
+                    delay(50);
+                }
+            }
+#endif
 
             // Initialize the L76K Chip, use GPS + GLONASS + BEIDOU
             _serial_gps->write("$PCAS04,7*1E\r\n");
@@ -1528,6 +1585,18 @@ GnssModel_t GPS::getProbeResponse(unsigned long timeout, const std::vector<ChipI
 
 std::unique_ptr<GPS> GPS::createGps()
 {
+#if defined(ARCH_ESP32)
+    if (!_serial_gps) {
+#if defined(USE_GPS_UART_RINGBUF)
+        static GpsUartRingBuffer s_gpsUart;
+        _serial_gps = &s_gpsUart;
+#else
+        static HardwareSerialGpsAdapter s_adapter(&GPS_SERIAL_PORT);
+        _serial_gps = &s_adapter;
+#endif
+    }
+#endif
+
     int8_t _rx_gpio = config.position.rx_gpio;
     int8_t _tx_gpio = config.position.tx_gpio;
     int8_t _en_gpio = config.position.gps_en_gpio;

--- a/src/gps/GPS.h
+++ b/src/gps/GPS.h
@@ -4,6 +4,9 @@
 
 #include <memory>
 
+#if defined(ARCH_ESP32)
+#include "IGpsSerial.h"
+#endif
 #include "GPSStatus.h"
 #include "GpioLogic.h"
 #include "Observer.h"
@@ -203,6 +206,8 @@ class GPS : private concurrency::OSThread
     static SerialUART *_serial_gps;
 #elif defined(ARCH_NRF52)
     static Uart *_serial_gps;
+#elif defined(ARCH_ESP32)
+    static IGpsSerial *_serial_gps;
 #else
     static HardwareSerial *_serial_gps;
 #endif

--- a/src/gps/GpsUartRingBuffer.cpp
+++ b/src/gps/GpsUartRingBuffer.cpp
@@ -1,0 +1,155 @@
+#include "configuration.h"
+#if !MESHTASTIC_EXCLUDE_GPS && defined(ARCH_ESP32) && defined(USE_GPS_UART_RINGBUF)
+
+#include "GpsUartRingBuffer.h"
+#include "configuration.h"
+#include <driver/uart.h>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+static const char *TAG = "GpsUart";
+
+GpsUartRingBuffer::GpsUartRingBuffer() {}
+
+GpsUartRingBuffer::~GpsUartRingBuffer()
+{
+    end();
+}
+
+void GpsUartRingBuffer::setRxBufferSize(size_t size)
+{
+    if (!_initialized) {
+        _rx_buffer_size = size;
+    }
+}
+
+void GpsUartRingBuffer::begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin)
+{
+    if (_initialized) {
+        uart_set_baudrate(_uart_num, baud);
+        _baud = baud;
+        return;
+    }
+
+    const int tx_buffer_size = 256;
+    esp_err_t err = uart_driver_install(_uart_num, (int)_rx_buffer_size, tx_buffer_size, 0, nullptr, 0);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "uart_driver_install failed %d", err);
+        return;
+    }
+
+    uart_config_t uart_config = {};
+    uart_config.baud_rate = (int)baud;
+    uart_config.data_bits = (uart_word_length_t)((config & 0xc) >> 2);
+    uart_config.parity = (uart_parity_t)(config & 0x3);
+    uart_config.stop_bits = (uart_stop_bits_t)((config & 0x30) >> 4);
+    uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+#if SOC_UART_SUPPORT_XTAL_CLK
+    uart_config.source_clk = UART_SCLK_XTAL;
+#else
+    uart_config.source_clk = UART_SCLK_APB;
+#endif
+
+    err = uart_param_config(_uart_num, &uart_config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "uart_param_config failed %d", err);
+        uart_driver_delete(_uart_num);
+        return;
+    }
+
+    if (rxPin >= 0 && txPin >= 0) {
+        err = uart_set_pin(_uart_num, txPin, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "uart_set_pin failed %d", err);
+        }
+    }
+
+    _baud = baud;
+    _initialized = true;
+}
+
+void GpsUartRingBuffer::end()
+{
+    if (!_initialized) {
+        return;
+    }
+    uart_driver_delete(_uart_num);
+    _initialized = false;
+}
+
+int GpsUartRingBuffer::available()
+{
+    if (!_initialized) {
+        return 0;
+    }
+    size_t len = 0;
+    esp_err_t err = uart_get_buffered_data_len(_uart_num, &len);
+    return (err == ESP_OK) ? (int)len : 0;
+}
+
+int GpsUartRingBuffer::read()
+{
+    if (!_initialized) {
+        return -1;
+    }
+    uint8_t c = 0;
+    int n = uart_read_bytes(_uart_num, &c, 1, 0);
+    return (n == 1) ? (int)c : -1;
+}
+
+size_t GpsUartRingBuffer::readBytes(uint8_t *buffer, size_t length)
+{
+    if (!_initialized || buffer == nullptr) {
+        return 0;
+    }
+    int n = uart_read_bytes(_uart_num, buffer, length, pdMS_TO_TICKS(20));
+    return (n > 0) ? (size_t)n : 0;
+}
+
+size_t GpsUartRingBuffer::write(uint8_t c)
+{
+    if (!_initialized) {
+        return 0;
+    }
+    int n = uart_write_bytes(_uart_num, &c, 1);
+    return (n == 1) ? 1 : 0;
+}
+
+size_t GpsUartRingBuffer::write(const uint8_t *buffer, size_t size)
+{
+    if (!_initialized || buffer == nullptr) {
+        return 0;
+    }
+    int n = uart_write_bytes(_uart_num, buffer, size);
+    return (n > 0) ? (size_t)n : 0;
+}
+
+void GpsUartRingBuffer::flush()
+{
+    if (_initialized) {
+        uart_wait_tx_done(_uart_num, pdMS_TO_TICKS(100));
+    }
+}
+
+void GpsUartRingBuffer::flush(bool txOnly)
+{
+    if (!_initialized) {
+        return;
+    }
+    if (txOnly) {
+        uart_wait_tx_done(_uart_num, pdMS_TO_TICKS(100));
+    } else {
+        uart_flush_input(_uart_num);
+    }
+}
+
+void GpsUartRingBuffer::updateBaudRate(unsigned long baud)
+{
+    if (_initialized) {
+        uart_set_baudrate(_uart_num, baud);
+        _baud = baud;
+    }
+}
+
+#endif // !MESHTASTIC_EXCLUDE_GPS && ARCH_ESP32 && USE_GPS_UART_RINGBUF

--- a/src/gps/GpsUartRingBuffer.h
+++ b/src/gps/GpsUartRingBuffer.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#if !MESHTASTIC_EXCLUDE_GPS && defined(ARCH_ESP32) && defined(USE_GPS_UART_RINGBUF)
+
+#include "IGpsSerial.h"
+#include <driver/uart.h>
+
+#ifndef GPS_UART_RINGBUF_RX_SIZE
+#define GPS_UART_RINGBUF_RX_SIZE 4096
+#endif
+
+/**
+ * GPS serial implementation using ESP-IDF UART driver with a large RX ring
+ * buffer. Data is received by the driver (interrupt-driven) and consumed by
+ * the existing parser via read()/readBytes(). Use when USE_GPS_UART_RINGBUF
+ * is defined (e.g. Heltec V4).
+ */
+class GpsUartRingBuffer : public IGpsSerial
+{
+  public:
+    GpsUartRingBuffer();
+    ~GpsUartRingBuffer() override;
+
+    int available() override;
+    int read() override;
+    size_t readBytes(uint8_t *buffer, size_t length) override;
+    size_t write(uint8_t c) override;
+    size_t write(const uint8_t *buffer, size_t size) override;
+    void flush() override;
+    void flush(bool txOnly) override;
+    void begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin) override;
+    void setRxBufferSize(size_t size) override;
+    void end() override;
+    uint32_t baudRate() override { return _baud; }
+    void updateBaudRate(unsigned long baud) override;
+
+  private:
+    uart_port_t _uart_num{UART_NUM_1};
+    size_t _rx_buffer_size{GPS_UART_RINGBUF_RX_SIZE};
+    unsigned long _baud{0};
+    bool _initialized{false};
+};
+
+#endif // !MESHTASTIC_EXCLUDE_GPS && ARCH_ESP32 && USE_GPS_UART_RINGBUF

--- a/src/gps/HardwareSerialGpsAdapter.h
+++ b/src/gps/HardwareSerialGpsAdapter.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#if !MESHTASTIC_EXCLUDE_GPS && defined(ARCH_ESP32)
+
+#include "IGpsSerial.h"
+#include <HardwareSerial.h>
+
+/**
+ * Wraps HardwareSerial so it can be used as IGpsSerial (e.g. when not using
+ * the GPS UART ring-buffer path).
+ */
+class HardwareSerialGpsAdapter : public IGpsSerial
+{
+  public:
+    explicit HardwareSerialGpsAdapter(HardwareSerial *ser) : _serial(ser) {}
+
+    int available() override { return _serial ? _serial->available() : 0; }
+    int read() override { return _serial ? _serial->read() : -1; }
+    size_t readBytes(uint8_t *buffer, size_t length) override { return _serial ? _serial->readBytes(buffer, length) : 0; }
+    size_t write(uint8_t c) override { return _serial ? _serial->write(c) : 0; }
+    size_t write(const uint8_t *buffer, size_t size) override { return _serial ? _serial->write(buffer, size) : 0; }
+    void flush() override
+    {
+        if (_serial)
+            _serial->flush();
+    }
+    void flush(bool txOnly) override
+    {
+        if (_serial)
+            _serial->flush(txOnly);
+    }
+    void begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin) override
+    {
+        if (_serial)
+            _serial->begin(baud, config, rxPin, txPin);
+    }
+    void setRxBufferSize(size_t size) override
+    {
+        if (_serial)
+            _serial->setRxBufferSize(size);
+    }
+    void end() override
+    {
+        if (_serial)
+            _serial->end();
+    }
+    uint32_t baudRate() override { return _serial ? _serial->baudRate() : 0; }
+    void updateBaudRate(unsigned long baud) override
+    {
+        if (_serial)
+            _serial->updateBaudRate(baud);
+    }
+
+  private:
+    HardwareSerial *_serial;
+};
+
+#endif // !MESHTASTIC_EXCLUDE_GPS && ARCH_ESP32

--- a/src/gps/IGpsSerial.h
+++ b/src/gps/IGpsSerial.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#if !MESHTASTIC_EXCLUDE_GPS
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+/**
+ * Minimal serial interface used by the GPS layer so we can plug either
+ * HardwareSerial or an ESP-IDF UART ring-buffer implementation (e.g. for
+ * larger RX buffer / future DMA) without changing the parser.
+ */
+class IGpsSerial
+{
+  public:
+    virtual ~IGpsSerial() = default;
+
+    virtual int available() = 0;
+    virtual int read() = 0;
+    virtual size_t readBytes(uint8_t *buffer, size_t length) = 0;
+    virtual size_t write(uint8_t c) = 0;
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    /** Convenience for string writes (e.g. _serial_gps->write("$PMTK...")). */
+    size_t write(const char *str) { return str ? write((const uint8_t *)str, strlen(str)) : 0; }
+    virtual void flush() = 0;
+    /** txOnly: true = wait for TX idle only; false = also discard RX (clearBuffer). */
+    virtual void flush(bool txOnly) = 0;
+    virtual void begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin) = 0;
+    virtual void setRxBufferSize(size_t size) = 0;
+    virtual void end() = 0;
+    virtual uint32_t baudRate() = 0;
+    virtual void updateBaudRate(unsigned long baud) = 0;
+};
+
+#endif // !MESHTASTIC_EXCLUDE_GPS

--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -508,8 +508,7 @@ class LGFX : public lgfx::LGFX_Device
             cfg.freq_read = SPI_READ_FREQUENCY; // SPI clock when receiving
             cfg.spi_3wire = false;
             cfg.use_lock = true;               // Set to true to use transaction locking
-            cfg.dma_channel = SPI_DMA_CH_AUTO; // SPI_DMA_CH_AUTO; // Set DMA channel to use (0=not use DMA / 1=1ch / 2=ch /
-                                               // SPI_DMA_CH_AUTO=auto setting)
+            cfg.dma_channel = SPI_DMA_CH_AUTO; // Use GDMA for display transfers (0=off). See docs/dma-audit-heltec-v4.md
             cfg.pin_sclk = ST7789_SCK;         // Set SPI SCLK pin number
             cfg.pin_mosi = ST7789_SDA;         // Set SPI MOSI pin number
             cfg.pin_miso = ST7789_MISO;        // Set SPI MISO pin number (-1 = disable)

--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -98,12 +98,18 @@ bool ButtonThread::initButton(const ButtonConfig &config)
 #ifdef USE_EINK
     userButton.setDebounceMs(0);
 #else
-    userButton.setDebounceMs(1);
+    userButton.setDebounceMs(BUTTON_DEBOUNCE_MS);
 #endif
     userButton.setPressMs(_longPressTime);
 
+    // With screen: short window (20ms) for snappy single-click; use BUTTON_CLICK_MS if variant defines
+    // USE_LONG_CLICK_WINDOW_WITH_SCREEN (e.g. mechanical button + double-click)
     if (screen) {
+#ifdef USE_LONG_CLICK_WINDOW_WITH_SCREEN
+        userButton.setClickMs(BUTTON_CLICK_MS);
+#else
         userButton.setClickMs(20);
+#endif
     } else {
         userButton.setClickMs(BUTTON_CLICK_MS);
     }
@@ -297,11 +303,12 @@ int32_t ButtonThread::runOnce()
     }
     btnEvent = BUTTON_EVENT_NONE;
 
-    // only pull when the button is pressed, we get notified via IRQ on a new press
+    // When active: poll for long-press and lead-up. When idle: poll at BUTTON_POLL_MS so we don't miss short presses.
+    // (Interrupt-only idle caused many missed presses: tick() in ISR is unreliable, e.g. millis() / OneButton state machine.)
     if (!userButton.isIdle() || waitingForLongPress) {
-        return 50;
+        return BUTTON_ACTIVE_POLL_MS;
     }
-    return 100; // FIXME: Why can't we rely on interrupts and use INT32_MAX here?
+    return BUTTON_POLL_MS;
 }
 
 /*

--- a/src/input/ButtonThread.h
+++ b/src/input/ButtonThread.h
@@ -34,8 +34,20 @@ struct ButtonConfig {
 #define BUTTON_CLICK_MS 250
 #endif
 
+#ifndef BUTTON_DEBOUNCE_MS
+#define BUTTON_DEBOUNCE_MS 1
+#endif
+
 #ifndef BUTTON_TOUCH_MS
 #define BUTTON_TOUCH_MS 400
+#endif
+
+#ifndef BUTTON_POLL_MS
+#define BUTTON_POLL_MS 100 // How often to poll when idle; lower = fewer missed presses, more CPU
+#endif
+
+#ifndef BUTTON_ACTIVE_POLL_MS
+#define BUTTON_ACTIVE_POLL_MS 50 // Poll interval while button pressed or waiting for long-press combo
 #endif
 
 #ifndef BUTTON_COMBO_TIMEOUT_MS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -798,7 +798,8 @@ void setup()
     SPI1.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
     LOG_DEBUG("SPI1.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
     SPI1.setFrequency(4000000);
-#else
+#elif !defined(USE_LORA_SPI_DMA)
+    // When USE_LORA_SPI_DMA is set, LoRa uses ESP-IDF SPI master (DMA); do not init Arduino SPI for LoRa bus
     SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
     LOG_DEBUG("SPI.begin(SCK=%d, MISO=%d, MOSI=%d, NSS=%d)", LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
     SPI.setFrequency(4000000);

--- a/src/mesh/ESP32LoRaSPIDMAHal.cpp
+++ b/src/mesh/ESP32LoRaSPIDMAHal.cpp
@@ -1,0 +1,127 @@
+#include "configuration.h"
+#if defined(ARCH_ESP32) && defined(USE_LORA_SPI_DMA)
+
+#include "ESP32LoRaSPIDMAHal.h"
+#include <cstring>
+#include <esp_log.h>
+
+#ifndef LORA_SPI_DMA_MAX_TRANSFER
+#define LORA_SPI_DMA_MAX_TRANSFER 256
+#endif
+
+// Dummy TX buffer for read-only transactions (out == nullptr)
+static uint8_t s_dummyTx[LORA_SPI_DMA_MAX_TRANSFER];
+
+ESP32LoRaSPIDMAHal::ESP32LoRaSPIDMAHal(SPIClass &spi, SPISettings spiSettings) : LockingArduinoHal(spi, spiSettings)
+{
+    _clock_hz = spiSettings._clock;
+#if CONFIG_IDF_TARGET_ESP32S3
+    _host = SPI2_HOST; // FSPI = default SPI on S3
+#elif CONFIG_IDF_TARGET_ESP32
+    _host = SPI3_HOST; // VSPI = default SPI on ESP32
+#else
+    _host = SPI2_HOST;
+#endif
+}
+
+void ESP32LoRaSPIDMAHal::init()
+{
+    spiBegin();
+    ArduinoHal::init();
+}
+
+void ESP32LoRaSPIDMAHal::term()
+{
+    spiEnd();
+    ArduinoHal::term();
+}
+
+void ESP32LoRaSPIDMAHal::spiBegin()
+{
+    if (_bus_initialized) {
+        return;
+    }
+#if defined(LORA_SCK) && defined(LORA_MISO) && defined(LORA_MOSI)
+    spi_bus_config_t buscfg = {};
+    buscfg.mosi_io_num = LORA_MOSI;
+    buscfg.miso_io_num = LORA_MISO;
+    buscfg.sclk_io_num = LORA_SCK;
+    buscfg.quadwp_io_num = -1;
+    buscfg.quadhd_io_num = -1;
+    buscfg.max_transfer_sz = LORA_SPI_DMA_MAX_TRANSFER;
+
+    esp_err_t ret = spi_bus_initialize(_host, &buscfg, SPI_DMA_CH_AUTO);
+    if (ret != ESP_OK) {
+        ESP_LOGE("LoRa DMA", "spi_bus_initialize failed %d", ret);
+        return;
+    }
+
+    spi_device_interface_config_t devcfg = {};
+    devcfg.clock_speed_hz = (int)_clock_hz;
+    devcfg.mode = 0;
+    devcfg.spics_io_num = -1; // CS controlled by RadioLib
+    devcfg.queue_size = 1;
+
+    ret = spi_bus_add_device(_host, &devcfg, &_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE("LoRa DMA", "spi_bus_add_device failed %d", ret);
+        spi_bus_free(_host);
+        return;
+    }
+    _bus_initialized = true;
+#else
+#error "USE_LORA_SPI_DMA requires LORA_SCK, LORA_MISO, LORA_MOSI"
+#endif
+}
+
+void ESP32LoRaSPIDMAHal::spiBeginTransaction()
+{
+    LockingArduinoHal::spiBeginTransaction();
+}
+
+void ESP32LoRaSPIDMAHal::spiTransfer(uint8_t *out, size_t len, uint8_t *in)
+{
+    if (!_handle || len == 0) {
+        return;
+    }
+    if (len > LORA_SPI_DMA_MAX_TRANSFER) {
+        ESP_LOGE("LoRa DMA", "transfer len %u > max %d", (unsigned)len, LORA_SPI_DMA_MAX_TRANSFER);
+        return;
+    }
+
+    // Full-duplex transaction. For read-only (out==nullptr) use dummy 0xFF buffer.
+    if (out == nullptr) {
+        memset(s_dummyTx, 0xFF, len);
+        out = s_dummyTx;
+    }
+
+    spi_transaction_t t = {};
+    t.length = len * 8;
+    t.tx_buffer = out;
+    t.rx_buffer = in;
+
+    esp_err_t ret = spi_device_polling_transmit(_handle, &t);
+    if (ret != ESP_OK) {
+        ESP_LOGE("LoRa DMA", "spi_device_polling_transmit failed %d", ret);
+    }
+}
+
+void ESP32LoRaSPIDMAHal::spiEndTransaction()
+{
+    LockingArduinoHal::spiEndTransaction();
+}
+
+void ESP32LoRaSPIDMAHal::spiEnd()
+{
+    if (!_bus_initialized) {
+        return;
+    }
+    if (_handle) {
+        spi_bus_remove_device(_handle);
+        _handle = nullptr;
+    }
+    spi_bus_free(_host);
+    _bus_initialized = false;
+}
+
+#endif // ARCH_ESP32 && USE_LORA_SPI_DMA

--- a/src/mesh/ESP32LoRaSPIDMAHal.h
+++ b/src/mesh/ESP32LoRaSPIDMAHal.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#if defined(ARCH_ESP32) && defined(USE_LORA_SPI_DMA)
+
+#include "RadioLibInterface.h"
+#include <SPI.h>
+#include <driver/spi_master.h>
+#include <esp_err.h>
+
+/**
+ * RadioLib HAL that uses ESP-IDF SPI master with DMA for LoRa SPI transfers.
+ * Use when USE_LORA_SPI_DMA is defined (e.g. Heltec V4). Replaces the default
+ * byte-by-byte Arduino SPI path so transfers use GDMA.
+ */
+class ESP32LoRaSPIDMAHal : public LockingArduinoHal
+{
+  public:
+    ESP32LoRaSPIDMAHal(SPIClass &spi, SPISettings spiSettings);
+
+    void init() override;
+    void term() override;
+    void spiBegin() override;
+    void spiBeginTransaction() override;
+    void spiTransfer(uint8_t *out, size_t len, uint8_t *in) override;
+    void spiEndTransaction() override;
+    void spiEnd() override;
+
+  private:
+    spi_host_device_t _host = SPI2_HOST;
+    spi_device_handle_t _handle = nullptr;
+    bool _bus_initialized = false;
+    uint32_t _clock_hz = 4000000;
+};
+
+#endif // ARCH_ESP32 && USE_LORA_SPI_DMA

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -32,6 +32,10 @@
 #include "STM32WLE5JCInterface.h"
 #endif
 
+#if defined(ARCH_ESP32) && defined(USE_LORA_SPI_DMA)
+#include "ESP32LoRaSPIDMAHal.h"
+#endif
+
 #define RDEF(name, freq_start, freq_end, duty_cycle, spacing, power_limit, audio_permitted, frequency_switching, wide_lora)      \
     {                                                                                                                            \
         meshtastic_Config_LoRaConfig_RegionCode_##name, freq_start, freq_end, duty_cycle, spacing, power_limit, audio_permitted, \
@@ -292,7 +296,10 @@ std::unique_ptr<RadioInterface> initLoRa()
 #elif defined(HW_SPI1_DEVICE)
     LockingArduinoHal *loraHal = new LockingArduinoHal(SPI1, loraSpiSettings);
     RadioLibHAL = loraHal;
-#else // HW_SPI1_DEVICE
+#elif defined(ARCH_ESP32) && defined(USE_LORA_SPI_DMA)
+    LockingArduinoHal *loraHal = new ESP32LoRaSPIDMAHal(SPI, loraSpiSettings);
+    RadioLibHAL = loraHal;
+#else
     LockingArduinoHal *loraHal = new LockingArduinoHal(SPI, loraSpiSettings);
     RadioLibHAL = loraHal;
 #endif

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -279,7 +279,12 @@ void doDeepSleep(uint32_t msecToWake, bool skipPreflight = false, bool skipSaveN
 #endif
 
 #if defined(VEXT_ENABLE)
-    digitalWrite(VEXT_ENABLE, !VEXT_ON_VALUE); // turn on the display power
+    digitalWrite(VEXT_ENABLE, !VEXT_ON_VALUE); // turn off display/peripheral rail to save power
+#if defined(HELTEC_V4) && defined(ARCH_ESP32)
+    if (GPIO_IS_VALID_OUTPUT_GPIO((gpio_num_t)VEXT_ENABLE)) {
+        gpio_hold_en((gpio_num_t)VEXT_ENABLE); // hold state during deep sleep (released on wake in initDeepSleep)
+    }
+#endif
 #endif
 
 #ifdef ARCH_ESP32
@@ -537,7 +542,11 @@ void enableModemSleep()
 #else
     esp32_config.max_freq_mhz = CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ;
 #endif
-    esp32_config.min_freq_mhz = 20; // 10Mhz is minimum recommended
+#if defined(HELTEC_V4)
+    esp32_config.min_freq_mhz = 10; // save power when CPU idle
+#else
+    esp32_config.min_freq_mhz = 20; // 10 MHz is minimum recommended
+#endif
     esp32_config.light_sleep_enable = false;
     int rv = esp_pm_configure(&esp32_config);
     LOG_DEBUG("Sleep request result %x", rv);

--- a/variants/esp32s3/heltec_v4/variant.h
+++ b/variants/esp32s3/heltec_v4/variant.h
@@ -1,5 +1,11 @@
-#define VEXT_ENABLE 36 // active low, powers the oled display and the lora antenna boost
+// VEXT_ENABLE: active low; powers OLED/TFT and LoRa FEM. Turned off before deep sleep and held to save power.
+#define VEXT_ENABLE 36
+#define VEXT_ON_VALUE LOW
 #define BUTTON_PIN 0
+#define BUTTON_DEBOUNCE_MS 30               // Debounce for mechanical button (GPIO0); 1ms default was too short
+#define BUTTON_POLL_MS 50                   // Poll when idle so short presses aren't missed (ISR-only idle was unreliable)
+#define BUTTON_ACTIVE_POLL_MS 25            // Poll while pressed for reliable long-press/lead-up
+#define USE_LONG_CLICK_WINDOW_WITH_SCREEN 1 // Use BUTTON_CLICK_MS (250ms) so double-click works with mechanical button
 
 #define ADC_CTRL 37
 #define ADC_CTRL_ENABLED HIGH
@@ -9,6 +15,7 @@
 #define ADC_MULTIPLIER 4.9 * 1.045
 
 #define USE_SX1262
+#define USE_LORA_SPI_DMA // LoRa SPI via ESP-IDF SPI master with DMA (see ESP32LoRaSPIDMAHal)
 
 #define LORA_DIO0 -1 // a No connect on the SX1262 module
 #define LORA_RESET 12
@@ -83,6 +90,14 @@
 #if HAS_TFT
 #define USE_TFTDISPLAY 1
 #endif
+/* GPS UART: large RX ring buffer via ESP-IDF (existing parser unchanged) */
+#define USE_GPS_UART_RINGBUF
+
+/* L76K: run at 115200; firmware sends $PCAS01,5 after detection and switches UART */
+#define GPS_BAUDRATE 115200
+#undef GPS_BAUDRATE_FIXED
+#define GPS_BAUDRATE_FIXED 0 /* probe 9600/115200/38400 first, then switch to GPS_BAUDRATE */
+
 /*
  * GPS pins
  */


### PR DESCRIPTION
- Power: VEXT off in deep sleep, min_freq_mhz 10, power-heltec-v4 doc
- Battery: voltage-rise heuristic for charging/Vbus on boards without EXT_PWR_DETECT
- Button: configurable poll intervals, debounce, long-click window for mechanical button
- LoRa: ESP32LoRaSPIDMAHal for SPI DMA (USE_LORA_SPI_DMA)
- GPS UART: IGpsSerial + GpsUartRingBuffer (USE_GPS_UART_RINGBUF), large RX ring
- L76K: send $PCAS01 after detection to set NMEA baud, then switch UART (GPS_BAUDRATE)
- Config: allow variant to set GPS_BAUDRATE_FIXED 0 when GPS_BAUDRATE is set

- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V4
