### PR TITLE
meshtasticd: Add configs for ebyte-ecb41-pge (mPWRD-OS)

### DIFF
--- a/bin/config.d/lora-ecb41-pge-MeshAdv-900M30S.yaml
+++ b/bin/config.d/lora-ecb41-pge-MeshAdv-900M30S.yaml
@@ -1,0 +1,39 @@
+# MeshAdv-Pi E22-900M30S
+# https://github.com/chrismyers2000/MeshAdv-Pi-Hat
+Meta:
+  name: MeshAdv-Pi E22-900M30S
+  support: community
+  compatible:
+    - ebyte-ecb41-pge # Armbian
+
+Lora:
+  Module: sx1262
+  CS: # GPIO0_A1 (physical 40)
+    pin: 1
+    gpiochip: 0
+    line: 1
+  IRQ: # GPIO0_A3 (physical 36)
+    pin: 3
+    gpiochip: 0
+    line: 3
+  Busy: # GPIO0_A0 (physical 38)
+    pin: 0
+    gpiochip: 0
+    line: 0
+  Reset: # GPIO0_B4 (physical 12)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  TXen: # GPIO1_D1 (physical 33)
+    pin: 57
+    gpiochip: 1
+    line: 25
+  RXen: # GPIO1_B3 (physical 32)
+    pin: 43
+    gpiochip: 1
+    line: 11
+  DIO3_TCXO_VOLTAGE: true
+  # Only for E22-900M33S:
+  # Limit the output power to 8 dBm
+  # SX126X_MAX_POWER: 8
+  spidev: spidev0.0

--- a/bin/config.d/lora-ecb41-pge-MeshAdv-Mini-900M22S.yaml
+++ b/bin/config.d/lora-ecb41-pge-MeshAdv-Mini-900M22S.yaml
@@ -1,0 +1,33 @@
+# MeshAdv Mini E22-900M22S
+# https://github.com/chrismyers2000/MeshAdv-Mini
+Meta:
+  name: MeshAdv Mini E22-900M22S
+  support: community
+  compatible:
+    - ebyte-ecb41-pge # Armbian
+
+Lora:
+  Module: sx1262 # Ebyte E22-900M22S
+  CS: # GPIO0_B6 (physical 24, SPI1_CSN0)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  IRQ: # GPIO0_A3 (physical 36)
+    pin: 3
+    gpiochip: 0
+    line: 3
+  Busy: # GPIO0_A0 (physical 38)
+    pin: 0
+    gpiochip: 0
+    line: 0
+  Reset: # GPIO1_C3 (physical 18)
+    pin: 51
+    gpiochip: 1
+    line: 19
+  RXen: # GPIO1_B3 (physical 32)
+    pin: 43
+    gpiochip: 1
+    line: 11
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: spidev0.0

--- a/bin/config.d/lora-ecb41-pge-RAK6421-13300-slot1.yaml
+++ b/bin/config.d/lora-ecb41-pge-RAK6421-13300-slot1.yaml
@@ -1,0 +1,38 @@
+Meta:
+  name: RAK6421 + RAK13300 Slot 1
+  support: community # Promote when tested
+  compatible:
+    - ebyte-ecb41-pge # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_A5 (IO6, physical 15)
+    pin: 5
+    gpiochip: 0
+    line: 5
+  Reset: # GPIO0_A3 (IO4, physical 36)
+    pin: 3
+    gpiochip: 0
+    line: 3
+  Busy: # GPIO1_C3 (IO5, physical 18)
+    pin: 51
+    gpiochip: 1
+    line: 19
+  # Ant_sw: # GPIO1_C2 (IO3, physical 16)
+  #   pin: 50
+  #   gpiochip: 1
+  #   line: 18
+  Enable_Pins:
+    - pin: 43 # GPIO1_B3 (physical 32)
+      gpiochip: 1
+      line: 11
+    - pin: 57 # GPIO1_D1 (physical 33)
+      gpiochip: 1
+      line: 25
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+  # CS: # GPIO0_B6 (SPI1_CSN0, physical 24)
+  #   pin: 14
+  #   gpiochip: 0
+  #   line: 14

--- a/bin/config.d/lora-ecb41-pge-RAK6421-13300-slot2.yaml
+++ b/bin/config.d/lora-ecb41-pge-RAK6421-13300-slot2.yaml
@@ -1,0 +1,36 @@
+Meta:
+  name: RAK6421 + RAK13300 Slot 2
+  support: community # Promote when tested
+  compatible:
+    - ebyte-ecb41-pge # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_B4 (IO6, physical 12)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  Reset: # GPIO1_C3 (IO4, physical 18)
+    pin: 51
+    gpiochip: 1
+    line: 19
+  Busy: # GPIO0_B3 (IO5, physical 35)
+    pin: 11
+    gpiochip: 0
+    line: 11
+  # Ant_sw: # GPIO1_C2 (IO3, physical 16)
+  #   pin: 50
+  #   gpiochip: 1
+  #   line: 18
+  Enable_Pins:
+    - pin: 2 # GPIO0_A2 (physical 37)
+      gpiochip: 0
+      line: 2
+    - pin: 50 # GPIO1_C2 (physical 16)
+      gpiochip: 1
+      line: 18
+  spidev: spidev0.1
+  # CS: # GPIO0_A7 (SPI1_CSN1, physical 26)
+  #   pin: 7
+  #   gpiochip: 0
+  #   line: 7

