### PR TITLE
Revert "Add include directive for mbedtls error handling in build flags"

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -39,7 +39,6 @@ build_flags =
   -Wall
   -Wextra
   -Isrc/platform/esp32
-  -include mbedtls/error.h
   -std=gnu++17
   -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG
   -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG


### PR DESCRIPTION
This reverts commit 391928ed08c267647af641dfc807338d7ea30129.

Fixes compile error under pioarduino:

<command-line>: fatal error: mbedtls/error.h: No such file or directory

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
