### PR TITLE
fix ExternalNotificationsModule Buzzer is all or nothing

### DIFF
--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -381,7 +381,7 @@ ProcessMessage ExternalNotificationModule::handleReceived(const meshtastic_MeshP
                 (config.device.buzzer_mode == meshtastic_Config_DeviceConfig_BuzzerMode_DIRECT_MSG_ONLY);
 
             if (containsBell || !is_muted) {
-                const bool alertPinEnabled = containsBell ? moduleConfig.external_notification.alert_bell = true
+                const bool alertPinEnabled = containsBell ? moduleConfig.external_notification.alert_bell
                                                           : moduleConfig.external_notification.alert_message;
                 const bool alertVibraEnabled = containsBell ? moduleConfig.external_notification.alert_bell_vibra
                                                             : moduleConfig.external_notification.alert_message_vibra;


### PR DESCRIPTION
fixes #6368

supersedes PR 9998 https://github.com/meshtastic/firmware/pull/9998

after good input from https://github.com/meshtastic/firmware/pull/9998#issuecomment-4121989364

There have been multiple times now, from several users of the key module ExternalNotifications,
that users suggested that since firmware 2.7, the behavior of External Notifications was not right anymore.

e.g. in #6368 Buzzer is all or nothing - activates for all messages even if set to bell only

or in https://github.com/meshtastic/firmware/issues/8908#issuecomment-3940717495

I made the changes suggested in https://github.com/meshtastic/firmware/issues/6368#issuecomment-4024832452
to ExternalNotificationsModule conditional logic and will have user @haflinger73 try the modifications with his Heltec v3.

Can only speak for Heltec v3, but the changes seem so intuitive that it should also work for all other kinds of devices with buzzers, alert handling etc.

I made the changes off tag 2.7.20

git clone --depth 1 --branch v2.7.20.6658ec2 https://github.com/meshtastic/firmware.git

and then built the firmware for heltec v3
```
$ pwd
/firmware
$ ./bin/build-esp32.sh heltec-v3
...
Successfully created esp32s3 image.
esp32_create_combined_bin([".pio/build/heltec-v3/firmware-heltec-v3-2.7.20.016e68e.bin"], [".pio/build/heltec-v3/firmware-heltec-v3-2.7.20.016e68e.elf"])
Generating combined binary for serial flashing
    Offset | File
 -  0x0000 | /firmware/.pio/build/heltec-v3/bootloader.bin
 -  0x8000 | /firmware/.pio/build/heltec-v3/partitions.bin
 -  0xe000 | /.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin
 - 0x10000 | /firmware/.pio/build/heltec-v3/firmware-heltec-v3-2.7.20.016e68e.bin
Using esptool.py arguments: --chip esp32s3 merge_bin -o /firmware/.pio/build/heltec-v3/firmware-heltec-v3-2.7.20.016e68e.factory.bin --flash_mode dio --flash_freq 80m --flash_size 8MB 0x0000 /firmware/.pio/build/heltec-v3/bootloader.bin 0x8000 /firmware/.pio/build/heltec-v3/partitions.bin 0xe000 /.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 /firmware/.pio/build/heltec-v3/firmware-heltec-v3-2.7.20.016e68e.bin
esptool.py v4.11.0
SHA digest in image updated
Wrote 0x20f460 bytes to file /firmware/.pio/build/heltec-v3/firmware-heltec-v3-2.7.20.016e68e.factory.bin, ready to flash to offset 0x0
mtjson_esp32_part(["mtjson"], ["buildprog", ".pio/build/heltec-v3/littlefs-heltec-v3-2.7.20.016e68e.bin"])
manifest_gather(["mtjson"], ["buildprog", ".pio/build/heltec-v3/littlefs-heltec-v3-2.7.20.016e68e.bin"])
{'name': 'firmware-heltec-v3-2.7.20.016e68e.elf', 'md5': '44f48df6ad379288035550e0d526b725', 'bytes': 22260936}
{'name': 'firmware-heltec-v3-2.7.20.016e68e.bin', 'md5': '5f24a9d167538ae44dfb0948ecd7e19a', 'bytes': 2094176, 'part_name': 'app0'}
{'name': 'firmware-heltec-v3-2.7.20.016e68e.factory.bin', 'md5': '950fa567eec5f6b907d310cfad266bef', 'bytes': 2159712}
{'name': 'littlefs-heltec-v3-2.7.20.016e68e.bin', 'md5': '0e325e359b7455ba90201425ad7fab74', 'bytes': 1572864, 'part_name': 'spiffs'}
=========================================================== [SUCCESS] Took 102.78 seconds ===========================================================

Environment    Status    Duration
-------------  --------  ------------
heltec-v3      SUCCESS   00:01:42.784
============================================================ 1 succeeded in 00:01:42.784 ============================================================
Copying ESP32 bin file
Copying ESP32 update bin file
Copying Filesystem for ESP32 targets
Copying manifest
```



@caveman99 @Xaositek can you weigh in on this, please? We'd truly appreciate it.

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌

- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentally duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the Linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and community members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
