### PR TITLE
Dependencies: Remove all fuzzy-matches, spot-add renovate

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -233,5 +233,5 @@ lib_deps =
 [environmental_extra_no_bsec]
 lib_deps =
 	${environmental_extra_common.lib_deps}
-	# renovate: datasource=custom.pio depName=adafruit/Adafruit BME680 Library packageName=adafruit/library/Adafruit BME680
-	adafruit/Adafruit BME680 Library@^2.0.5
+	# renovate: datasource=custom.pio depName=Adafruit_BME680 packageName=adafruit/library/Adafruit BME680 Library
+	adafruit/Adafruit BME680 Library@2.0.5

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -8,7 +8,7 @@ platform =
   platformio/espressif32@6.13.0
 platform_packages =
   # renovate: datasource=custom.pio depName=platformio/tool-mklittlefs packageName=platformio/tool/tool-mklittlefs
-  platformio/tool-mklittlefs@^1.203.210628
+  platformio/tool-mklittlefs@1.203.210628
 
 extra_scripts =
   ${env.extra_scripts}
@@ -70,7 +70,7 @@ lib_deps =
   # renovate: datasource=git-refs depName=meshtastic-esp32_https_server packageName=https://github.com/meshtastic/esp32_https_server gitBranch=master
   https://github.com/meshtastic/esp32_https_server/archive/b78f12c86ea65c3ca08968840ff554ff7ed69b60.zip
   # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
-  h2zero/NimBLE-Arduino@^1.4.3
+  h2zero/NimBLE-Arduino@1.4.3
   # renovate: datasource=git-refs depName=libpax packageName=https://github.com/dbinfrago/libpax gitBranch=master
   https://github.com/dbinfrago/libpax/archive/3cdc0371c375676a97967547f4065607d4c53fd1.zip
   # renovate: datasource=custom.pio depName=XPowersLib packageName=lewisxhe/library/XPowersLib

--- a/variants/esp32/esp32.ini
+++ b/variants/esp32/esp32.ini
@@ -25,7 +25,7 @@ lib_deps =
   ${environmental_base.lib_deps}
   ${environmental_extra_no_bsec.lib_deps}
   # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
-  h2zero/NimBLE-Arduino@^1.4.3
+  h2zero/NimBLE-Arduino@1.4.3
   # renovate: datasource=custom.pio depName=XPowersLib packageName=lewisxhe/library/XPowersLib
   lewisxhe/XPowersLib@0.3.3
   # renovate: datasource=custom.pio depName=rweather/Crypto packageName=rweather/library/Crypto

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -34,8 +34,8 @@ lib_deps =
 	adafruit/Adafruit seesaw Library@1.7.9
   # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
-  # renovate: datasource=custom.pio depName=adafruit/Adafruit BME680 Library packageName=adafruit/library/Adafruit BME680
-  adafruit/Adafruit BME680 Library@^2.0.5
+  # renovate: datasource=custom.pio depName=Adafruit_BME680 packageName=adafruit/library/Adafruit BME680 Library
+  adafruit/Adafruit BME680 Library@2.0.5
 
 build_flags =
   ${arduino_base.build_flags}

--- a/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
+++ b/variants/nrf52840/ELECROW-ThinkNode-M4/platformio.ini
@@ -12,4 +12,5 @@ build_flags = ${nrf52840_base.build_flags}
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/ELECROW-ThinkNode-M4>
 lib_deps =
   ${nrf52840_base.lib_deps}
-  lewisxhe/PCF8563_Library@^1.0.1
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
+  lewisxhe/PCF8563_Library@1.0.1

--- a/variants/nrf52840/t-echo-plus/platformio.ini
+++ b/variants/nrf52840/t-echo-plus/platformio.ini
@@ -22,5 +22,7 @@ build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/t-echo-
 lib_deps =
   ${nrf52840_base.lib_deps}
   https://github.com/meshtastic/GxEPD2/archive/55f618961db45a23eff0233546430f1e5a80f63a.zip
-  lewisxhe/PCF8563_Library@^1.0.1
+  # renovate: datasource=custom.pio depName=PCF8563 packageName=lewisxhe/library/PCF8563_Library
+  lewisxhe/PCF8563_Library@1.0.1
+  # renovate: datasource=custom.pio depName=Adafruit DRV2605 packageName=adafruit/library/Adafruit DRV2605 Library
   adafruit/Adafruit DRV2605 Library@1.2.4


### PR DESCRIPTION
Remove all platformio fuzzy matches `^@`, add renovate comments for a few deps that were missing.

Fuzzy lib matches keep our builds from being reproducible. Down with fuzzy matches! (I need to automate a nag for this)

Also fixes renovate error described in:
- https://github.com/meshtastic/firmware/issues/6538