### PR TITLE
Switch PlatformIO deps from PIO Registry to tagged GitHub zips

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -131,107 +131,115 @@ lib_deps =
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]
 lib_deps =
-	# renovate: datasource=custom.pio depName=Adafruit BusIO packageName=adafruit/library/Adafruit BusIO
-	adafruit/Adafruit BusIO@1.17.4
-	# renovate: datasource=custom.pio depName=Adafruit Unified Sensor packageName=adafruit/library/Adafruit Unified Sensor
-	adafruit/Adafruit Unified Sensor@1.1.15
-	# renovate: datasource=custom.pio depName=Adafruit BMP280 packageName=adafruit/library/Adafruit BMP280 Library
-	adafruit/Adafruit BMP280 Library@3.0.0
-	# renovate: datasource=custom.pio depName=Adafruit BMP085 packageName=adafruit/library/Adafruit BMP085 Library
-	adafruit/Adafruit BMP085 Library@1.2.4
-	# renovate: datasource=custom.pio depName=Adafruit BME280 packageName=adafruit/library/Adafruit BME280 Library
-	adafruit/Adafruit BME280 Library@2.3.0
-	# renovate: datasource=custom.pio depName=Adafruit DPS310 packageName=adafruit/library/Adafruit DPS310
-	adafruit/Adafruit DPS310@1.1.6
-	# renovate: datasource=custom.pio depName=Adafruit MCP9808 packageName=adafruit/library/Adafruit MCP9808 Library
-	adafruit/Adafruit MCP9808 Library@2.0.2
-	# renovate: datasource=custom.pio depName=Adafruit INA260 packageName=adafruit/library/Adafruit INA260 Library
-	adafruit/Adafruit INA260 Library@1.5.3
-	# renovate: datasource=custom.pio depName=Adafruit INA219 packageName=adafruit/library/Adafruit INA219
-	adafruit/Adafruit INA219@1.2.3
-	# renovate: datasource=custom.pio depName=Adafruit MPU6050 packageName=adafruit/library/Adafruit MPU6050
-	adafruit/Adafruit MPU6050@2.2.9
-	# renovate: datasource=custom.pio depName=Adafruit LIS3DH packageName=adafruit/library/Adafruit LIS3DH
-	adafruit/Adafruit LIS3DH@1.3.0
-	# renovate: datasource=custom.pio depName=Adafruit AHTX0 packageName=adafruit/library/Adafruit AHTX0
-	adafruit/Adafruit AHTX0@2.0.6
-	# renovate: datasource=custom.pio depName=Adafruit LSM6DS packageName=adafruit/library/Adafruit LSM6DS
-	adafruit/Adafruit LSM6DS@4.7.4
-	# renovate: datasource=custom.pio depName=Adafruit TSL2591 packageName=adafruit/library/Adafruit TSL2591 Library
-	adafruit/Adafruit TSL2591 Library@1.4.5
-	# renovate: datasource=custom.pio depName=EmotiBit MLX90632 packageName=emotibit/library/EmotiBit MLX90632
-	emotibit/EmotiBit MLX90632@1.0.8
-	# renovate: datasource=custom.pio depName=Adafruit MLX90614 packageName=adafruit/library/Adafruit MLX90614 Library
-	adafruit/Adafruit MLX90614 Library@2.1.6
+	# renovate: datasource=github-tags depName=Adafruit BusIO packageName=adafruit/Adafruit_BusIO
+	https://github.com/adafruit/Adafruit_BusIO/archive/refs/tags/1.17.4.zip
+	# renovate: datasource=github-tags depName=Adafruit Unified Sensor packageName=adafruit/Adafruit_Sensor
+	https://github.com/adafruit/Adafruit_Sensor/archive/refs/tags/1.1.15.zip
+	# renovate: datasource=github-tags depName=Adafruit GFX packageName=adafruit/Adafruit-GFX-Library
+	https://github.com/adafruit/Adafruit-GFX-Library/archive/refs/tags/1.12.6.zip
+	# renovate: datasource=github-tags depName=NeoPixel packageName=adafruit/Adafruit_NeoPixel
+	https://github.com/adafruit/Adafruit_NeoPixel/archive/refs/tags/1.15.4.zip
+	# renovate: datasource=github-tags depName=Adafruit SSD1306 packageName=adafruit/Adafruit_SSD1306
+	https://github.com/adafruit/Adafruit_SSD1306/archive/refs/tags/2.5.16.zip
+	# renovate: datasource=github-tags depName=Adafruit BMP280 packageName=adafruit/Adafruit_BMP280_Library
+	https://github.com/adafruit/Adafruit_BMP280_Library/archive/refs/tags/3.0.0.zip
+	# renovate: datasource=github-tags depName=Adafruit BMP085 packageName=adafruit/Adafruit-BMP085-Library
+	https://github.com/adafruit/Adafruit-BMP085-Library/archive/refs/tags/1.2.4.zip
+	# renovate: datasource=github-tags depName=Adafruit BME280 packageName=adafruit/Adafruit_BME280_Library
+	https://github.com/adafruit/Adafruit_BME280_Library/archive/refs/tags/2.3.0.zip
+	# renovate: datasource=github-tags depName=Adafruit DPS310 packageName=adafruit/Adafruit_DPS310
+	https://github.com/adafruit/Adafruit_DPS310/archive/refs/tags/1.1.6.zip
+	# renovate: datasource=github-tags depName=Adafruit SH110x packageName=adafruit/Adafruit_SH110x
+	https://github.com/adafruit/Adafruit_SH110x/archive/refs/tags/2.1.14.zip
+	# renovate: datasource=github-tags depName=Adafruit MCP9808 packageName=adafruit/Adafruit_MCP9808_Library
+	https://github.com/adafruit/Adafruit_MCP9808_Library/archive/refs/tags/2.0.2.zip
+	# renovate: datasource=github-tags depName=Adafruit INA260 packageName=adafruit/Adafruit_INA260
+	https://github.com/adafruit/Adafruit_INA260/archive/refs/tags/1.5.3.zip
+	# renovate: datasource=github-tags depName=Adafruit INA219 packageName=adafruit/Adafruit_INA219
+	https://github.com/adafruit/Adafruit_INA219/archive/refs/tags/1.2.3.zip
+	# renovate: datasource=github-tags depName=Adafruit MPU6050 packageName=adafruit/Adafruit_MPU6050
+	https://github.com/adafruit/Adafruit_MPU6050/archive/refs/tags/2.2.9.zip
+	# renovate: datasource=github-tags depName=Adafruit LIS3DH packageName=adafruit/Adafruit_LIS3DH
+	https://github.com/adafruit/Adafruit_LIS3DH/archive/refs/tags/1.3.0.zip
+	# renovate: datasource=github-tags depName=Adafruit AHTX0 packageName=adafruit/Adafruit_AHTX0
+	https://github.com/adafruit/Adafruit_AHTX0/archive/refs/tags/2.0.6.zip
+	# renovate: datasource=github-tags depName=Adafruit LSM6DS packageName=adafruit/Adafruit_LSM6DS
+	https://github.com/adafruit/Adafruit_LSM6DS/archive/refs/tags/4.7.4.zip
+	# renovate: datasource=github-tags depName=Adafruit TSL2591 packageName=adafruit/Adafruit_TSL2591_Library
+	https://github.com/adafruit/Adafruit_TSL2591_Library/archive/refs/tags/1.4.5.zip
+	# renovate: datasource=github-tags depName=EmotiBit MLX90632 packageName=emotibit/EmotiBit_MLX90632
+	https://github.com/EmotiBit/EmotiBit_MLX90632/archive/refs/tags/v1.0.8.zip
+	# renovate: datasource=github-tags depName=Adafruit MLX90614 packageName=adafruit/Adafruit_MLX90614
+	https://github.com/adafruit/Adafruit-MLX90614-Library/archive/refs/tags/2.1.6.zip
 	# renovate: datasource=git-refs depName=INA3221 packageName=https://github.com/sgtwilko/INA3221 gitBranch=FixOverflow
 	https://github.com/sgtwilko/INA3221/archive/bb03d7e9bfcc74fc798838a54f4f99738f29fc6a.zip
