### PR TITLE
ESP32: Take away "tbeam" boards PSRAM to reclaim iram

### DIFF
--- a/boards/ttgo-tbeam.json
+++ b/boards/ttgo-tbeam.json
@@ -1,0 +1,29 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_T_Beam",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "tbeam"
+  },
+  "connectivity": ["wifi", "bluetooth", "can", "ethernet"],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "TTGO T-Beam (PSRAM Disabled)",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 1310720,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/LilyGO/TTGO-T-Beam",
+  "vendor": "TTGO"
+}

--- a/variants/esp32/nano-g1-explorer/platformio.ini
+++ b/variants/esp32/nano-g1-explorer/platformio.ini
@@ -9,7 +9,7 @@ custom_meshtastic_display_name = Nano G1 Explorer
 custom_meshtastic_tags = B&Q
 
 extends = esp32_base
-board = ttgo-t-beam
+board = ttgo-tbeam
 build_flags = 
   ${esp32_base.build_flags}
   -D NANO_G1_EXPLORER

--- a/variants/esp32/nano-g1/platformio.ini
+++ b/variants/esp32/nano-g1/platformio.ini
@@ -9,7 +9,7 @@ custom_meshtastic_display_name = Nano G1
 custom_meshtastic_tags = B&Q
 
 extends = esp32_base
-board = ttgo-t-beam
+board = ttgo-tbeam
 build_flags = 
   ${esp32_base.build_flags}
   -D NANO_G1

--- a/variants/esp32/station-g1/platformio.ini
+++ b/variants/esp32/station-g1/platformio.ini
@@ -9,10 +9,7 @@ custom_meshtastic_display_name = Station G1
 custom_meshtastic_tags = B&Q
 
 extends = esp32_base
-board = ttgo-t-beam
-build_unflags =
-  ${esp32_common.build_unflags}
-  -DBOARD_HAS_PSRAM
+board = ttgo-tbeam
 build_flags = 
   ${esp32_base.build_flags}
   -D STATION_G1

--- a/variants/esp32/tbeam/platformio.ini
+++ b/variants/esp32/tbeam/platformio.ini
@@ -10,14 +10,12 @@ custom_meshtastic_images = tbeam.svg
 custom_meshtastic_tags = LilyGo
 
 extends = esp32_base
-board = ttgo-t-beam
+board = ttgo-tbeam
 
 board_check = true
 build_flags = ${esp32_base.build_flags}
   -D TBEAM_V10
   -I variants/esp32/tbeam
-  -DBOARD_HAS_PSRAM
-  -mfix-esp32-psram-cache-issue
   -ULED_BUILTIN
 upload_speed = 921600
 

--- a/variants/esp32/tbeam_v07/platformio.ini
+++ b/variants/esp32/tbeam_v07/platformio.ini
@@ -9,7 +9,7 @@ custom_meshtastic_tags = LilyGo
 
 board_level = extra
 extends = esp32_base
-board = ttgo-t-beam
+board = ttgo-tbeam
 build_flags = 
   ${esp32_base.build_flags}
   -D TBEAM_V07


### PR DESCRIPTION
You read that right! Disable PSRAM on the ttgo-tbeam board to reclaim *iram*.

`ttgo-tbeam.json` is a copy of https://github.com/platformio/platform-espressif32/blob/v6.13.0/boards/ttgo-t-beam.json with `-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue` removed.

PSRAM support on OG-ESP32 involves a lot of iram usage thanks to iram-heavy workarounds that have been added to address hardware bugs.

See https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-guides/performance/ram-usage.html#optimizing-iram-usage

- Fixes compiles on `nano-g1-explorer`
- Fixes compiles on `tbeam`