### PR TITLE
pioarduino esp32c6: fix build due to LED_BUILTIN compile error.

### DIFF
--- a/variants/esp32c6/esp32c6.ini
+++ b/variants/esp32c6/esp32c6.ini
@@ -22,6 +22,7 @@ build_flags =
   -DHAS_BLUETOOTH=0
   -DMESHTASTIC_EXCLUDE_PAXCOUNTER
   -DMESHTASTIC_EXCLUDE_BLUETOOTH
+  -ULED_BUILTIN
 
 lib_deps =
   ${arduino_base.lib_deps}


### PR DESCRIPTION
<command-line>: error: expected unqualified-id before '-' token /home/<snip>/.platformio/packages/framework-arduinoespressif32/variants/esp32c6/pins_arduino.h:9:22: note: in expansion of macro 'LED_BUILTIN'
    9 | static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
      |                      ^~~~~~~~~~~
<command-line>: error: expected unqualified-id before '-' token

Similar to commit dcfead5.

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