-	# renovate: datasource=custom.pio depName=QMC5883L Compass packageName=mprograms/library/QMC5883LCompass
-	mprograms/QMC5883LCompass@1.2.3
-	# renovate: datasource=custom.pio depName=DFRobot_RTU packageName=dfrobot/library/DFRobot_RTU
-	dfrobot/DFRobot_RTU@1.0.6
+	# renovate: datasource=github-tags depName=QMC5883L Compass packageName=mprograms/QMC5883LCompass
+	https://github.com/mprograms/QMC5883LCompass/archive/refs/tags/v1.2.3.zip
+	# renovate: datasource=github-tags depName=DFRobot_RTU packageName=dfrobot/DFRobot_RTU
+	https://github.com/DFRobot/DFRobot_RTU/archive/refs/tags/V1.0.6.zip
 	# renovate: datasource=git-refs depName=DFRobot_RainfallSensor packageName=https://github.com/DFRobot/DFRobot_RainfallSensor gitBranch=master
 	https://github.com/DFRobot/DFRobot_RainfallSensor/archive/38fea5e02b40a5430be6dab39a99a6f6347d667e.zip
-	# renovate: datasource=custom.pio depName=INA226 packageName=robtillaart/library/INA226
-	robtillaart/INA226@0.6.6
-	# renovate: datasource=custom.pio depName=SparkFun MAX3010x packageName=sparkfun/library/SparkFun MAX3010x Pulse and Proximity Sensor Library
-	sparkfun/SparkFun MAX3010x Pulse and Proximity Sensor Library@1.1.2
-	# renovate: datasource=custom.pio depName=SparkFun 9DoF IMU Breakout ICM 20948 packageName=sparkfun/library/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library
-	sparkfun/SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library@1.3.2
-	# renovate: datasource=custom.pio depName=Adafruit LTR390 Library packageName=adafruit/library/Adafruit LTR390 Library
-	adafruit/Adafruit LTR390 Library@1.1.2
-	# renovate: datasource=custom.pio depName=Adafruit PCT2075 packageName=adafruit/library/Adafruit PCT2075
-	adafruit/Adafruit PCT2075@1.0.6
-	# renovate: datasource=custom.pio depName=DFRobot_BMM150 packageName=dfrobot/library/DFRobot_BMM150
-	dfrobot/DFRobot_BMM150@1.0.0
-	# renovate: datasource=custom.pio depName=Adafruit_TSL2561 packageName=adafruit/library/Adafruit TSL2561
-	adafruit/Adafruit TSL2561@1.1.3
-	# renovate: datasource=custom.pio depName=BH1750_WE packageName=wollewald/library/BH1750_WE
-	wollewald/BH1750_WE@1.1.10
+	# renovate: datasource=github-tags depName=INA226 packageName=robtillaart/INA226
+	https://github.com/RobTillaart/INA226/archive/refs/tags/0.6.6.zip
+	# renovate: datasource=github-tags depName=SparkFun MAX3010x packageName=sparkfun/SparkFun_MAX3010x_Sensor_Library
+	https://github.com/sparkfun/SparkFun_MAX3010x_Sensor_Library/archive/refs/tags/v1.1.2.zip
+	# renovate: datasource=github-tags depName=SparkFun 9DoF IMU Breakout ICM 20948 packageName=sparkfun/SparkFun_ICM-20948_ArduinoLibrary
+	https://github.com/sparkfun/SparkFun_ICM-20948_ArduinoLibrary/archive/refs/tags/v1.3.2.zip
+	# renovate: datasource=github-tags depName=Adafruit LTR390 Library packageName=adafruit/Adafruit_LTR390
+	https://github.com/adafruit/Adafruit_LTR390/archive/refs/tags/1.1.2.zip
+	# renovate: datasource=github-tags depName=Adafruit PCT2075 packageName=adafruit/Adafruit_PCT2075
+	https://github.com/adafruit/Adafruit_PCT2075/archive/refs/tags/1.0.6.zip
+	# renovate: datasource=github-tags depName=DFRobot_BMM150 packageName=dfrobot/DFRobot_BMM150
+	https://github.com/DFRobot/DFRobot_BMM150/archive/refs/tags/V1.0.0.zip
+	# renovate: datasource=github-tags depName=Adafruit_TSL2561 packageName=adafruit/Adafruit_TSL2561
+	https://github.com/adafruit/Adafruit_TSL2561/archive/refs/tags/1.1.3.zip
+	# renovate: datasource=github-tags depName=BH1750_WE packageName=wollewald/BH1750_WE
+	https://github.com/wollewald/BH1750_WE/archive/refs/tags/1.1.10.zip
 
 ; Common environmental sensor libraries (not included in native / portduino)
 [environmental_extra_common]
 lib_deps =
