### PR TITLE
fix(nodedb): force null-terminate name fields in UserLite/User conversions (#8174)

### DIFF
--- a/src/mesh/TypeConversions.cpp
+++ b/src/mesh/TypeConversions.cpp
@@ -81,7 +81,9 @@ meshtastic_UserLite TypeConversions::ConvertToUserLite(meshtastic_User user)
     meshtastic_UserLite lite = meshtastic_UserLite_init_default;
 
     strncpy(lite.long_name, user.long_name, sizeof(lite.long_name));
+    lite.long_name[sizeof(lite.long_name) - 1] = '\0';
     strncpy(lite.short_name, user.short_name, sizeof(lite.short_name));
+    lite.short_name[sizeof(lite.short_name) - 1] = '\0';
     lite.hw_model = user.hw_model;
     lite.role = user.role;
     lite.is_licensed = user.is_licensed;
@@ -99,7 +101,9 @@ meshtastic_User TypeConversions::ConvertToUser(uint32_t nodeNum, meshtastic_User
 
     snprintf(user.id, sizeof(user.id), "!%08x", nodeNum);
     strncpy(user.long_name, lite.long_name, sizeof(user.long_name));
+    user.long_name[sizeof(user.long_name) - 1] = '\0';
     strncpy(user.short_name, lite.short_name, sizeof(user.short_name));
+    user.short_name[sizeof(user.short_name) - 1] = '\0';
     user.hw_model = lite.hw_model;
     user.role = lite.role;
     user.is_licensed = lite.is_licensed;


### PR DESCRIPTION
## Summary

Fixes #8174.

Serial module in TEXTMSG mode prefixes incoming text messages with the sender's
short name, but the prefix frequently prints as garbled bytes (e.g. `X�� �:`
instead of `SCR2:`). The message body itself prints correctly — only the name
prefix is corrupted.

## Root cause

`TypeConversions::ConvertToUserLite()` and `TypeConversions::ConvertToUser()`
copy `short_name` and `long_name` with plain `strncpy(dst, src, sizeof(dst))`.
If the source happens to fill the destination buffer exactly (no remaining
byte for the terminator), `strncpy` leaves the destination **without a null
terminator**. Subsequent `printf("%s", name)` then reads past the end of the
buffer into adjacent struct members until it finds a stray zero — producing
the garbled prefix observed in SerialModule's TEXTMSG output path.

`short_name` is `char[5]` (4 visible chars + 1 terminator), so the footgun
triggers whenever a short name is exactly 4 characters plus whatever upstream
path loses the null on copy. `long_name` (`char[40]`) has the same class of
bug but larger headroom.

The safe pattern is already used elsewhere in the tree — for example
`src/mesh/NodeDB.cpp:1280-1281` does:

```cpp
memcpy(owner.short_name, us->user.short_name, sizeof(owner.short_name));
owner.short_name[sizeof(owner.short_name) - 1] = '\0';
```

This PR applies the same defensive terminator to both conversion functions for
both `short_name` and `long_name`.

## Fix

```diff
     strncpy(lite.long_name, user.long_name, sizeof(lite.long_name));
+    lite.long_name[sizeof(lite.long_name) - 1] = '\0';
     strncpy(lite.short_name, user.short_name, sizeof(lite.short_name));
+    lite.short_name[sizeof(lite.short_name) - 1] = '\0';
```

Same pattern applied in reverse (`ConvertToUser`). Four added lines total, no
logic changes.

## Scope — kept intentionally small

Other sites in the tree use the same `strncpy(dst, src, sizeof(dst))` pattern
without forced termination:

- `src/modules/AdminModule.cpp:632`, `:1433`
- `src/mqtt/MQTT.cpp:889` (`memcpy` without forced null)
- `src/graphics/draw/MessageRenderer.cpp:520`, `:535`, `:961` (uses
  `sizeof(...) - 1`, which leaves room but doesn't explicitly write the null —
  only safe if the destination was zero-initialized)

These are not addressed here so this PR stays focused on directly closing
#8174. Happy to open a follow-up "defensive null-termination audit" PR if
maintainers want a broader sweep.

## Testing

- Not built locally — submitting for CI verification.
- Mechanical change: four added lines, each forcing `buf[sizeof(buf) - 1] = '\0'`
  after an existing `strncpy`. Matches the pattern already used at
  `NodeDB.cpp:1280-1281`.
- No behavior change when source is already properly null-terminated (the
  added write is a no-op over the existing null); only affects the buggy case
  where `strncpy` would otherwise leave the destination unterminated.

## Backward compatibility

Pure fix — no on-wire changes, no config changes, no API changes. Output
paths that previously printed garbage will now print the intended short/long
name. No clients need to be updated.

