### PR TITLE
fix: replace weak PRNG with CSPRNG in crypto paths

### DIFF
--- a/src/mesh/CryptoEngine.cpp
+++ b/src/mesh/CryptoEngine.cpp
@@ -29,7 +29,8 @@ void CryptoEngine::generateKeyPair(uint8_t *pubKey, uint8_t *privKey)
     if (myNodeInfo.device_id.size == 16) {
         CryptRNG.stir(myNodeInfo.device_id.bytes, myNodeInfo.device_id.size);
     }
-    auto noise = random();
+    uint32_t noise;
+    CryptRNG.rand((uint8_t *)&noise, sizeof(noise));
     CryptRNG.stir((uint8_t *)&noise, sizeof(noise));
 
     LOG_DEBUG("Generate Curve25519 keypair");
@@ -106,11 +107,12 @@ bool CryptoEngine::encryptCurve25519(uint32_t toNode, uint32_t fromNode, meshtas
                                      uint64_t packetNum, size_t numBytes, const uint8_t *bytes, uint8_t *bytesOut)
 {
     uint8_t *auth;
-    long extraNonceTmp = random();
+    uint32_t extraNonceTmp;
+    RNG.rand((uint8_t *)&extraNonceTmp, sizeof(extraNonceTmp));
     auth = bytesOut + numBytes;
     memcpy((uint8_t *)(auth + 8), &extraNonceTmp,
            sizeof(uint32_t)); // do not use dereference on potential non aligned pointers : *extraNonce = extraNonceTmp;
-    LOG_DEBUG("Random nonce value: %d", extraNonceTmp);
+    LOG_DEBUG("Random nonce value: %u", extraNonceTmp);
     if (remotePublic.size == 0) {
         LOG_DEBUG("Node %d or their public_key not found", toNode);
         return false;
@@ -145,7 +147,11 @@ bool CryptoEngine::encryptCurve25519(uint32_t toNode, uint32_t fromNode, meshtas
 bool CryptoEngine::decryptCurve25519(uint32_t fromNode, meshtastic_UserLite_public_key_t remotePublic, uint64_t packetNum,
                                      size_t numBytes, const uint8_t *bytes, uint8_t *bytesOut)
 {
-    const uint8_t *auth = bytes + numBytes - 12; // set to last 8 bytes of text?
+    if (numBytes < 12) {
+        LOG_WARN("PKI decrypt: packet too small (%u bytes), need at least 12 for tag+nonce", numBytes);
+        return false;
+    }
+    const uint8_t *auth = bytes + numBytes - 12; // 8-byte CCM tag + 4-byte extraNonce
     uint32_t extraNonce;                         // pointer was not really used
     memcpy(&extraNonce, auth + 8,
            sizeof(uint32_t)); // do not use dereference on potential non aligned pointers : (uint32_t *)(auth + 8);
@@ -290,3 +296,14 @@ void CryptoEngine::initNonce(uint32_t fromNode, uint64_t packetId, uint32_t extr
 #ifndef HAS_CUSTOM_CRYPTO_ENGINE
 CryptoEngine *crypto = new CryptoEngine;
 #endif
+
+uint32_t cryptoSecureRandom32()
+{
+    uint32_t val;
+#if !(MESHTASTIC_EXCLUDE_PKI)
+    RNG.rand((uint8_t *)&val, sizeof(val));
+#else
+    val = random(UINT32_MAX);
+#endif
+    return val;
+}

--- a/src/mesh/CryptoEngine.h
+++ b/src/mesh/CryptoEngine.h
@@ -95,3 +95,9 @@ class CryptoEngine
 };
 
 extern CryptoEngine *crypto;
+
+/**
+ * Generate a cryptographically secure 32-bit random number.
+ * Uses hardware CSPRNG (RNG) when PKI is available, falls back to random() on minimal builds.
+ */
+uint32_t cryptoSecureRandom32();

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -192,15 +192,14 @@ PacketId generatePacketId()
         didInit = true;
 
         // pick a random initial sequence number at boot (to prevent repeated reboots always starting at 0)
-        // Note: we mask the high order bit to ensure that we never pass a 'negative' number to random
-        rollingPacketId = random(UINT32_MAX & 0x7fffffff);
+        rollingPacketId = cryptoSecureRandom32();
         LOG_DEBUG("Initial packet id %u", rollingPacketId);
     }
 
     rollingPacketId++;
 
-    rollingPacketId &= ID_COUNTER_MASK;                                    // Mask out the top 22 bits
-    PacketId id = rollingPacketId | random(UINT32_MAX & 0x7fffffff) << 10; // top 22 bits
+    rollingPacketId &= ID_COUNTER_MASK;                                         // Mask out the top 22 bits
+    PacketId id = rollingPacketId | (cryptoSecureRandom32() & 0xFFFFFC00); // top 22 bits from CSPRNG
     LOG_DEBUG("Partially randomized packet id %u", id);
     return id;
 }


### PR DESCRIPTION
## Summary

- Replace all 4 uses of Arduino `random()` in cryptographic code paths with hardware-backed CSPRNG (`RNG.rand()` from the Crypto library)
- Affected paths: PKI key generation entropy, PKI nonce generation (extraNonce), and packet ID generation (used as nonce input for ALL channel encryption)
- Add `cryptoSecureRandom32()` helper function accessible from all platform builds, with graceful fallback to `random()` on minimal builds that exclude PKI
- Fix type mismatch: `extraNonceTmp` was `long` (sign-extended on 32-bit platforms) but written as `uint32_t` via memcpy

## Why this matters

Arduino `random()` uses a linear congruential generator (LCG) seeded from `analogRead()`. LCG output is trivially predictable after observing a few values. Since packet IDs feed directly into AES-CTR/CCM nonces, predictable packet IDs = predictable nonces = catastrophic for encryption security (nonce reuse enables plaintext recovery).

## Test plan

- [x] All `test_crypto` tests pass (SHA256, ECB, DH25519, AES-CTR, PKC round-trip)
- [x] All other native test suites pass (one pre-existing failure in `test_transmit_history` unrelated to this change)
- [ ] Verify on nRF52840 (RAK4631) that packet IDs are generated and encryption works normally
- [ ] Verify on ESP32 that `cryptoSecureRandom32()` links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)