-	# renovate: datasource=custom.pio depName=Adafruit BMP3XX packageName=adafruit/library/Adafruit BMP3XX Library
-	adafruit/Adafruit BMP3XX Library@2.1.6
-	# renovate: datasource=custom.pio depName=Adafruit MAX1704X packageName=adafruit/library/Adafruit MAX1704X
-	adafruit/Adafruit MAX1704X@1.0.3
-	# renovate: datasource=custom.pio depName=Adafruit SHTC3 packageName=adafruit/library/Adafruit SHTC3 Library
-	adafruit/Adafruit SHTC3 Library@1.0.2
-	# renovate: datasource=custom.pio depName=Adafruit LPS2X packageName=adafruit/library/Adafruit LPS2X
-	adafruit/Adafruit LPS2X@2.0.6
-	# renovate: datasource=custom.pio depName=Adafruit SHT31 packageName=adafruit/library/Adafruit SHT31 Library
-	adafruit/Adafruit SHT31 Library@2.2.2
-	# renovate: datasource=custom.pio depName=Adafruit VEML7700 packageName=adafruit/library/Adafruit VEML7700 Library
-	adafruit/Adafruit VEML7700 Library@2.1.6
-	# renovate: datasource=custom.pio depName=Adafruit SHT4x packageName=adafruit/library/Adafruit SHT4x Library
-	adafruit/Adafruit SHT4x Library@1.0.5
-	# renovate: datasource=custom.pio depName=SparkFun Qwiic Scale NAU7802 packageName=sparkfun/library/SparkFun Qwiic Scale NAU7802 Arduino Library
-	sparkfun/SparkFun Qwiic Scale NAU7802 Arduino Library@1.0.6
+	# renovate: datasource=github-tags depName=Adafruit BMP3XX packageName=adafruit/Adafruit_BMP3XX
+	https://github.com/adafruit/Adafruit_BMP3XX/archive/refs/tags/2.1.6.zip
+	# renovate: datasource=github-tags depName=Adafruit MAX1704X packageName=adafruit/Adafruit_MAX1704X
+	https://github.com/adafruit/Adafruit_MAX1704X/archive/refs/tags/1.0.3.zip
+	# renovate: datasource=github-tags depName=Adafruit SHTC3 packageName=adafruit/Adafruit_SHTC3
+	https://github.com/adafruit/Adafruit_SHTC3/archive/refs/tags/1.0.2.zip
+	# renovate: datasource=github-tags depName=Adafruit LPS2X packageName=adafruit/Adafruit_LPS2X
+	https://github.com/adafruit/Adafruit_LPS2X/archive/refs/tags/2.0.6.zip
+	# renovate: datasource=github-tags depName=Adafruit SHT31 packageName=adafruit/Adafruit_SHT31
+	https://github.com/adafruit/Adafruit_SHT31/archive/refs/tags/2.2.2.zip
+	# renovate: datasource=github-tags depName=Adafruit VEML7700 packageName=adafruit/Adafruit_VEML7700
+	https://github.com/adafruit/Adafruit_VEML7700/archive/refs/tags/2.1.6.zip
+	# renovate: datasource=github-tags depName=Adafruit SHT4x packageName=adafruit/Adafruit_SHT4X
+	https://github.com/adafruit/Adafruit_SHT4X/archive/refs/tags/1.0.5.zip
+	# renovate: datasource=github-tags depName=SparkFun Qwiic Scale NAU7802 packageName=sparkfun/SparkFun_Qwiic_Scale_NAU7802_Arduino_Library
+	https://github.com/sparkfun/SparkFun_Qwiic_Scale_NAU7802_Arduino_Library/archive/refs/tags/v1.0.6.zip
 	# renovate: datasource=custom.pio depName=ClosedCube OPT3001 packageName=closedcube/library/ClosedCube OPT3001
 	closedcube/ClosedCube OPT3001@1.1.2
 	# renovate: datasource=git-refs depName=meshtastic-DFRobot_LarkWeatherStation packageName=https://github.com/meshtastic/DFRobot_LarkWeatherStation gitBranch=master
 	https://github.com/meshtastic/DFRobot_LarkWeatherStation/archive/4de3a9cadef0f6a5220a8a906cf9775b02b0040d.zip