--- a/bin/config.d/lora-ecb41-pge-RAK6421-13302-slot1.yaml
+++ b/bin/config.d/lora-ecb41-pge-RAK6421-13302-slot1.yaml
@@ -1,0 +1,39 @@
+Meta:
+  name: RAK6421 + RAK13302 Slot 1
+  support: community # Promote when tested
+  compatible:
+    - ebyte-ecb41-pge # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_A5 (IO6, physical 15)
+    pin: 5
+    gpiochip: 0
+    line: 5
+  Reset: # GPIO0_A3 (IO4, physical 36)
+    pin: 3
+    gpiochip: 0
+    line: 3
+  Busy: # GPIO1_C3 (IO5, physical 18)
+    pin: 51
+    gpiochip: 1
+    line: 19
+  # Ant_sw: # GPIO1_C2 (IO3, physical 16)
+  #   pin: 50
+  #   gpiochip: 1
+  #   line: 18
+  Enable_Pins:
+    - pin: 43 # GPIO1_B3 (physical 32)
+      gpiochip: 1
+      line: 11
+    - pin: 57 # GPIO1_D1 (physical 33)
+      gpiochip: 1
+      line: 25
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+  # CS: # GPIO0_B6 (SPI1_CSN0, physical 24)
+  #   pin: 14
+  #   gpiochip: 0
+  #   line: 14
+  TX_GAIN_LORA: [9, 9, 10, 11, 9, 8, 9, 10, 10, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 10, 9, 8]

--- a/bin/config.d/lora-ecb41-pge-RAK6421-13302-slot2.yaml
+++ b/bin/config.d/lora-ecb41-pge-RAK6421-13302-slot2.yaml
@@ -1,0 +1,37 @@
+Meta:
+  name: RAK6421 + RAK13302 Slot 2
+  support: community # Promote when tested
+  compatible:
+    - ebyte-ecb41-pge # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_B4 (IO6, physical 12)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  Reset: # GPIO1_C3 (IO4, physical 18)
+    pin: 51
+    gpiochip: 1
+    line: 19
+  Busy: # GPIO0_B3 (IO5, physical 35)
+    pin: 11
+    gpiochip: 0
+    line: 11
+  # Ant_sw: # GPIO1_C2 (IO3, physical 16)
+  #   pin: 50
+  #   gpiochip: 1
+  #   line: 18
+  Enable_Pins:
+    - pin: 2 # GPIO0_A2 (physical 37)
+      gpiochip: 0
+      line: 2
+    - pin: 50 # GPIO1_C2 (physical 16)
+      gpiochip: 1
+      line: 18
+  spidev: spidev0.1
+  # CS: # GPIO0_A7 (SPI1_CSN1, physical 26)
+  #   pin: 7
+  #   gpiochip: 0
+  #   line: 7
+  TX_GAIN_LORA: [9, 9, 10, 11, 9, 8, 9, 10, 10, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 10, 9, 8]

--- a/bin/config.d/lora-ecb41-pge-waveshare-sxxx.yaml
+++ b/bin/config.d/lora-ecb41-pge-waveshare-sxxx.yaml
@@ -1,0 +1,30 @@
+Meta:
+  name: Waveshare SX1262
+  support: deprecated
+  compatible:
+    - ebyte-ecb41-pge # Armbian
+
+Lora:
+  Module: sx1262  # Waveshare SX126X XXXM
+  DIO2_AS_RF_SWITCH: true
+  CS: # GPIO0_A1 (physical 40)
+    pin: 1
+    gpiochip: 0
+    line: 1
+  IRQ: # GPIO0_A3 (physical 36)
+    pin: 3
+    gpiochip: 0
+    line: 3
+  Busy: # GPIO0_A0 (physical 38)
+    pin: 0
+    gpiochip: 0
+    line: 0
+  Reset: # GPIO0_B4 (physical 12)
+    pin: 12
+    gpiochip: 0
+    line: 12
+  SX126X_ANT_SW: # GPIO1_B2 (physical 31)
+    pin: 42
+    gpiochip: 1
+    line: 10
+  spidev: spidev0.0


### PR DESCRIPTION
Add configs for all Pi Hats (except RF95 :vomiting_face:) for `ebyte-ecb41-pge`
https://www.cdebyte.com/products/ECB41-PGE1N2-N

For use with mPWRD-OS.

These configs were generated programatically by Opus 4.6.
See: https://github.com/vidplace7/meshtasticd-40pin

Tested with MeshAdv-Pi, other pinmaps are untested but should work.

RAK6421 support should be promoted from `community` to `official` once each configuration has been tested.