### PR TITLE
Feat/stm32 rtc

### DIFF
--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -6,6 +6,9 @@
 #include <Throttle.h>
 #include <sys/time.h>
 #include <time.h>
+#if defined(ARCH_STM32WL) && HAS_RTC
+#include <STM32RTC.h>
+#endif
 
 static RTCQuality currentQuality = RTCQualityNone;
 uint32_t lastSetFromPhoneNtpOrGps = 0;
@@ -161,6 +164,48 @@ RTCSetResult readFromRTC()
             return RTCSetResultSuccess;
         }
     }
+#elif defined(ARCH_STM32WL)
+#if HAS_RTC
+    {
+        uint32_t now = millis();
+        STM32RTC &rtc = STM32RTC::getInstance();
+        if (!rtc.isConfigured()) {
+#ifdef RCC_LSEDRIVE_CONFIG
+            __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_CONFIG);
+#endif
+            rtc.setClockSource(STM32RTC::LSE_CLOCK);
+            rtc.begin();
+        }
+        if (!rtc.isTimeSet()) {
+            return RTCSetResultNotSet;
+        }
+#ifdef HAL_RTC_MODULE_ENABLED
+        // Wait for shadow register sync (RSF flag) after INIT mode exit or a recent
+        // setEpoch() write; without this getEpoch() may return stale data.
+        HAL_RTC_WaitForSynchro(rtc.getHandle());
+#endif
+        tv.tv_sec = rtc.getEpoch();
+        tv.tv_usec = 0;
+        uint32_t printableEpoch = tv.tv_sec;
+        LOG_DEBUG("Read RTC time from STM32 RTC as %ld", printableEpoch);
+#ifdef BUILD_EPOCH
+        if (tv.tv_sec < BUILD_EPOCH) {
+            if (Throttle::isWithinTimespanMs(lastTimeValidationWarning, TIME_VALIDATION_WARNING_INTERVAL_MS) == false) {
+                LOG_WARN("Ignore time (%ld) before build epoch (%ld)!", printableEpoch, BUILD_EPOCH);
+                lastTimeValidationWarning = millis();
+            }
+            return RTCSetResultInvalidTime;
+        }
+#endif
+        if (currentQuality == RTCQualityNone) {
+            timeStartMsec = now;
+            zeroOffsetSecs = tv.tv_sec;
+            currentQuality = RTCQualityDevice;
+        }
+        return RTCSetResultSuccess;
+    }
+#endif // HAS_RTC
+    // HAS_RTC == 0: no LSE crystal on this board, fall through to RTCSetResultNotSet
 #else
     if (!gettimeofday(&tv, NULL)) {
         uint32_t now = millis();
@@ -291,6 +336,12 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
             } else {
                 LOG_WARN("Failed to set time for RX8130CE");
             }
+        }
+#elif defined(ARCH_STM32WL) && HAS_RTC
+        {
+            STM32RTC &rtc = STM32RTC::getInstance();
+            rtc.setEpoch(tv->tv_sec);
+            LOG_DEBUG("STM32 RTC setEpoch %ld", (uint32_t)tv->tv_sec);
         }
 #elif defined(ARCH_ESP32)
         settimeofday(tv, NULL);

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -198,9 +198,11 @@ RTCSetResult readFromRTC()
         }
 #endif
         if (currentQuality == RTCQualityNone) {
+            RTCQuality oldQuality = currentQuality;
             timeStartMsec = now;
             zeroOffsetSecs = tv.tv_sec;
             currentQuality = RTCQualityDevice;
+            triggerNodeInfoCheckOnTimeSource(oldQuality, currentQuality);
         }
         return RTCSetResultSuccess;
     }

--- a/src/graphics/draw/UIRenderer.cpp
+++ b/src/graphics/draw/UIRenderer.cpp
@@ -5,6 +5,7 @@
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "NodeListRenderer.h"
+#include "RTC.h"
 #include "UIRenderer.h"
 #include "airtime.h"
 #include "gps/GeoCoord.h"
@@ -15,7 +16,6 @@
 #include "main.h"
 #include "target_specific.h"
 #include <OLEDDisplay.h>
-#include <RTC.h>
 #include <cstring>
 
 // External variables

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -29,8 +29,8 @@
 #if !MESHTASTIC_EXCLUDE_MQTT
 #include "mqtt/MQTT.h"
 #endif
+#include "RTC.h"
 #include "Throttle.h"
-#include <RTC.h>
 
 // Flag to indicate a heartbeat was received and we should send queue status
 bool heartbeatReceived = false;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -39,7 +39,7 @@
 #include <machine/endian.h>
 #define ntohl __ntohl
 #endif
-#include <RTC.h>
+#include "RTC.h"
 
 MQTT *mqtt;
 