-	# renovate: datasource=custom.pio depName=Sensirion Core packageName=sensirion/library/Sensirion Core
-	sensirion/Sensirion Core@0.7.3
-	# renovate: datasource=custom.pio depName=Sensirion I2C SCD4x packageName=sensirion/library/Sensirion I2C SCD4x
-	sensirion/Sensirion I2C SCD4x@1.1.0
-	# renovate: datasource=custom.pio depName=Sensirion I2C SFA3x packageName=sensirion/library/Sensirion I2C SFA3x
-	sensirion/Sensirion I2C SFA3x@1.0.0
-	# renovate: datasource=custom.pio depName=Sensirion I2C SCD30 packageName=sensirion/library/Sensirion I2C SCD30
-	sensirion/Sensirion I2C SCD30@1.0.0
+	# renovate: datasource=github-tags depName=Sensirion Core packageName=sensirion/arduino-core
+	https://github.com/Sensirion/arduino-core/archive/refs/tags/0.7.3.zip
+	# renovate: datasource=github-tags depName=Sensirion I2C SCD4x packageName=sensirion/arduino-i2c-scd4x
+	https://github.com/Sensirion/arduino-i2c-scd4x/archive/refs/tags/1.1.0.zip
+	# renovate: datasource=github-tags depName=Sensirion I2C SFA3x packageName=sensirion/arduino-i2c-sfa3x
+	https://github.com/Sensirion/arduino-i2c-sfa3x/archive/refs/tags/1.0.0.zip
+	# renovate: datasource=github-tags depName=Sensirion I2C SCD30 packageName=sensirion/arduino-i2c-scd30
+	https://github.com/Sensirion/arduino-i2c-scd30/archive/refs/tags/1.0.0.zip
 
 ; Environmental sensors with BSEC2 (Bosch proprietary IAQ)
 [environmental_extra]
 lib_deps =
 	${environmental_extra_common.lib_deps}
