### PR TITLE
fix(mesh): remove unused PointerQueue::dequeuePtrFromISR

### DIFF
--- a/src/mesh/PointerQueue.h
+++ b/src/mesh/PointerQueue.h
@@ -17,14 +17,4 @@ template <class T> class PointerQueue : public TypedQueue<T *>
 
         return this->dequeue(&p, maxWait) ? p : nullptr;
     }
-
-#ifdef HAS_FREE_RTOS
-    // returns a ptr or null if the queue was empty
-    T *dequeuePtrFromISR(BaseType_t *higherPriWoken)
-    {
-        T *p;
-
-        return this->dequeueFromISR(&p, higherPriWoken) ? p : nullptr;
-    }
-#endif
 };


### PR DESCRIPTION
## Summary

Dead code removal - `PointerQueue::dequeuePtrFromISR` has no callers since commit db766f1 (#99). The underlying `dequeueFromISR` remains available in `TypedQueue` for future use.

## Changes

- `src/mesh/PointerQueue.h`: Remove `dequeuePtrFromISR()` method (-10 lines)

## Testing

- [x] Confirmed no callers exist in codebase

Fixes #10090