### PR TITLE
Move core lib_deps to github zips

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,10 +77,10 @@ lib_deps =
 	https://github.com/meshtastic/TinyGPSPlus/archive/71a82db35f3b973440044c476d4bcdc673b104f4.zip
 	# renovate: datasource=git-refs depName=meshtastic-ArduinoThread packageName=https://github.com/meshtastic/ArduinoThread gitBranch=master
 	https://github.com/meshtastic/ArduinoThread/archive/b841b0415721f1341ea41cccfb4adccfaf951567.zip
-	# renovate: datasource=custom.pio depName=Nanopb packageName=nanopb/library/Nanopb
-	nanopb/Nanopb@0.4.91
-	# renovate: datasource=custom.pio depName=ErriezCRC32 packageName=erriez/library/ErriezCRC32
-	erriez/ErriezCRC32@1.0.1
+	# renovate: datasource=github-tags depName=Nanopb packageName=nanopb/nanopb
+	https://github.com/nanopb/nanopb/archive/refs/tags/nanopb-0.4.9.1.zip
+	# renovate: datasource=github-tags depName=ErriezCRC32 packageName=Erriez/ErriezCRC32
+	https://github.com/Erriez/ErriezCRC32/archive/refs/tags/1.0.1.zip
 
 ; Used for the code analysis in PIO Home / Inspect
 check_tool = cppcheck
@@ -95,8 +95,8 @@ check_flags =
 framework = arduino
 lib_deps =
 	${env.lib_deps}
-	# renovate: datasource=custom.pio depName=NonBlockingRTTTL packageName=end2endzone/library/NonBlockingRTTTL
-	end2endzone/NonBlockingRTTTL@1.4.0
+	# renovate: datasource=github-tags depName=NonBlockingRTTTL packageName=end2endzone/NonBlockingRTTTL
+	https://github.com/end2endzone/NonBlockingRTTTL/archive/refs/tags/1.4.0.zip
 build_unflags =
 	-std=c++11
 	-std=gnu++11
@@ -107,21 +107,21 @@ build_src_filter = ${env.build_src_filter} -<platform/portduino/> -<graphics/nic
 ; Common libs for communicating over TCP/IP networks such as MQTT
 [networking_base]
 lib_deps =
-	# renovate: datasource=custom.pio depName=TBPubSubClient packageName=thingsboard/library/TBPubSubClient
-	thingsboard/TBPubSubClient@2.12.1
-	# renovate: datasource=custom.pio depName=NTPClient packageName=arduino-libraries/library/NTPClient
-	arduino-libraries/NTPClient@3.2.1
+	# renovate: datasource=github-tags depName=TBPubSubClient packageName=thingsboard/pubsubclient
+	https://github.com/thingsboard/pubsubclient/archive/refs/tags/v2.12.1.zip
+	# renovate: datasource=github-tags depName=NTPClient packageName=arduino-libraries/NTPClient
+	https://github.com/arduino-libraries/NTPClient/archive/refs/tags/3.2.1.zip
 
 ; Extra TCP/IP networking libs for supported devices
 [networking_extra]
 lib_deps =
-	# renovate: datasource=custom.pio depName=Syslog packageName=arcao/library/Syslog
-	arcao/Syslog@2.0.0
+	# renovate: datasource=github-tags depName=Syslog packageName=arcao/Syslog
+	https://github.com/arcao/Syslog/archive/refs/tags/v2.0.zip
 
 [radiolib_base]
 lib_deps =
-	# renovate: datasource=custom.pio depName=RadioLib packageName=jgromes/library/RadioLib
-	jgromes/RadioLib@7.6.0
+	# renovate: datasource=github-tags depName=RadioLib packageName=jgromes/RadioLib
+	https://github.com/jgromes/RadioLib/archive/refs/tags/7.6.0.zip
 
 [device-ui_base]
 lib_deps =


### PR DESCRIPTION
PlatformIO registry is (probably) rate limiting us. Mitigate by switching to GitHub source zips (based upon tags) for core libraries.

Hoping this addresses the issue without having to change the entire sensor-zoo.

This change does not include any updates, simply swapping to a new download location.
