### PR TITLE
fix(esp32): resolve T-Beam WiFi crash (abort) introduced in v2.7.21

### DIFF
--- a/src/mesh/wifi/WiFiAPClient.cpp
+++ b/src/mesh/wifi/WiFiAPClient.cpp
@@ -401,7 +401,9 @@ static void WiFiEvent(WiFiEvent_t event)
             WiFi.disconnect(false, true);
             syslog.disable();
             needReconnect = true;
-            wifiReconnect->setIntervalFromNow(1000);
+            if (wifiReconnect) {
+                wifiReconnect->setIntervalFromNow(1000);
+            }
         }
         break;
     case ARDUINO_EVENT_WIFI_STA_AUTHMODE_CHANGE:
@@ -431,7 +433,9 @@ static void WiFiEvent(WiFiEvent_t event)
             WiFi.disconnect(false, true);
             syslog.disable();
             needReconnect = true;
-            wifiReconnect->setIntervalFromNow(1000);
+            if (wifiReconnect) {
+                wifiReconnect->setIntervalFromNow(1000);
+            }
         }
         break;
     case ARDUINO_EVENT_WPS_ER_SUCCESS:

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -165,18 +165,30 @@ void esp32Setup()
 // #define APP_WATCHDOG_SECS 45
 #define APP_WATCHDOG_SECS 90
 
-#ifdef CONFIG_IDF_TARGET_ESP32C6
-    esp_task_wdt_config_t *wdt_config = (esp_task_wdt_config_t *)malloc(sizeof(esp_task_wdt_config_t));
-    wdt_config->timeout_ms = APP_WATCHDOG_SECS * 1000;
-    wdt_config->trigger_panic = true;
-    res = esp_task_wdt_init(wdt_config);
-    assert(res == ESP_OK);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+    // IDF 5.1+ uses esp_task_wdt_reconfigure to handle pre-initialized TWDT
+    esp_task_wdt_config_t wdt_config;
+    wdt_config.timeout_ms = APP_WATCHDOG_SECS * 1000;
+    wdt_config.trigger_panic = true;
+    res = esp_task_wdt_reconfigure(&wdt_config);
+    if (res == ESP_ERR_INVALID_STATE) {
+        // TWDT not yet initialized, initialize it now
+        res = esp_task_wdt_init(&wdt_config);
+    }
+    if (res != ESP_OK) {
+        LOG_WARN("Failed to (re)configure watchdog timer: 0x%x", res);
+    }
 #else
+    // IDF < 5.1: use legacy init, TWDT not pre-initialized by the framework
     res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
-    assert(res == ESP_OK);
+    if (res != ESP_OK) {
+        LOG_WARN("Failed to initialize watchdog timer: 0x%x", res);
+    }
 #endif
     res = esp_task_wdt_add(NULL);
-    assert(res == ESP_OK);
+    if (res != ESP_OK) {
+        LOG_WARN("Failed to add task to watchdog timer: 0x%x", res);
+    }
 
 #if HAS_32768HZ
     enableSlowCLK();


### PR DESCRIPTION
## Summary

Two bugs exposed by removing `createSSLCert()` which previously masked them via timing.

### Part 1 - Watchdog IDF v5.x compatibility (`main-esp32.cpp`)
- Replace fragile `#ifdef CONFIG_IDF_TARGET_ESP32C6` with proper `ESP_IDF_VERSION >= 5.1` check
- Use `esp_task_wdt_reconfigure()` first; fall back to `init()` if TWDT not yet initialized by framework
- Replace `assert()` with `LOG_WARN` - watchdog failures are non-fatal
- Fix memory leak: config now stack-allocated, not malloc'd

### Part 2 - Null-safe WiFi event handlers (`WiFiAPClient.cpp`)
- Guard `wifiReconnect->setIntervalFromNow()` with `if(wifiReconnect)` in `ARDUINO_EVENT_WIFI_STA_DISCONNECTED` and `LOST_IP` handlers
- Prevents null dereference between `WiFi.onEvent()` registration and `new Periodic()` assignment

## Testing

- [ ] Heltec (Lora32) V3
- [ ] LilyGo T-Deck
- [ ] LilyGo T-Beam
- [ ] RAK WisBlock 4631
- [ ] Seeed Studio T-1000E tracker card

Fixes #10108