### PR TITLE
wio-sdk-wm1110: inherit build_unflags

### DIFF
--- a/variants/nrf52840/wio-sdk-wm1110/platformio.ini
+++ b/variants/nrf52840/wio-sdk-wm1110/platformio.ini
@@ -9,6 +9,7 @@ extra_scripts =
 
 # Remove adafruit USB serial from the build (it is incompatible with using the ch340 serial chip on this board)
 build_unflags =
+  ${nrf52840_base.build_unflags}
   -Ofast
   -Og
   -ggdb3


### PR DESCRIPTION
Fixes current build errors with `wio-sdk-wm1110`.
