### PR TITLE
fix: use constant-time comparison for admin key checks

### DIFF
--- a/src/meshUtils.cpp
+++ b/src/meshUtils.cpp
@@ -79,6 +79,19 @@ bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes)
     return true;
 }
 
+int constantTimeCompare(const uint8_t *a, const uint8_t *b, size_t len)
+{
+    if (len == 0)
+        return 0;
+    if (!a || !b)
+        return -1;
+    volatile uint8_t d = 0;
+    for (size_t i = 0; i < len; i++) {
+        d |= (a[i] ^ b[i]);
+    }
+    return (d == 0) ? 0 : -1;
+}
+
 bool isOneOf(int item, int count, ...)
 {
     va_list args;

--- a/src/meshUtils.h
+++ b/src/meshUtils.h
@@ -33,6 +33,9 @@ bool memfll(const uint8_t *mem, uint8_t find, size_t numbytes);
 
 bool isOneOf(int item, int count, ...);
 
+// Constant-time comparison of two byte arrays (timing-safe alternative to memcmp for secrets)
+int constantTimeCompare(const uint8_t *a, const uint8_t *b, size_t len);
+
 const std::string vformat(const char *const zcFormat, ...);
 
 // Get actual string length for nanopb char array fields.

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -98,11 +98,11 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         }
     } else if (mp.pki_encrypted) {
         if ((config.security.admin_key[0].size == 32 &&
-             memcmp(mp.public_key.bytes, config.security.admin_key[0].bytes, 32) == 0) ||
+             constantTimeCompare(mp.public_key.bytes, config.security.admin_key[0].bytes, 32) == 0) ||
             (config.security.admin_key[1].size == 32 &&
-             memcmp(mp.public_key.bytes, config.security.admin_key[1].bytes, 32) == 0) ||
+             constantTimeCompare(mp.public_key.bytes, config.security.admin_key[1].bytes, 32) == 0) ||
             (config.security.admin_key[2].size == 32 &&
-             memcmp(mp.public_key.bytes, config.security.admin_key[2].bytes, 32) == 0)) {
+             constantTimeCompare(mp.public_key.bytes, config.security.admin_key[2].bytes, 32) == 0)) {
             LOG_INFO("PKC admin payload with authorized sender key");
 
             // Automatically favorite the node that is using the admin key
@@ -1477,7 +1477,7 @@ bool AdminModule::checkPassKey(meshtastic_AdminMessage *res)
     printBytes("Incoming session key: ", res->session_passkey.bytes, 8);
     printBytes("Expected session key: ", session_passkey, 8);
     return (session_time + 300 > millis() / 1000 && res->session_passkey.size == 8 &&
-            memcmp(res->session_passkey.bytes, session_passkey, 8) == 0);
+            constantTimeCompare(res->session_passkey.bytes, session_passkey, 8) == 0);
 }
 
 bool AdminModule::messageIsResponse(const meshtastic_AdminMessage *r)


### PR DESCRIPTION
## Summary

- Add `constantTimeCompare()` utility function to `meshUtils.h/cpp` for timing-safe byte array comparison
- Replace 4 `memcmp()` calls in `AdminModule.cpp` that compare security-sensitive key material:
  - 3 admin public key comparisons (authorization gate for remote admin access)
  - 1 session passkey comparison (session authentication)

## Why this matters

`memcmp()` returns early on the first differing byte, leaking which bytes of the secret match via response timing. For admin key comparison, this means an attacker can brute-force the 32-byte admin public key one byte at a time (256 * 32 = 8,192 attempts) instead of brute-forcing the full key space.

While LoRa timing attacks are harder than TCP, an attacker with an SDR at close range can measure response latency with sub-millisecond precision. Admin key compromise grants full remote control: config changes, channel key extraction, firmware updates, and factory reset.

The new `constantTimeCompare()` uses XOR accumulation with `volatile` to prevent compiler optimization, matching the existing pattern in `aes-ccm.cpp` (which was `static` and not available to other modules).

## Test plan

- [x] All native test suites pass (151/151, one pre-existing flaky failure in transmit_history)
- [x] `test_admin_radio` passes (exercises admin module code paths)
- [ ] Verify on hardware that admin key authentication still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)