### PR TITLE
Fixes #9792 : Hop with Meshtastic ffff and ?dB is added to missing hop in traceroute

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -101,8 +101,9 @@ void FloodingRouter::reprocessPacket(const meshtastic_MeshPacket *p)
             printPacket("reprocessPacket(DUP)", p);
         } else {
             // Fatal decoding error, we can't do anything with this packet
-            LOG_WARN("FloodingRouter::reprocessPacket: Fatal decode error (state=%d, id=0x%08x, from=%u), can't check for traceroute",
-                     static_cast<int>(decodedState), p->id, getFrom(p));
+            LOG_WARN(
+                "FloodingRouter::reprocessPacket: Fatal decode error (state=%d, id=0x%08x, from=%u), can't check for traceroute",
+                static_cast<int>(decodedState), p->id, getFrom(p));
             return;
         }
     }


### PR DESCRIPTION
This fixes the situation where a duplicate packet from a traceroute will replace the packet to be rebroadcasted with the original packet (not containing the processing node).

fixes #9792 

The change is to check in FloodingRouter::reprocessPacket if the packet is already decoded. This is necessary to check portnum for TraceRoute messages. If decode fails we bailout (can't test it).
If decode succeeds we let the original code run. I kept the original test for decoded, just in case this fix is changed in the future and we risk reaching to that test without decoding (it could crash if we test an uninitialized field - portnum -)

Tests were run, forcing the flow to use the change. Output in tracepath was correct. Node run for about 10H without noticeable issues caused by this change.

Log showing the new situation:

> ===> Receive traceroute from ca70. Packet ID 0x1eb460e8. Process and enqueue for TX
> 
> Mar 19 02:00:20 DOH2_9468 RadioIf ﻿[2551]: Corrected frequency offset: 136.593735
> Mar 19 02:00:20 DOH2_9468 RadioIf ﻿[2552]: Lora RX (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 0, WantAck=1, HopLim=5 Ch=0x8 encrypted len=22 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> Mar 19 02:00:20 DOH2_9468 RadioIf ﻿[2552]: Packet RX: 395ms
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Packet History - insert: Using new slot @uptime 2552.031s TRACE NEW
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Use channel 0 (hash 0x8)
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Expand short PSK #1
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Use AES128 key!
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: decoded message (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=5 Ch=0x0 Portnum=70 WANTRESP rxtime=1773885794 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: handleReceived(REMOTE) (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=5 Ch=0x0 Portnum=70 WANTRESP rxtime=1773885794 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Module 'traceroute' wantsPacket=1
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Received traceroute from=0xdb2aca70, id=0x1eb460e8, portnum=70, payloadlen=0
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Route traced:#0120xdb2aca70 --> 0x433c9468 (5.25dB) --> ...
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Module 'traceroute' considered
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Module 'routing' wantsPacket=1
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Routing sniffing (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=5 Ch=0x0 Portnum=70 WANTRESP rxtime=1773885794 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Rebroadcast received message coming from 70
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Packet History - insert: Reusing slot aged 0.124s TRACE MATCHED PACKET
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Setting next hop for packet with dest 55fc8418 to 18
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Setting next retransmission in 7246 msecs: 
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]:  (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=4 Ch=0x0 Portnum=70 WANTRESP rxtime=1773885794 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x18 relay=0x68)
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Expand short PSK #1
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Use AES128 key!
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: enqueue for send (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=4 Ch=0x8 encrypted len=33 rxtime=1773885794 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x18 relay=0x68 priority=70)
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: txGood=127,txRelay=127,rxGood=572,rxBad=81
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: rx_snr found. hop_limit:4 rx_snr:5.250000
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: rx_snr found in packet. Setting tx delay:3080
> Mar 19 02:00:20 DOH2_9468 Router ﻿[2552]: Module 'routing' considered
> 
> ===> Packet not yet sent but duplicate received
> 
> Mar 19 02:00:29 DOH2_9468 RadioIf ﻿[2561]: Corrected frequency offset: 130.781250
> Mar 19 02:00:29 DOH2_9468 RadioIf ﻿[2561]: Lora RX (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 0, WantAck=1, HopLim=5 Ch=0x8 encrypted len=22 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> Mar 19 02:00:29 DOH2_9468 RadioIf ﻿[2561]: Packet RX: 395ms
> Mar 19 02:00:29 DOH2_9468 RadioIf ﻿[2561]: rx_snr found. hop_limit:4 rx_snr:5.250000
> Mar 19 02:00:29 DOH2_9468 RadioIf ﻿[2561]: rx_snr found in packet. Setting tx delay:3500
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: Packet History - insert: Reusing slot aged 9.481s TRACE MATCHED PACKET
> 
> ===> Packet duplicate detected
> 
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: Ignore dupe incoming msg (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=5 Ch=0x8 encrypted len=22 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: cancelSending id=0x1eb460e8, removed=1
> 
> ===> Changed: Decoded in reprocessPacket()
> 
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: Use channel 0 (hash 0x8)
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: Expand short PSK #1
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: Use AES128 key!
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: decoded message (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=5 Ch=0x0 Portnum=70 WANTRESP rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> 
> ===> Changed: print packet in reprocessPacket()
>
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: reprocessPacket(DUP) (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=5 Ch=0x0 Portnum=70 WANTRESP rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x68 relay=0x70)
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: Route traced:#0120xdb2aca70 --> 0x433c9468 (5.25dB) --> ...
> Mar 19 02:00:29 DOH2_9468 Router ﻿[2561]: Rebroadcast received message coming from 70
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: Packet History - insert: Reusing slot aged 0.105s TRACE MATCHED PACKET
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: Setting next hop for packet with dest 55fc8418 to 18
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: Setting next retransmission in 7246 msecs: 
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]:  (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=4 Ch=0x0 Portnum=70 WANTRESP rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x18 relay=0x68)
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: Expand short PSK #1
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: Use AES128 key!
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: enqueue for send (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=4 Ch=0x8 encrypted len=33 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x18 relay=0x68 priority=70)
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: txGood=127,txRelay=127,rxGood=577,rxBad=81
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: rx_snr found. hop_limit:4 rx_snr:5.250000
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: rx_snr found in packet. Setting tx delay:3920
> Mar 19 02:00:30 DOH2_9468 Router ﻿[2561]: Incoming msg was filtered from 0xdb2aca70
> 
> ===> Packet finally sent
> 
> Mar 19 02:00:33 DOH2_9468 RadioIf ﻿[2565]: Started Tx (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=4 Ch=0x8 encrypted len=33 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x18 relay=0x68 priority=70)
> Mar 19 02:00:33 DOH2_9468 RadioIf ﻿[2565]: 1 packets remain in the TX queue
> Mar 19 02:00:33 DOH2_9468 Position ﻿[2565]: Ch. util >25%. Skip send
> Mar 19 02:00:33 DOH2_9468 RadioIf ﻿[2565]: Packet TX: 477ms
> Mar 19 02:00:33 DOH2_9468 RadioIf ﻿[2565]: Completed sending (id=0x1eb460e8 fr=0xdb2aca70 to=0x55fc8418, transport = 1, WantAck=1, HopLim=4 Ch=0x8 encrypted len=33 rxSNR=5.25 rxRSSI=-96 hopStart=5 nextHop=0x18 relay=0x68 priority=70)
> Mar 19 02:00:33 DOH2_9468 RadioIf ﻿[2565]: rx_snr found. hop_limit:0 rx_snr:-6.000000
> Mar 19 02:00:33 DOH2_9468 RadioIf ﻿[2565]: rx_snr found in packet. Setting tx delay:644
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: Can not send yet, busyRx
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: rx_snr found. hop_limit:0 rx_snr:-6.000000
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: rx_snr found in packet. Setting tx delay:1120
> 
> ===> Returned packet...
> 
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: Corrected frequency offset: -188.906250
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: Lora RX (id=0x7dd81ff3 fr=0x55fc8418 to=0xdb2aca70, transport = 0, WantAck=1, HopLim=3 Ch=0x8 encrypted len=37 rxSNR=5.75 rxRSSI=-77 hopStart=3 relay=0x18)
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: Packet RX: 518ms
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: rx_snr found. hop_limit:0 rx_snr:-6.000000
> Mar 19 02:00:34 DOH2_9468 RadioIf ﻿[2566]: rx_snr found in packet. Setting tx delay:840
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Packet History - insert: Using new slot @uptime 2566.549s TRACE NEW
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Use channel 0 (hash 0x8)
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Expand short PSK #1
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Use AES128 key!
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: decoded message (id=0x7dd81ff3 fr=0x55fc8418 to=0xdb2aca70, transport = 1, WantAck=1, HopLim=3 Ch=0x0 Portnum=70 requestId=1eb460e8 rxtime=1773885808 rxSNR=5.75 rxRSSI=-77 hopStart=3 relay=0x18)
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: handleReceived(REMOTE) (id=0x7dd81ff3 fr=0x55fc8418 to=0xdb2aca70, transport = 1, WantAck=1, HopLim=3 Ch=0x0 Portnum=70 requestId=1eb460e8 rxtime=1773885808 rxSNR=5.75 rxRSSI=-77 hopStart=3 relay=0x18)
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Module 'traceroute' wantsPacket=1
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Received traceroute from=0x55fc8418, id=0x7dd81ff3, portnum=70, payloadlen=10
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Route traced:#0120xdb2aca70 --> 0x433c9468 (5.25dB) --> 0x55fc8418 (6.75dB)#012...(5.75dB) 0x433c9468 <-- 0x55fc8418
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Module 'traceroute' considered
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Module 'routing' wantsPacket=1
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Routing sniffing (id=0x7dd81ff3 fr=0x55fc8418 to=0xdb2aca70, transport = 1, WantAck=1, HopLim=3 Ch=0x0 Portnum=70 requestId=1eb460e8 rxtime=1773885808 rxSNR=5.75 rxRSSI=-77 hopStart=3 relay=0x18)
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: cancelSending id=0x1eb460e8, removed=0
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: cancelSending id=0x1eb460e8, removed=0
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Rebroadcast received message coming from 18
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Packet History - insert: Reusing slot aged 0.150s TRACE MATCHED PACKET
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Expand short PSK #1
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: Use AES128 key!
> Mar 19 02:00:34 DOH2_9468 Router ﻿[2566]: enqueue for send (id=0x7dd81ff3 fr=0x55fc8418 to=0xdb2aca70, transport = 1, WantAck=1, HopLim=2 Ch=0x8 encrypted len=46 rxtime=1773885808 rxSNR=5.75 rxRSSI=-77 hopStart=3 relay=0x68 priority=80)
> Mar 19 02:00:35 DOH2_9468 Router ﻿[2566]: txGood=128,txRelay=128,rxGood=579,rxBad=81
> Mar 19 02:00:35 DOH2_9468 Router ﻿[2566]: rx_snr found. hop_limit:2 rx_snr:5.750000
> Mar 19 02:00:35 DOH2_9468 Router ﻿[2566]: rx_snr found in packet. Setting tx delay:2604
> Mar 19 02:00:35 DOH2_9468 Router ﻿[2566]: Module 'routing' considered
> 
> ===> Returned packet sent
> 
> Mar 19 02:00:39 DOH2_9468 RadioIf ﻿[2571]: Started Tx (id=0x7dd81ff3 fr=0x55fc8418 to=0xdb2aca70, transport = 1, WantAck=1, HopLim=2 Ch=0x8 encrypted len=46 rxtime=1773885808 rxSNR=5.75 rxRSSI=-77 hopStart=3 relay=0x68 priority=80)
> Mar 19 02:00:39 DOH2_9468 RadioIf ﻿[2571]: 1 packets remain in the TX queue
> Mar 19 02:00:40 DOH2_9468 RadioIf ﻿[2571]: Packet TX: 600ms
> Mar 19 02:00:40


![Screenshot_20260319_021510_Meshtastic](https://github.com/user-attachments/assets/5a38f8e8-c45e-48a9-9dcb-3f87efe803e2)


## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [x] Other (please specify below)
  Heltec WSL V3
