### PR TITLE
meshtasticd: Add configs for luckfox-lyra-zero-w (mPWRD-OS)

### DIFF
--- a/bin/config.d/lora-lyra-zero-MeshAdv-900M30S.yaml
+++ b/bin/config.d/lora-lyra-zero-MeshAdv-900M30S.yaml
@@ -1,0 +1,39 @@
+# MeshAdv-Pi E22-900M30S
+# https://github.com/chrismyers2000/MeshAdv-Pi-Hat
+Meta:
+  name: MeshAdv-Pi E22-900M30S
+  support: community
+  compatible:
+    - luckfox-lyra-zero-w # Armbian
+
+Lora:
+  Module: sx1262
+  CS: # GPIO0_C2 (physical 40)
+    pin: 18
+    gpiochip: 0
+    line: 18
+  IRQ: # GPIO1_D1 (physical 36)
+    pin: 57
+    gpiochip: 1
+    line: 25
+  Busy: # GPIO0_C1 (physical 38)
+    pin: 17
+    gpiochip: 0
+    line: 17
+  Reset: # GPIO0_B6 (physical 12)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  TXen: # GPIO1_C2 (physical 33)
+    pin: 50
+    gpiochip: 1
+    line: 18
+  RXen: # GPIO1_D2 (physical 32)
+    pin: 58
+    gpiochip: 1
+    line: 26
+  DIO3_TCXO_VOLTAGE: true
+  # Only for E22-900M33S:
+  # Limit the output power to 8 dBm
+  # SX126X_MAX_POWER: 8
+  spidev: spidev0.0

--- a/bin/config.d/lora-lyra-zero-MeshAdv-Mini-900M22S.yaml
+++ b/bin/config.d/lora-lyra-zero-MeshAdv-Mini-900M22S.yaml
@@ -1,0 +1,33 @@
+# MeshAdv Mini E22-900M22S
+# https://github.com/chrismyers2000/MeshAdv-Mini
+Meta:
+  name: MeshAdv Mini E22-900M22S
+  support: community
+  compatible:
+    - luckfox-lyra-zero-w # Armbian
+
+Lora:
+  Module: sx1262 # Ebyte E22-900M22S
+  CS: # GPIO0_B2_d (phys 24, RPi CE0)
+    pin: 10
+    gpiochip: 0
+    line: 10
+  IRQ: # GPIO1_D1_d (phys 36, RPi GPIO16)
+    pin: 57
+    gpiochip: 1
+    line: 25
+  Busy: # GPIO0_C1_d (phys 38, RPi GPIO20)
+    pin: 17
+    gpiochip: 0
+    line: 17
+  Reset: # GPIO0_B4_d (phys 18, RPi GPIO24)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  RXen: # GPIO1_D2_d (phys 32, RPi GPIO12)
+    pin: 58
+    gpiochip: 1
+    line: 26
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: spidev0.0

--- a/bin/config.d/lora-lyra-zero-RAK6421-13300-slot1.yaml
+++ b/bin/config.d/lora-lyra-zero-RAK6421-13300-slot1.yaml
@@ -1,0 +1,38 @@
+Meta:
+  name: RAK6421 + RAK13300 Slot 1
+  support: community # Promote when tested
+  compatible:
+    - luckfox-lyra-zero-w # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_A5 (IO6)
+    pin: 5
+    gpiochip: 0
+    line: 5
+  Reset: # GPIO1_D1 (IO4)
+    pin: 57
+    gpiochip: 1
+    line: 25
+  Busy: # GPIO0_B4 (IO5)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  # Ant_sw: # GPIO1_C2 (IO3)
+  #   pin: 50
+  #   gpiochip: 1
+  #   line: 18
+  Enable_Pins:
+    - pin: 58 # GPIO1_D2
+      gpiochip: 1
+      line: 26
+    - pin: 50 # GPIO1_C2
+      gpiochip: 1
+      line: 18
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+  # CS: # GPIO0_B2
+  #   pin: 10
+  #   gpiochip: 0
+  #   line: 10

--- a/bin/config.d/lora-lyra-zero-RAK6421-13300-slot2.yaml
+++ b/bin/config.d/lora-lyra-zero-RAK6421-13300-slot2.yaml
@@ -1,0 +1,36 @@
+Meta:
+  name: RAK6421 + RAK13300 Slot 2
+  support: community # Promote when tested
+  compatible:
+    - luckfox-lyra-zero-w # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_B6 (IO6)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  Reset: # GPIO0_B4 (IO4)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  Busy: # GPIO1_C0 (IO5)
+    pin: 48
+    gpiochip: 1
+    line: 16
+  # Ant_sw: # GPIO0_B5 (IO3)
+  #   pin: 13
+  #   gpiochip: 0
+  #   line: 13
+  Enable_Pins:
+    - pin: 51 # GPIO1_C3
+      gpiochip: 1
+      line: 19
+    - pin: 13 # GPIO0_B5
+      gpiochip: 0
+      line: 13
+  spidev: spidev0.1
+  # CS: # GPIO0_B1
+  #   pin: 9
+  #   gpiochip: 0
+  #   line: 9

