### PR TITLE
fix: prevent integer underflow in hop routing arithmetic

### DIFF
--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -151,14 +151,19 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                         LOG_INFO("Traffic management: exhausting hops for 0x%08x, setting hop_limit=0", getFrom(p));
                     } else if (shouldDecrementHopLimit(p)) {
                         // Use shared logic to determine if hop_limit should be decremented
-                        tosend->hop_limit--; // bump down the hop count
+                        if (tosend->hop_limit > 0)
+                            tosend->hop_limit--; // bump down the hop count
                     } else {
                         LOG_INFO("favorite-ROUTER/CLIENT_BASE-to-ROUTER/CLIENT_BASE rebroadcast: preserving hop_limit");
                     }
 #if USERPREFS_EVENT_MODE
                     if (tosend->hop_limit > 2) {
-                        // if we are "correcting" the hop_limit, "correct" the hop_start by the same amount to preserve hops away.
-                        tosend->hop_start -= (tosend->hop_limit - 2);
+                        // Correct hop_limit to max 2 for event mode, adjusting hop_start to preserve hops-away metric.
+                        uint8_t reduction = tosend->hop_limit - 2;
+                        if (tosend->hop_start >= reduction)
+                            tosend->hop_start -= reduction;
+                        else
+                            tosend->hop_start = 0; // clamp to prevent uint8_t underflow
                         tosend->hop_limit = 2;
                     }
 #endif


### PR DESCRIPTION
## Summary

- Add bounds check before `hop_limit--` decrement in `NextHopRouter::perhapsRebroadcast()` as defense-in-depth against uint8_t underflow (0 wrapping to 255 = infinite relay loop)
- Fix `hop_start -= (hop_limit - 2)` in EVENT_MODE to clamp instead of underflowing when a packet arrives with `hop_start < hop_limit` (crafted or buggy packet)

## Why this matters

Both `hop_limit` and `hop_start` are `uint8_t`. Unsigned integer underflow wraps to 255:

- **hop_limit underflow**: A packet with hop_limit=255 would be relayed by every node on the mesh up to 255 times, consuming all available airtime and draining batteries across the entire network.
- **hop_start underflow**: Corrupts the "hops away" metric (`hop_start - hop_limit`) for every downstream node, breaking routing quality decisions.

A malicious node (or buggy firmware) could craft packets with `hop_start=1, hop_limit=7` to trigger the EVENT_MODE underflow on any node running event mode.

## Test plan

- [x] All 152 native test cases pass
- [ ] Verify on hardware that normal hop decrement behavior is unchanged
- [ ] Verify EVENT_MODE hop clamping works correctly with edge case values

🤖 Generated with [Claude Code](https://claude.com/claude-code)