### PR TITLE
put SHTXX back to fix build fail

### DIFF
--- a/src/detect/ScanI2C.h
+++ b/src/detect/ScanI2C.h
@@ -32,6 +32,7 @@ class ScanI2C
         MAX17048,
         MCP9808,
         SHT31,
+        SHTXX,
         SHT4X,
         SHTC3,
         LPS22HB,


### PR DESCRIPTION
This PR fixes an issue introduced from I believe merging master on this https://github.com/meshtastic/firmware/pull/10204 , fixed by just adding SHTXX back to the main sensor list

<img width="944" height="339" alt="image" src="https://github.com/user-attachments/assets/6494023d-56dd-4a4f-a572-91526222d88c" />
