### PR TITLE
Deps: Cleanup LewisHe library references

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -73,8 +73,8 @@ lib_deps =
   h2zero/NimBLE-Arduino@^1.4.3
   # renovate: datasource=git-refs depName=libpax packageName=https://github.com/dbinfrago/libpax gitBranch=master
   https://github.com/dbinfrago/libpax/archive/3cdc0371c375676a97967547f4065607d4c53fd1.zip
-  # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib
-  https://github.com/lewisxhe/XPowersLib/archive/v0.3.3.zip
+  # renovate: datasource=custom.pio depName=XPowersLib packageName=lewisxhe/library/XPowersLib
+  lewisxhe/XPowersLib@0.3.3
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
   rweather/Crypto@0.4.0
 

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -26,7 +26,7 @@ lib_deps =
   ${environmental_extra_no_bsec.lib_deps}
   # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
   h2zero/NimBLE-Arduino@^1.4.3
-  # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib
-  https://github.com/lewisxhe/XPowersLib/archive/v0.3.3.zip
+  # renovate: datasource=custom.pio depName=XPowersLib packageName=lewisxhe/library/XPowersLib
+  lewisxhe/XPowersLib@0.3.3
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto
   rweather/Crypto@0.4.0

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -32,5 +32,5 @@ lib_deps =
   ${env:tbeam.lib_deps}
   # renovate: datasource=github-tags depName=meshtastic-st7796 packageName=meshtastic/st7796
   https://github.com/meshtastic/st7796/archive/1.0.5.zip
-  # renovate: datasource=custom.pio depName=lewisxhe-SensorLib packageName=lewisxhe/library/SensorLib
+  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
   lewisxhe/SensorLib@0.3.4

--- a/variants/esp32s3/t5s3_epaper/platformio.ini
+++ b/variants/esp32s3/t5s3_epaper/platformio.ini
@@ -23,10 +23,8 @@ build_src_filter =
   +<../variants/esp32s3/t5s3_epaper>
 lib_deps =
   ${esp32s3_base.lib_deps}
-  # renovate: datasource=github-tags depName=XPowersLib packageName=lewisxhe/XPowersLib
-  https://github.com/lewisxhe/XPowersLib/archive/refs/tags/v0.3.3.zip
-  # renovate: datasource=github-tags depName=SensorLib packageName=lewisxhe/SensorLib
-  https://github.com/lewisxhe/SensorLib/archive/refs/tags/v0.3.4.zip
+  # renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
+  lewisxhe/SensorLib@0.3.4
   https://github.com/mverch67/BQ27220/archive/07d92be846abd8a0258a50c23198dac0858b22ed.zip
   https://github.com/mverch67/FastEPD/archive/0df1bff329b6fc782e062f611758880762340647.zip
 


### PR DESCRIPTION
We cache and dedupe our dependencies, referring to them with multiple methods/urls is just noise.

```ini
# renovate: datasource=custom.pio depName=XPowersLib packageName=lewisxhe/library/XPowersLib
lewisxhe/XPowersLib@0.3.3
# renovate: datasource=custom.pio depName=SensorLib packageName=lewisxhe/library/SensorLib
lewisxhe/SensorLib@0.3.4
```

This does *not* include any updates, just a cleanup.

This will consolidate duplicate PRs:
- https://github.com/meshtastic/firmware/pull/9848
- https://github.com/meshtastic/firmware/pull/9849