### PR TITLE
Add timeout to PPA uploads

### DIFF
--- a/.github/workflows/daily_packaging.yml
+++ b/.github/workflows/daily_packaging.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - develop # Default branch, same as 'cron' above
     paths:
       - debian/**
       - "*.rpkg"

--- a/.github/workflows/package_ppa.yml
+++ b/.github/workflows/package_ppa.yml
@@ -68,5 +68,6 @@ jobs:
 
       - name: Publish with dput
         if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'pull_request' }}
+        timeout-minutes: 15 # dput is terrible, sometimes runs 'forever'
         run: |
           dput ${{ inputs.ppa_repo }} meshtasticd_${{ steps.version.outputs.deb }}~${{ inputs.series }}_source.changes


### PR DESCRIPTION
Don't allow PPA uploads (dput) to run for more than 15 minutes.

Successful runs typically take about ~8 minutes, so this is plenty generous.
Sometimes this job will run for *hours* for no good reason.
