### PR TITLE
Ensure infrastructure role-based minimums are coerced since they don't have scaling

### DIFF
--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -13,12 +13,12 @@
 #define TEN_SECONDS_MS 10 * 1000
 #define MAX_INTERVAL INT32_MAX // FIXME: INT32_MAX to avoid overflow issues with Apple clients but should be UINT32_MAX
 
-#define min_default_telemetry_interval_secs 30 * 60
+#define min_default_telemetry_interval_secs IF_ROUTER(ONE_DAY / 2, 30 * 60)
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
 #define default_telemetry_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define default_broadcast_smart_minimum_interval_secs 5 * 60
-#define min_default_broadcast_interval_secs 60 * 60
+#define min_default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
 #define min_default_broadcast_smart_minimum_interval_secs 5 * 60
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)
 #define default_sds_secs IF_ROUTER(ONE_DAY, UINT32_MAX) // Default to forever super deep sleep

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -322,9 +322,9 @@ NodeDB::NodeDB()
     // config.network.enabled_protocols = meshtastic_Config_NetworkConfig_ProtocolFlags_UDP_BROADCAST;
 
     // If we are setup to broadcast on any default channel slot (with default frequency slot semantics),
-    // ensure that the telemetry intervals are coerced to the minimum value of 30 minutes or more.
+    // ensure that the telemetry intervals are coerced to the role-aware minimum value.
     if (channels.hasDefaultChannel()) {
-        LOG_DEBUG("Coerce telemetry to min of 30 minutes on defaults");
+        LOG_DEBUG("Coerce telemetry to role-aware minimum on defaults");
         moduleConfig.telemetry.device_update_interval = Default::getConfiguredOrMinimumValue(
             moduleConfig.telemetry.device_update_interval, min_default_telemetry_interval_secs);
         moduleConfig.telemetry.environment_update_interval = Default::getConfiguredOrMinimumValue(
@@ -347,7 +347,7 @@ NodeDB::NodeDB()
         }
     }
     if (positionUsesDefaultChannel) {
-        LOG_DEBUG("Coerce position broadcasts to min of 1 hour and smart broadcast min of 5 minutes on defaults");
+        LOG_DEBUG("Coerce position broadcasts to role-aware minimum and smart broadcast min of 5 minutes on defaults");
         config.position.position_broadcast_secs =
             Default::getConfiguredOrMinimumValue(config.position.position_broadcast_secs, min_default_broadcast_interval_secs);
         config.position.broadcast_smart_minimum_interval_secs = Default::getConfiguredOrMinimumValue(

--- a/test/test_default/test_main.cpp
+++ b/test/test_default/test_main.cpp
@@ -93,6 +93,39 @@ void test_client_medium_fast_preset_scaling()
     TEST_ASSERT_INT_WITHIN(1, expected, res);
 }
 
+void test_router_uses_router_minimums()
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER;
+
+    uint32_t telemetry = Default::getConfiguredOrMinimumValue(60, min_default_telemetry_interval_secs);
+    uint32_t position = Default::getConfiguredOrMinimumValue(60, min_default_broadcast_interval_secs);
+
+    TEST_ASSERT_EQUAL_UINT32(ONE_DAY / 2, telemetry);
+    TEST_ASSERT_EQUAL_UINT32(ONE_DAY / 2, position);
+}
+
+void test_router_late_uses_router_minimums()
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_ROUTER_LATE;
+
+    uint32_t telemetry = Default::getConfiguredOrMinimumValue(60, min_default_telemetry_interval_secs);
+    uint32_t position = Default::getConfiguredOrMinimumValue(60, min_default_broadcast_interval_secs);
+
+    TEST_ASSERT_EQUAL_UINT32(ONE_DAY / 2, telemetry);
+    TEST_ASSERT_EQUAL_UINT32(ONE_DAY / 2, position);
+}
+
+void test_client_uses_public_channel_minimums()
+{
+    config.device.role = meshtastic_Config_DeviceConfig_Role_CLIENT;
+
+    uint32_t telemetry = Default::getConfiguredOrMinimumValue(60, min_default_telemetry_interval_secs);
+    uint32_t position = Default::getConfiguredOrMinimumValue(60, min_default_broadcast_interval_secs);
+
+    TEST_ASSERT_EQUAL_UINT32(30 * 60, telemetry);
+    TEST_ASSERT_EQUAL_UINT32(60 * 60, position);
+}
+
 void setup()
 {
     // Small delay to match other test mains
@@ -103,6 +136,9 @@ void setup()
     RUN_TEST(test_client_below_threshold);
     RUN_TEST(test_client_default_preset_scaling);
     RUN_TEST(test_client_medium_fast_preset_scaling);
+    RUN_TEST(test_router_uses_router_minimums);
+    RUN_TEST(test_router_late_uses_router_minimums);
+    RUN_TEST(test_client_uses_public_channel_minimums);
     exit(UNITY_END());
 }
 

--- a/test/test_default/test_main.cpp
+++ b/test/test_default/test_main.cpp
@@ -10,8 +10,9 @@ static uint32_t computeExpectedMs(uint32_t defaultSeconds, uint32_t numOnlineNod
 {
     uint32_t baseMs = Default::getConfiguredOrDefaultMs(0, defaultSeconds);
 
-    // Routers don't scale
-    if (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER) {
+    // Routers (including ROUTER_LATE) don't scale
+    if (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER ||
+        config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE) {
         return baseMs;
     }
 


### PR DESCRIPTION
As was pointed out in a discussion, the infrastructure roles don't enforce scaling, so instead we must ensure that the interval floors are coerced in line with those courser-grained default broadcasts minimums.