### PR TITLE
hexDump: Add const to the buf parameter in hexDump.

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -345,7 +345,7 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
     return;
 }
 
-void RedirectablePrint::hexDump(const char *logLevel, unsigned char *buf, uint16_t len)
+void RedirectablePrint::hexDump(const char *logLevel, const unsigned char *buf, uint16_t len)
 {
     const char alphabet[17] = "0123456789abcdef";
     log(logLevel, "    +------------------------------------------------+ +----------------+");

--- a/src/RedirectablePrint.h
+++ b/src/RedirectablePrint.h
@@ -44,7 +44,7 @@ class RedirectablePrint : public Print
     /** like printf but va_list based */
     size_t vprintf(const char *logLevel, const char *format, va_list arg);
 
-    void hexDump(const char *logLevel, unsigned char *buf, uint16_t len);
+    void hexDump(const char *logLevel, const unsigned char *buf, uint16_t len);
 
     std::string mt_sprintf(const std::string fmt_str, ...);
 


### PR DESCRIPTION
The function only reads the buffer, so marking it const clarifies intent and prevents accidental modification.


- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
