### PR TITLE
meshtasticd: Add configs for forlinx-ok3506-s12 (mPWRD-OS)

### DIFF
--- a/bin/config.d/lora-ok3506-MeshAdv-900M30S.yaml
+++ b/bin/config.d/lora-ok3506-MeshAdv-900M30S.yaml
@@ -1,0 +1,41 @@
+# !! WARNING: Hats on the OK3506 board are installed "backwards" (facing outwards)
+
+# MeshAdv-Pi E22-900M30S
+# https://github.com/chrismyers2000/MeshAdv-Pi-Hat
+Meta:
+  name: MeshAdv-Pi E22-900M30S
+  support: community
+  compatible:
+    - forlinx-ok3506-s12 # Armbian
+
+Lora:
+  Module: sx1262
+  CS: # GPIO0_B0 (physical 40)
+    pin: 8
+    gpiochip: 0
+    line: 8
+  IRQ: # GPIO3_B0 (physical 36)
+    pin: 104
+    gpiochip: 3
+    line: 8
+  Busy: # GPIO0_B1 (physical 38)
+    pin: 9
+    gpiochip: 0
+    line: 9
+  Reset: # GPIO0_B6 (physical 12)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  TXen: # GPIO0_A3 (physical 33)
+    pin: 3
+    gpiochip: 0
+    line: 3
+  RXen: # GPIO0_A2 (physical 32)
+    pin: 2
+    gpiochip: 0
+    line: 2
+  DIO3_TCXO_VOLTAGE: true
+  # Only for E22-900M33S:
+  # Limit the output power to 8 dBm
+  # SX126X_MAX_POWER: 8
+  spidev: spidev0.0

--- a/bin/config.d/lora-ok3506-MeshAdv-Mini-900M22S.yaml
+++ b/bin/config.d/lora-ok3506-MeshAdv-Mini-900M22S.yaml
@@ -1,0 +1,35 @@
+# !! WARNING: Hats on the OK3506 board are installed "backwards" (facing outwards)
+
+# MeshAdv Mini E22-900M22S
+# https://github.com/chrismyers2000/MeshAdv-Mini
+Meta:
+  name: MeshAdv Mini E22-900M22S
+  support: community
+  compatible:
+    - forlinx-ok3506-s12 # Armbian
+
+Lora:
+  Module: sx1262 # Ebyte E22-900M22S
+  CS: # GPIO0_C3 (physical 24, SPI0_CSN0)
+    pin: 19
+    gpiochip: 0
+    line: 19
+  IRQ: # GPIO3_B0 (physical 36)
+    pin: 104
+    gpiochip: 3
+    line: 8
+  Busy: # GPIO0_B1 (physical 38)
+    pin: 9
+    gpiochip: 0
+    line: 9
+  Reset: # GPIO3_A6 (physical 18)
+    pin: 102
+    gpiochip: 3
+    line: 6
+  RXen: # GPIO0_A2 (physical 32)
+    pin: 2
+    gpiochip: 0
+    line: 2
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: spidev0.0

--- a/bin/config.d/lora-ok3506-RAK6421-13300-slot1.yaml
+++ b/bin/config.d/lora-ok3506-RAK6421-13300-slot1.yaml
@@ -1,0 +1,40 @@
+# !! WARNING: Hats on the OK3506 board are installed "backwards" (facing outwards)
+
+Meta:
+  name: RAK6421 + RAK13300 Slot 1
+  support: community # Promote when tested
+  compatible:
+    - forlinx-ok3506-s12 # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO3_B5 (IO6, physical 15)
+    pin: 109
+    gpiochip: 3
+    line: 13
+  Reset: # GPIO3_B0 (IO4, physical 36)
+    pin: 104
+    gpiochip: 3
+    line: 8
+  Busy: # GPIO3_A6 (IO5, physical 18)
+    pin: 102
+    gpiochip: 3
+    line: 6
+  # Ant_sw: # GPIO0_A3 (IO3, physical 33)
+  #   pin: 3
+  #   gpiochip: 0
+  #   line: 3
+  Enable_Pins:
+    - pin: 2 # GPIO0_A2 (physical 32)
+      gpiochip: 0
+      line: 2
+    - pin: 3 # GPIO0_A3 (physical 33)
+      gpiochip: 0
+      line: 3
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+  # CS: # GPIO0_C3 (SPI0_CSN0, physical 24)
+  #   pin: 19
+  #   gpiochip: 0
+  #   line: 19

--- a/bin/config.d/lora-ok3506-RAK6421-13300-slot2.yaml
+++ b/bin/config.d/lora-ok3506-RAK6421-13300-slot2.yaml
@@ -1,0 +1,38 @@
+# !! WARNING: Hats on the OK3506 board are installed "backwards" (facing outwards)
+
+Meta:
+  name: RAK6421 + RAK13300 Slot 2
+  support: community # Promote when tested
+  compatible:
+    - forlinx-ok3506-s12 # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_B6 (IO6, physical 12)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  Reset: # GPIO3_A6 (IO4, physical 18)
+    pin: 102
+    gpiochip: 3
+    line: 6
+  Busy: # GPIO0_B2 (IO5, physical 35)
+    pin: 10
+    gpiochip: 0
+    line: 10
+  # Ant_sw: # GPIO3_A7 (IO3, physical 16)
+  #   pin: 103
+  #   gpiochip: 3
+  #   line: 7
+  Enable_Pins:
+    - pin: 106 # GPIO3_B2 (physical 37)
+      gpiochip: 3
+      line: 10
+    - pin: 103 # GPIO3_A7 (physical 16)
+      gpiochip: 3
+      line: 7
+  spidev: spidev0.1
+  # CS: # GPIO0_B7 (SPI0_CSN1, physical 26)
+  #   pin: 15
+  #   gpiochip: 0
+  #   line: 15

