### PR TITLE
cardputer-adv: Move variant.cpp -> extra_variants/variant.cpp

### DIFF
--- a/src/platform/extra_variants/m5stack_cardputer_adv/variant.cpp
+++ b/src/platform/extra_variants/m5stack_cardputer_adv/variant.cpp
@@ -1,5 +1,8 @@
-#include "AudioBoard.h"
 #include "configuration.h"
+
+#ifdef M5STACK_CARDPUTER_ADV
+
+#include "AudioBoard.h"
 
 DriverPins PinsAudioBoardES8311;
 AudioBoard board(AudioDriverES8311, PinsAudioBoardES8311);
@@ -38,3 +41,5 @@ void lateInitVariant()
     es8311_write_reg(0x32, 0xBF); // DAC volume (0dB)
     es8311_write_reg(0x37, 0x08); // EQ bypass
 }
+
+#endif

--- a/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
+++ b/variants/esp32s3/m5stack_cardputer_adv/platformio.ini
@@ -10,9 +10,6 @@ build_flags =
   -D M5STACK_CARDPUTER_ADV
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -I variants/esp32s3/m5stack_cardputer_adv
-build_src_filter =
-  ${esp32s3_base.build_src_filter}
-  +<../variants/esp32s3/m5stack_cardputer_adv>
 lib_deps =
   ${esp32s3_base.lib_deps}
   # renovate: datasource=git-refs depName=meshtastic-st7789 packageName=https://github.com/meshtastic/st7789 gitBranch=main


### PR DESCRIPTION
Fixes `m5stack_cardputer_adv` issues with #includes inherited from `configuration.h` when building for pioarduino (`variants/` is not included by the LDF there).

Aligns cardputer-adv with other variants like t_deck_pro.

This is intentionally targeting `develop` even though it fixes an issue with `pioarduino` builds. Trying to keep that PR from getting too huge.