--- a/variants/stm32/rak3172/variant.h
+++ b/variants/stm32/rak3172/variant.h
@@ -19,4 +19,10 @@ Do not expect a working Meshtastic device with this target.
 #define RAK3172
 #define SERIAL_PRINT_PORT 1
 
+// RAK3172 has a built-in 32.768 kHz LSE crystal, so use internal RTC
+// Drive level from here:
+// https://github.com/RAKWireless/RAK-STM32-RUI/blob/main/variants/WisDuo_RAK3172_Evaluation_Board/rui_inner_main.c
+#define HAS_RTC 1
+#define RCC_LSEDRIVE_CONFIG RCC_LSEDRIVE_LOW
+
 #endif

--- a/variants/stm32/russell/variant.h
+++ b/variants/stm32/russell/variant.h
@@ -38,4 +38,8 @@
 // https://github.com/stm32duino/Arduino_Core_STM32/blob/main/variants/STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U/variant_RAK3172_MODULE.h
 #define RAK3172
 
+// Use RTC in RAK3172 module
+#define HAS_RTC 1
+#define RCC_LSEDRIVE_CONFIG RCC_LSEDRIVE_LOW
+
 #endif

--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -16,6 +16,7 @@ build_flags =
   ${arduino_base.build_flags}
   -flto
   -Isrc/platform/stm32wl -g
+  -iquote src/gps ; Required due to overlap of src/gps/RTC.h and STM32 rtc.h on case-insensitive filesystems
   -DMESHTASTIC_EXCLUDE_AUDIO=1
   -DMESHTASTIC_EXCLUDE_ATAK=1 ; ATAK is quite big, disable it for big flash savings.
   -DMESHTASTIC_EXCLUDE_INPUTBROKER=1
@@ -53,6 +54,8 @@ lib_deps =
   ${radiolib_base.lib_deps}
   # renovate: datasource=git-refs depName=caveman99-stm32-Crypto packageName=https://github.com/caveman99/Crypto gitBranch=main
   https://github.com/caveman99/Crypto/archive/1aa30eb536bd52a576fde6dfa393bf7349cf102d.zip
+  # renovate: datasource=github-releases depName=stm32duino/STM32RTC
+  https://github.com/stm32duino/STM32RTC/archive/refs/tags/1.9.0.zip
 
 lib_ignore =
   OneButton

--- a/variants/stm32/wio-e5/variant.h
+++ b/variants/stm32/wio-e5/variant.h
@@ -19,4 +19,10 @@ Do not expect a working Meshtastic device with this target.
 
 #define WIO_E5
 
+// Wio-E5 has a built-in 32.768 kHz LSE crystal, so use internal RTC
+// Drive level from here:
+// https://github.com/Seeed-Studio/LoRaWan-E5-Node/blob/main/Projects/Applications/LoRaWAN/LoRaWAN_End_Node/Core/Src/main.c
+#define HAS_RTC 1
+#define RCC_LSEDRIVE_CONFIG RCC_LSEDRIVE_LOW
+
 #endif


### PR DESCRIPTION
Implement LSE-backed hardware RTC using STM32RTC library:

Add a proper ARCH_STM32WL branch in readFromRTC() and perhapsSetRTC() backed by the STM32duino STM32RTC library (1.9.0), using the hardware RTC peripheral with LSE_CLOCK as the clock source. The branch is guarded by HAS_RTC, which should be set to 1 only in variant files for boards that have a 32.768kHz LSE crystal populated.

The LSE drive strength is configured per-board via RCC_LSEDRIVE_CONFIG (one of the RCC_LSEDRIVE_* values), set before begin() so it takes effect before the library starts the LSE oscillator. When HAS_RTC=0, the branch returns RTCSetResultNotSet immediately without touching zeroOffsetSecs, bypassing the broken gettimeofday() fallback.

Add STM32duino RTC to stm32.ini lib_deps and HAL_RTC_MODULE_ENABLED to build_flags. LTO strips the unused RTC code on HAS_RTC=0 boards.

Coincidentally this also fixes an issue for STM32 targets, where they previously fell through to a gettimeofday() fallback in readFromRTC() that returns millis()/1000 on STM32duino — not a Unix timestamp — silently corrupting zeroOffsetSecs on first boot.

Also changed incorrect include convention for RTC.h in src/graphics/draw/UIRenderer.cpp and src/mesh/PhoneAPI.cpp which caused clashing includes with STM32's rtc.h on case-insensitive file systems.

Implemented to Wio-E5, RAK3172 and Russell variant (Russell build will fail due to another bug, fix in #10097).

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
- [x] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
    - [x] RAK3172
    - [x] Wio-E5
