### PR TITLE
Docker: Pull images from Google/AWS during build

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -56,23 +56,31 @@ jobs:
           echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
         id: version
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          cache-image: true
+
+      - name: Docker setup
+        uses: docker/setup-buildx-action@v4
+        with:
+          # Add Google/Amazon DockerHub mirrors to buildkit config
+          # https://docs.docker.com/build/ci/github-actions/configure-builder/#registry-mirror
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io", "public.ecr.aws"]
+
+      - name: Sanitize platform string
+        id: sanitize_platform
+        # Replace slashes with underscores
+        run: echo "cleaned_platform=${{ inputs.platform }}" | sed 's/\//_/g' >> $GITHUB_OUTPUT
+
       - name: Docker login
         if: ${{ inputs.push }}
         uses: docker/login-action@v4
         with:
           username: meshtastic
           password: ${{ secrets.DOCKER_FIRMWARE_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Docker setup
-        uses: docker/setup-buildx-action@v4
-
-      - name: Sanitize platform string
-        id: sanitize_platform
-        # Replace slashes with underscores
-        run: echo "cleaned_platform=${{ inputs.platform }}" | sed 's/\//_/g' >> $GITHUB_OUTPUT
 
       - name: Docker tag
         id: meta
@@ -95,3 +103,6 @@ jobs:
           platforms: ${{ inputs.platform }}
           build-args: |
             PIO_ENV=${{ inputs.pio_env }}
+          # Cache image layers in GitHub Actions cache to speed up subsequent builds.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
- Use Google / Amazon mirrors, not DockerHub, when pulling images for Docker builds.
- Login to DockerHub *after* setup (run setup unauthenticated).

Should prevent Docker ratelimiting during CI (Actions) builds.

This will need to be backmerged to `develop`