### PR TITLE
Modify log output to show milliseconds

### DIFF
--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -137,7 +137,7 @@ void RedirectablePrint::log_to_serial(const char *logLevel, const char *format, 
         if (color) {
             ::printf("\u001b[0m");
         }
-        ::printf("| %02d:%02d:%02d %u ", hour, min, sec, millis() / 1000);
+        ::printf("| %02d:%02d:%02d %u.%03u ", hour, min, sec, millis() / 1000, millis() % 1000);
 #else
         printf("%s ", logLevel);
         if (color) {
@@ -151,7 +151,7 @@ void RedirectablePrint::log_to_serial(const char *logLevel, const char *format, 
         if (color) {
             ::printf("\u001b[0m");
         }
-        ::printf("| ??:??:?? %u ", millis() / 1000);
+        ::printf("| ??:??:?? %u.%03u ", millis() / 1000, millis() % 1000);
 #else
         printf("%s ", logLevel);
         if (color) {


### PR DESCRIPTION
Very useful for tracking down performance and timing quirks.