### PR TITLE
Supporting STM32WL is like squeezing blood from a stone

### DIFF
--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -27,7 +27,7 @@ build_flags =
   -DMESHTASTIC_EXCLUDE_TZ=1 ; Exclude TZ to save some flash space.
   -DSERIAL_RX_BUFFER_SIZE=256 ; For GPS - the default of 64 is too small.
   -DHAS_SCREEN=0 ; Always disable screen for STM32, it is not supported.
-  -DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF ; This is REQUIRED for at least traceroute debug prints - without it the length ends up uninitialized.
+  ;-DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF ; Enable this if enabling debugg logging. It is REQUIRED for at least traceroute debug prints - without it the length returned by printf ends up uninitialized.
   -DDEBUG_MUTE ; You can #undef DEBUG_MUTE in certain source files if you need the logs.
   -fmerge-all-constants
   -ffunction-sections


### PR DESCRIPTION
This is the last bit of flash left. Really this time.
Before:
/home/stary/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/12.3.1/../../../../arm-none-eabi/bin/ld: region `FLASH' overflowed by 1088 bytes
After:
Flash: [==========] 97.0% (used 226480 bytes from 233472 bytes)

## 🤝 Attestations

- [x I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [x] Wio E5
