### PR TITLE
Set t5s3_epaper_inkhud to `extra`

### DIFF
--- a/bin/generate_ci_matrix.py
+++ b/bin/generate_ci_matrix.py
@@ -43,7 +43,7 @@ for pio_env in pio_envs:
   env = {
     "ci": {"board": pio_env, "platform": env_platform},
     "board_level": cfg.get(f"env:{pio_env}", "board_level", default=None),
-    "board_check": bool(cfg.get(f"env:{pio_env}", "board_check", default=False)),
+    "board_check": cfg.get(f"env:{pio_env}", "board_check", default="false").strip().lower() == "true",
   }
   all_envs.append(env)
 

--- a/variants/esp32s3/t5s3_epaper/platformio.ini
+++ b/variants/esp32s3/t5s3_epaper/platformio.ini
@@ -30,6 +30,8 @@ lib_deps =
 
 [env:t5s3_epaper_inkhud]
 extends = t5s3_epaper_base, inkhud
+board_level = extra # inkhud port is incomplete
+board_check = false
 build_flags =
   ${t5s3_epaper_base.build_flags}
   ${inkhud.build_flags}


### PR DESCRIPTION
`t5s3_epaper_inkhud` is incomplete (missing macros). Disable it for now.

Also fixes the board_check evaluation in `generate_ci_matrix.py` so that `false` actually works correctly.
