### PR TITLE
Hack: Use re-uploaded framework-arduinoespressif32 on ESP32c6

### DIFF
--- a/variants/esp32c6/esp32c6.ini
+++ b/variants/esp32c6/esp32c6.ini
@@ -3,6 +3,9 @@ extends = esp32_common
 platform =
   # Do not renovate until we have switched to pioarduino tagged builds
   https://github.com/Jason2866/platform-espressif32/archive/22faa566df8c789000f8136cd8d0aca49617af55.zip
+platform_packages =
+  # HACK: This release was automatically removed upstream
+  framework-arduinoespressif32 @ https://github.com/vidplace7/platform-espressif32/releases/download/meshtastic-esp32c6/framework-arduinoespressif32-all-release_v5.1-124d64e.zip
 build_flags =
   ${arduino_base.build_flags}
   -Wall


### PR DESCRIPTION
Dirty hack to keep ESP32c6 building. This zip was extracted from the `ghcr.io/meshtastic/gh-action-firmware:master-esp32c6` image.

Remove when updating to pioarduino
