### PR TITLE
Make consoleInit() Reentrant, and initialize it earlier on native

### DIFF
--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -30,6 +30,9 @@ SerialConsole *console;
 
 void consoleInit()
 {
+    if (console) {
+        return;
+    }
     auto sc = new SerialConsole(); // Must be dynamically allocated because we are now inheriting from thread
 
 #if defined(SERIAL_HAS_ON_RECEIVE)

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -182,6 +182,10 @@ void portduinoSetup()
     // Force stdout to be line buffered
     setvbuf(stdout, stdoutBuffer, _IOLBF, sizeof(stdoutBuffer));
 
+    // We do this super early so that we can log from the rest of the init code
+    concurrency::hasBeenSetup = true;
+    consoleInit();
+
     if (portduino_config.force_simradio == true) {
         portduino_config.lora_module = use_simradio;
     } else if (configPath != nullptr) {


### PR DESCRIPTION
Actually fixes a crash with the hardware entropy code on native, but this has been a problem for a long time.