-	# renovate: datasource=custom.pio depName=Bosch BSEC2 packageName=boschsensortec/library/bsec2
-	boschsensortec/bsec2@1.10.2610
-	# renovate: datasource=custom.pio depName=Bosch BME68x packageName=boschsensortec/library/BME68x Sensor Library
-	boschsensortec/BME68x Sensor Library@1.3.40408
+	# renovate: datasource=github-tags depName=Bosch BSEC2 packageName=boschsensortec/Bosch-BSEC2-Library
+	https://github.com/boschsensortec/Bosch-BSEC2-Library/archive/refs/tags/1.10.2610.zip
+	# renovate: datasource=github-tags depName=Bosch BME68x packageName=boschsensortec/Bosch-BME68x-Library
+	https://github.com/boschsensortec/Bosch-BME68x-Library/archive/refs/tags/v1.3.40408.zip
 
 ; Environmental sensors without BSEC (saves ~3.5KB DRAM for original ESP32 targets)
 [environmental_extra_no_bsec]
 lib_deps =
 	${environmental_extra_common.lib_deps}
-	# renovate: datasource=custom.pio depName=Adafruit_BME680 packageName=adafruit/library/Adafruit BME680 Library
-	adafruit/Adafruit BME680 Library@2.0.6
+	# renovate: datasource=github-tags depName=Adafruit_BME680 packageName=adafruit/Adafruit_BME680
+	https://github.com/adafruit/Adafruit_BME680/archive/refs/tags/2.0.6.zip

--- a/variants/esp32/betafpv_2400_tx_micro/platformio.ini
+++ b/variants/esp32/betafpv_2400_tx_micro/platformio.ini
@@ -13,7 +13,3 @@ board_build.f_cpu = 240000000L
 upload_protocol = esptool
 ;upload_port = /dev/ttyUSB0
 upload_speed = 460800
-lib_deps =
-  ${esp32_base.lib_deps}
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4

--- a/variants/esp32c3/heltec_hru_3601/platformio.ini
+++ b/variants/esp32c3/heltec_hru_3601/platformio.ini
@@ -5,6 +5,3 @@ build_flags =
   ${esp32c3_base.build_flags}
   -D HELTEC_HRU_3601
   -I variants/esp32c3/heltec_hru_3601
-lib_deps = ${esp32c3_base.lib_deps}
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4

--- a/variants/esp32c6/m5stack_unitc6l/platformio.ini
+++ b/variants/esp32c6/m5stack_unitc6l/platformio.ini
@@ -23,8 +23,6 @@ build_unflags =
   -D HAS_WIFI
 lib_deps =
   ${esp32c6_base.lib_deps}
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4
   # renovate: datasource=custom.pio depName=NimBLE-Arduino packageName=h2zero/library/NimBLE-Arduino
   h2zero/NimBLE-Arduino@2.3.7
 build_flags = 