--- a/bin/config.d/lora-ok3506-RAK6421-13302-slot1.yaml
+++ b/bin/config.d/lora-ok3506-RAK6421-13302-slot1.yaml
@@ -1,0 +1,41 @@
+# !! WARNING: Hats on the OK3506 board are installed "backwards" (facing outwards)
+
+Meta:
+  name: RAK6421 + RAK13302 Slot 1
+  support: community # Promote when tested
+  compatible:
+    - forlinx-ok3506-s12 # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO3_B5 (IO6, physical 15)
+    pin: 109
+    gpiochip: 3
+    line: 13
+  Reset: # GPIO3_B0 (IO4, physical 36)
+    pin: 104
+    gpiochip: 3
+    line: 8
+  Busy: # GPIO3_A6 (IO5, physical 18)
+    pin: 102
+    gpiochip: 3
+    line: 6
+  # Ant_sw: # GPIO0_A3 (IO3, physical 33)
+  #   pin: 3
+  #   gpiochip: 0
+  #   line: 3
+  Enable_Pins:
+    - pin: 2 # GPIO0_A2 (physical 32)
+      gpiochip: 0
+      line: 2
+    - pin: 3 # GPIO0_A3 (physical 33)
+      gpiochip: 0
+      line: 3
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+  # CS: # GPIO0_C3 (SPI0_CSN0, physical 24)
+  #   pin: 19
+  #   gpiochip: 0
+  #   line: 19
+  TX_GAIN_LORA: [9, 9, 10, 11, 9, 8, 9, 10, 10, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 10, 9, 8]

--- a/bin/config.d/lora-ok3506-RAK6421-13302-slot2.yaml
+++ b/bin/config.d/lora-ok3506-RAK6421-13302-slot2.yaml
@@ -1,0 +1,39 @@
+# !! WARNING: Hats on the OK3506 board are installed "backwards" (facing outwards)
+
+Meta:
+  name: RAK6421 + RAK13302 Slot 2
+  support: community # Promote when tested
+  compatible:
+    - forlinx-ok3506-s12 # Armbian
+
+Lora:
+  Module: sx1262
+  IRQ: # GPIO0_B6 (IO6, physical 12)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  Reset: # GPIO3_A6 (IO4, physical 18)
+    pin: 102
+    gpiochip: 3
+    line: 6
+  Busy: # GPIO0_B2 (IO5, physical 35)
+    pin: 10
+    gpiochip: 0
+    line: 10
+  # Ant_sw: # GPIO3_A7 (IO3, physical 16)
+  #   pin: 103
+  #   gpiochip: 3
+  #   line: 7
+  Enable_Pins:
+    - pin: 106 # GPIO3_B2 (physical 37)
+      gpiochip: 3
+      line: 10
+    - pin: 103 # GPIO3_A7 (physical 16)
+      gpiochip: 3
+      line: 7
+  spidev: spidev0.1
+  # CS: # GPIO0_B7 (SPI0_CSN1, physical 26)
+  #   pin: 15
+  #   gpiochip: 0
+  #   line: 15
+  TX_GAIN_LORA: [9, 9, 10, 11, 9, 8, 9, 10, 10, 10, 11, 12, 12, 12, 12, 12, 12, 12, 12, 10, 9, 8]

--- a/bin/config.d/lora-ok3506-waveshare-sxxx.yaml
+++ b/bin/config.d/lora-ok3506-waveshare-sxxx.yaml
@@ -1,0 +1,32 @@
+# !! WARNING: Hats on the OK3506 board are installed "backwards" (facing outwards)
+
+Meta:
+  name: Waveshare SX1262
+  support: deprecated
+  compatible:
+    - forlinx-ok3506-s12 # Armbian
+
+Lora:
+  Module: sx1262  # Waveshare SX126X XXXM
+  DIO2_AS_RF_SWITCH: true
+  CS: # GPIO0_B0 (physical 40)
+    pin: 8
+    gpiochip: 0
+    line: 8
+  IRQ: # GPIO3_B0 (physical 36)
+    pin: 104
+    gpiochip: 3
+    line: 8
+  Busy: # GPIO0_B1 (physical 38)
+    pin: 9
+    gpiochip: 0
+    line: 9
+  Reset: # GPIO0_B6 (physical 12)
+    pin: 14
+    gpiochip: 0
+    line: 14
+  SX126X_ANT_SW: # GPIO3_B3 (physical 31)
+    pin: 107
+    gpiochip: 3
+    line: 11
+  spidev: spidev0.0


### PR DESCRIPTION
Add configs for all Pi Hats (except RF95 :vomiting_face:) for `forlinx-ok3506-s12`
https://www.forlinx.net/product/rk3506-s12-mini-sbc-170.html

![PXL_20260406_001612676](https://github.com/user-attachments/assets/354f02d8-92c1-41c5-ae78-a0f4bb21c0c0)


For use with mPWRD-OS.

These configs were generated programatically by Opus 4.6.
See: https://github.com/vidplace7/meshtasticd-40pin

Tested with MeshAdv-Pi, other pinmaps are untested but should work.

RAK6421 support should be promoted from `community` to `official` once each configuration has been tested.