### PR TITLE
fix: redact MQTT password from log output

### DIFF
--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -322,8 +322,8 @@ bool connectPubSub(const PubSubConfig &config, PubSubClient &pubSub, Client &cli
     pubSub.setClient(client);
     pubSub.setServer(config.serverAddr.c_str(), config.serverPort);
 
-    LOG_INFO("Connecting directly to MQTT server %s, port: %d, username: %s, password: %s", config.serverAddr.c_str(),
-             config.serverPort, config.mqttUsername, config.mqttPassword);
+    LOG_INFO("Connecting directly to MQTT server %s, port: %d, username: %s, password: ***", config.serverAddr.c_str(),
+             config.serverPort, config.mqttUsername);
 
     // Generate node ID from nodenum for client identification
     std::string nodeId = nodeDB->getNodeId();


### PR DESCRIPTION
## Summary
- MQTT password was logged in cleartext via `LOG_INFO` when connecting to the broker (`MQTT.cpp:325`), exposing credentials to anyone with access to serial/debug output
- Replaced password format specifier with static `***` mask -- username is still logged for debugging

## Test plan
- [ ] Verify MQTT connection still works (password is passed to `pubSub.connect()` unchanged)
- [ ] Verify log output shows `password: ***` instead of the actual password
- [ ] All 152 native tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)