--- a/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_eink/platformio.ini
@@ -12,8 +12,6 @@ lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.8
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4
 build_unflags =
   ${esp32s3_base.build_unflags}
   -DARDUINO_USB_MODE=1

--- a/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
+++ b/variants/esp32s3/diy/my_esp32s3_diy_oled/platformio.ini
@@ -8,10 +8,6 @@ board_build.f_cpu = 240000000L
 upload_protocol = esptool
 ;upload_port = /dev/ttyACM0
 upload_speed = 921600
-lib_deps =
-  ${esp32s3_base.lib_deps}
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4
 build_unflags =
   ${esp32s3_base.build_unflags}
   -DARDUINO_USB_MODE=1

--- a/variants/esp32s3/esp32-s3-pico/platformio.ini
+++ b/variants/esp32s3/esp32-s3-pico/platformio.ini
@@ -24,5 +24,3 @@ build_flags = ${esp32s3_base.build_flags}
 lib_deps = ${esp32s3_base.lib_deps}
   # renovate: datasource=custom.pio depName=GxEPD2 packageName=zinggjm/library/GxEPD2
   zinggjm/GxEPD2@1.6.8
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4

--- a/variants/esp32s3/heltec_sensor_hub/platformio.ini
+++ b/variants/esp32s3/heltec_sensor_hub/platformio.ini
@@ -8,7 +8,3 @@ build_flags =
   -I variants/esp32s3/heltec_sensor_hub
   -D HELTEC_SENSOR_HUB
   -ULED_BUILTIN
-
-lib_deps = ${esp32s3_base.lib_deps}
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4

--- a/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
+++ b/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
@@ -23,5 +23,3 @@ lib_deps =
   https://github.com/meshtastic/ESP8266Audio/archive/343024632ee78d6216907b2353fc943a62422d80.zip
   # renovate: datasource=custom.pio depName=ESP8266SAM packageName=earlephilhower/library/ESP8266SAM
   earlephilhower/ESP8266SAM@1.1.0
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4

--- a/variants/esp32s3/unphone/platformio.ini
+++ b/variants/esp32s3/unphone/platformio.ini
@@ -40,8 +40,6 @@ lib_deps = ${esp32s3_base.lib_deps}
   lovyan03/LovyanGFX@1.2.19
   # TODO renovate https://gitlab.com/hamishcunningham/unphonelibrary#meshtastic@9.0.0
   https://gitlab.com/hamishcunningham/unphonelibrary/-/archive/meshtastic/unphonelibrary-meshtastic.zip
-  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
-  adafruit/Adafruit NeoPixel@1.15.4
 
 [env:unphone-tft]
 board_level = extra

--- a/variants/native/portduino.ini
+++ b/variants/native/portduino.ini
@@ -34,8 +34,8 @@ lib_deps =
 	adafruit/Adafruit seesaw Library@1.7.9
   # renovate: datasource=git-refs depName=RAK12034-BMX160 packageName=https://github.com/RAKWireless/RAK12034-BMX160 gitBranch=main
   https://github.com/RAKWireless/RAK12034-BMX160/archive/dcead07ffa267d3c906e9ca4a1330ab989e957e2.zip
-  # renovate: datasource=custom.pio depName=Adafruit_BME680 packageName=adafruit/library/Adafruit BME680 Library
-  adafruit/Adafruit BME680 Library@2.0.6
+  # renovate: datasource=github-tags depName=Adafruit_BME680 packageName=adafruit/Adafruit_BME680
+  https://github.com/adafruit/Adafruit_BME680/archive/refs/tags/2.0.6.zip
 
 build_flags =
   ${arduino_base.build_flags}
@@ -59,4 +59,5 @@ build_flags =
 lib_ignore =
   Adafruit NeoPixel
   Adafruit ST7735 and ST7789 Library
+  Adafruit SSD1306
   SD


### PR DESCRIPTION
Switch all dependencies defined in the base `platformio.ini` from PlatformIO Registry sources to GitHub tag sources.
This does not include any library upgrades. Simply a source change.

Should help further with PlatformIO Registry ratelimiting issues.

This should be backmerged to `develop` ASAFP after merge (the build containers are cache based on the state of `master`)