### PR TITLE
Improve options to align to names of UI options

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -75,11 +75,11 @@ body:
   - type: checkboxes
     id: mui
     attributes:
-      label: Is this bug report about any UI component firmware like InkHUD or Meshtatic UI (MUI)?
+      label: Is this bug report about any UI (https://meshtastic.org/docs/configuration/device-uis/) component firmware?
       options:
-        - label: Meshtastic UI aka MUI colorTFT
-        - label: InkHUD ePaper
-        - label: OLED slide UI on any display
+        - label: Meshtastic UI aka MUI
+        - label: InkHUD
+        - label: BaseUI
 
   - type: input
     id: version


### PR DESCRIPTION
This improves the question around "Is this bug report about any UI component firmware?"