### PR TITLE
[pioarduino] Workaround BLE stability issues on reconnect to certain Android phones

### DIFF
--- a/src/nimble/NimbleBluetooth.cpp
+++ b/src/nimble/NimbleBluetooth.cpp
@@ -620,12 +620,18 @@ class NimbleBluetoothServerCallback : public BLEServerCallbacks
 
         const uint16_t connHandle = desc->conn_handle;
 
+        // With Google Pixel 8 Android devices, this causes ESP32 device crash
+        // when phone reconnects. Disable this to make progress on the
+        // Arduino v3 migration while we investigate the Android compatibility
+        // issue.
+#if 0
         int dataLenResult = ble_gap_set_data_len(connHandle, kPreferredBleTxOctets, kPreferredBleTxTimeUs);
         if (dataLenResult == 0) {
             LOG_INFO("BLE conn %u requested data length %u bytes", connHandle, kPreferredBleTxOctets);
         } else {
             LOG_WARN("Failed to raise data length for conn %u, rc=%d", connHandle, dataLenResult);
         }
+#endif
 
         LOG_INFO("BLE conn %u peer MTU %u (target %u)", connHandle, pServer->getPeerMTU(connHandle), kPreferredBleMtu);
         pServer->updateConnParams(connHandle, 6, 12, 0, 200);

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -38,7 +38,11 @@ build_flags =
   -Isrc/platform/esp32
   -std=gnu++17
   -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG
-  -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+  # DO NOT INCREASE THIS TO DEBUG. It appears to trigger a bug in ESP-IDF
+  # Bluetooth stack with Pixel 8 Android devices:
+  # https://github.com/espressif/esp-idf/issues/18126#issuecomment-4286197744
+  # Once the bug is resolved, we can remove this warning.
+  -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_INFO
   -DMYNEWT_VAL_BLE_HS_LOG_LVL=LOG_LEVEL_CRITICAL
   -DAXP_DEBUG_PORT=Serial
   -DESP_OPENSSL_SUPPRESS_LEGACY_WARNING


### PR DESCRIPTION
This is addressing the lengthy debugging of pioarduino NimBLE problems with re-connect to Android devices, worked on by @vidplace7  @mverch67  and myself on Discord from February 2026 to April 2026, and currently the main blocker to migrating to pioarduino (https://github.com/meshtastic/firmware/pull/10164, https://github.com/meshtastic/firmware/pull/9122).

The workarounds aren't pretty, but since I had something that works, I thought I would post it for discussion at least.

Tested with Google Pixel 8 Android 16, which previously failed to reconnect to the Meshtastic node (Heltec v3), and now **successfully reconnects** to the node.

I think it is worth considering that, even if the workarounds are ugly, it will unblock us from moving forward with the pioarduino / NimBLE migration (https://github.com/meshtastic/firmware/pull/10164) which is itself increasingly painful as folks have to maintain effectively a fork (constantly backporting and forward porting changes between develop and pioarduino and pioarduino-nimble).

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [X] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
