### PR TITLE
T watch pinfix

### DIFF
--- a/src/input/ButtonThread.cpp
+++ b/src/input/ButtonThread.cpp
@@ -143,6 +143,10 @@ int32_t ButtonThread::runOnce()
         leadUpSequenceActive = false;
         resetLeadUpSequence();
     }
+#ifdef INPUT_DEBUG
+    if (buttonCurrentlyPressed)
+        LOG_WARN("Button held for %u ms", millis() - buttonPressStartTime);
+#endif
 
     // Progressive lead-up sound system
     if (!_suppressLeadUp && buttonCurrentlyPressed && (millis() - buttonPressStartTime) >= BUTTON_LEADUP_MS) {
@@ -311,7 +315,8 @@ int32_t ButtonThread::runOnce()
 void ButtonThread::attachButtonInterrupts()
 {
     // Interrupt for user button, during normal use. Improves responsiveness.
-    attachInterrupt(_pinNum, _intRoutine, CHANGE);
+    if (_intRoutine != nullptr)
+        attachInterrupt(_pinNum, _intRoutine, CHANGE);
 }
 
 /*
@@ -320,7 +325,8 @@ void ButtonThread::attachButtonInterrupts()
  */
 void ButtonThread::detachButtonInterrupts()
 {
-    detachInterrupt(_pinNum);
+    if (_intRoutine != nullptr)
+        detachInterrupt(_pinNum);
 }
 
 #ifdef ARCH_ESP32

--- a/variants/esp32s3/t-watch-s3/variant.h
+++ b/variants/esp32s3/t-watch-s3/variant.h
@@ -39,7 +39,7 @@
 #define DAC_I2S_BCK 48
 #define DAC_I2S_WS 15
 #define DAC_I2S_DOUT 46
-#define DAC_I2S_MCLK 0
+#define DAC_I2S_MCLK -1
 
 #define HAS_AXP2101
 


### PR DESCRIPTION
Couple debugging niceties, but the real fix is to set DAC_I2S_MCLK to -1 (disabled) instead of 0 (button pin). 