### PR TITLE
Update RadioLib to 7.6.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -114,7 +114,7 @@ lib_deps =
 [radiolib_base]
 lib_deps =
 	# renovate: datasource=custom.pio depName=RadioLib packageName=jgromes/library/RadioLib
-	jgromes/RadioLib@7.5.0
+	jgromes/RadioLib@7.6.0
 
 [device-ui_base]
 lib_deps =


### PR DESCRIPTION
Released February 20th.

Since we're soon going to have to upgrade RadioLib again to add in LR2021 support, let's first upgrade to the latest officially released version. This way we can test our existing modules and have a little bit less of a delta for the next jump.