--- a/bin/config.d/lora-lyra-zero-RAK6421-13302-slot1.yaml
+++ b/bin/config.d/lora-lyra-zero-RAK6421-13302-slot1.yaml
@@ -1,0 +1,39 @@
+Meta:
+  name: RAK6421 + RAK13300 Slot 1
+  support: community # Promote when tested
+  compatible:
+    - luckfox-lyra-zero-w # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_A5 (IO6)
+    pin: 5
+    gpiochip: 0
+    line: 5
+  Reset: # GPIO1_D1 (IO4)
+    pin: 57
+    gpiochip: 1
+    line: 25
+  Busy: # GPIO0_B4 (IO5)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  # Ant_sw: # GPIO1_C2 (IO3)
+  #   pin: 50
+  #   gpiochip: 1
+  #   line: 18
+  Enable_Pins:
+    - pin: 58 # GPIO1_D2
+      gpiochip: 1
+      line: 26
+    - pin: 50 # GPIO1_C2
+      gpiochip: 1
+      line: 18
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+  # CS: # GPIO0_B2
+  #   pin: 10
+  #   gpiochip: 0
+  #   line: 10
+  TX_GAIN_LORA: [9, 9, 10, 11, 9, 8, 9, 10, 10, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 10, 9, 8]

--- a/bin/config.d/lora-lyra-zero-RAK6421-13302-slot2.yaml
+++ b/bin/config.d/lora-lyra-zero-RAK6421-13302-slot2.yaml
@@ -1,0 +1,37 @@
+Meta:
+  name: RAK6421 + RAK13300 Slot 2
+  support: community # Promote when tested
+  compatible:
+    - luckfox-lyra-zero-w # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_B6 (IO6)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  Reset: # GPIO0_B4 (IO4)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  Busy: # GPIO1_C0 (IO5)
+    pin: 48
+    gpiochip: 1
+    line: 16
+  # Ant_sw: # GPIO0_B5 (IO3)
+  #   pin: 13
+  #   gpiochip: 0
+  #   line: 13
+  Enable_Pins:
+    - pin: 51 # GPIO1_C3
+      gpiochip: 1
+      line: 19
+    - pin: 13 # GPIO0_B5
+      gpiochip: 0
+      line: 13
+  spidev: spidev0.1
+  # CS: # GPIO0_B1
+  #   pin: 9
+  #   gpiochip: 0
+  #   line: 9
+  TX_GAIN_LORA: [9, 9, 10, 11, 9, 8, 9, 10, 10, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 10, 9, 8]

--- a/bin/config.d/lora-lyra-zero-waveshare-sxxx.yaml
+++ b/bin/config.d/lora-lyra-zero-waveshare-sxxx.yaml
@@ -1,0 +1,30 @@
+Meta:
+  name: Waveshare SX1262
+  support: deprecated
+  compatible:
+    - luckfox-lyra-zero-w # Armbian
+
+Lora:
+  Module: sx1262  # Waveshare SX126X XXXM
+  DIO2_AS_RF_SWITCH: true
+  CS: # GPIO0_C2 (physical 40)
+    pin: 18
+    gpiochip: 0
+    line: 18
+  IRQ: # GPIO1_D1 (physical 36)
+    pin: 57
+    gpiochip: 1
+    line: 25
+  Busy: # GPIO0_C1 (physical 38)
+    pin: 17
+    gpiochip: 0
+    line: 17
+  Reset: # GPIO0_B6 (physical 12)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  SX126X_ANT_SW: # GPIO1_B3 (physical 31)
+    pin: 43
+    gpiochip: 1
+    line: 11
+  spidev: spidev0.0


### PR DESCRIPTION
Add configs for all Pi Hats (except RF95 :vomiting_face:) for luckfox-lyra-zero-w.
https://www.luckfox.com/Luckfox-Lyra-Zero-W

For use with mPWRD-OS.

These configs were generated programatically by Opus 4.6.
See: https://github.com/vidplace7/meshtasticd-40pin

Tested with MeshAdv-Mini, other pinmaps are untested but should work.

RAK6421 support should be promoted from `community` to `official` once each configuration has been tested.