### PR TITLE
fix(esp32): remove mbedtls/error.h include causing pioarduino compile error

### DIFF
--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -39,7 +39,6 @@ build_flags =
   -Wall
   -Wextra
   -Isrc/platform/esp32
-  -include mbedtls/error.h
   -std=gnu++17
   -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG
   -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG


### PR DESCRIPTION
## Summary

Reverts commit 391928ed08c267647af641dfc807338d7ea30129 which added `-include mbedtls/error.h` to ESP32 build flags. This header does not exist under pioarduino, causing compilation failures.

## Changes

- `variants/esp32/esp32-common.ini`: Remove `-include mbedtls/error.h` from build_flags

## Testing

- [ ] Compilation succeeds on ESP32 targets with pioarduino

Fixes #10073