### PR TITLE
Fix TFTDisplay::display to align pixels at 32-bit boundary

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -1278,6 +1278,10 @@ void TFTDisplay::display(bool fromBlank)
             // Most displays will have even number of pixels in a row -- this will be in bounds
             // of the displayWidth. (Hopefully odd displays will just ignore that extra pixel.)
             x_LastPixelUpdate |= 1;
+            // Ensure the last pixel index does not exceed the display width.
+            if (x_LastPixelUpdate >= displayWidth) {
+                x_LastPixelUpdate = displayWidth - 1;
+            }
 #if defined(HACKADAY_COMMUNICATOR)
             tft->draw16bitBeRGBBitmap(x_FirstPixelUpdate, y, &linePixelBuffer[x_FirstPixelUpdate],
                                       (x_LastPixelUpdate - x_FirstPixelUpdate + 1), 1);


### PR DESCRIPTION
The device, such as esp32c6, require 32-bit alignment for the data.

The patch aligns start and end of the update pixels buffer. In worst case, it will add two extra pixels per row.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
  - [X] Private hardware based on esp32c6 with 1.47" LCD
