### PR TITLE
Fix display method to use const qualifier for previousBuffer pointer

### DIFF
--- a/src/graphics/EInkParallelDisplay.cpp
+++ b/src/graphics/EInkParallelDisplay.cpp
@@ -202,7 +202,7 @@ void EInkParallelDisplay::display(void)
 
     // Get pointers to internal buffers
     uint8_t *cur = epaper->currentBuffer();
-    uint8_t *prev = epaper->previousBuffer(); // may be NULL on first init
+    const uint8_t *prev = epaper->previousBuffer(); // may be NULL on first init
 
     // Track changed row range while converting
     int newTop = h;     // min changed row (initialized to out-of-range)

--- a/variants/esp32s3/mini-epaper-s3/nicheGraphics.h
+++ b/variants/esp32s3/mini-epaper-s3/nicheGraphics.h
@@ -98,7 +98,7 @@ void setupNicheGraphics()
     buttons->setTwoWayRockerPressHandlers(
         [inkhud]() {
             bool systemHandlingInput = false;
-            for (InkHUD::SystemApplet *sa : inkhud->systemApplets) {
+            for (const InkHUD::SystemApplet *sa : inkhud->systemApplets) {
                 if (sa->handleInput) {
                     systemHandlingInput = true;
                     break;
@@ -112,7 +112,7 @@ void setupNicheGraphics()
         },
         [inkhud]() {
             bool systemHandlingInput = false;
-            for (InkHUD::SystemApplet *sa : inkhud->systemApplets) {
+            for (const InkHUD::SystemApplet *sa : inkhud->systemApplets) {
                 if (sa->handleInput) {
                     systemHandlingInput = true;
                     break;


### PR DESCRIPTION
Addresses cppcheck failures (GitHub Action)
```
src/graphics/EInkParallelDisplay.cpp:205: [low:style] Variable 'prev' can be declared as pointer to const [constVariablePointer]
variants/esp32s3/mini-epaper-s3/nicheGraphics.h:101: [low:style] Variable 'sa' can be declared as pointer to const [constVariablePointer]
variants/esp32s3/mini-epaper-s3/nicheGraphics.h:115: [low:style] Variable 'sa' can be declared as pointer to const [constVariablePointer]
```

Trying to clearup some of these `check` failures.