### PR TITLE
Add LED_BUILTIN for variant tlora_v1

### DIFF
--- a/variants/esp32/tlora_v1/platformio.ini
+++ b/variants/esp32/tlora_v1/platformio.ini
@@ -13,4 +13,5 @@ build_flags =
   ${esp32_base.build_flags}
   -D TLORA_V1
   -I variants/esp32/tlora_v1
+  -ULED_BUILTIN
 upload_speed = 115200


### PR DESCRIPTION
Similar to https://github.com/meshtastic/firmware/pull/9647 *LED_BUILTIN* is not defined for variant _tlora_v1_. 
