### PR TITLE
StoreForwardModule::historyAdd: memcpy source size, not buffer capacity

### DIFF
--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -206,7 +206,7 @@ void StoreForwardModule::historyAdd(const meshtastic_MeshPacket &mp)
     this->packetHistory[this->packetHistoryTotalCount].hop_limit = mp.hop_limit;
     this->packetHistory[this->packetHistoryTotalCount].via_mqtt = mp.via_mqtt;
     this->packetHistory[this->packetHistoryTotalCount].transport_mechanism = mp.transport_mechanism;
-    memcpy(this->packetHistory[this->packetHistoryTotalCount].payload, p.payload.bytes, meshtastic_Constants_DATA_PAYLOAD_LEN);
+    memcpy(this->packetHistory[this->packetHistoryTotalCount].payload, p.payload.bytes, p.payload.size);
 
     this->packetHistoryTotalCount++;
 }


### PR DESCRIPTION
## Problem

In `src/modules/StoreForwardModule.cpp::historyAdd()`:

```cpp
this->packetHistory[...].payload_size = p.payload.size;
...
memcpy(this->packetHistory[this->packetHistoryTotalCount].payload, p.payload.bytes, meshtastic_Constants_DATA_PAYLOAD_LEN);
```

The module correctly records `payload_size = p.payload.size`, but the very next `memcpy` copies the full **buffer capacity** (`DATA_PAYLOAD_LEN` = 237 bytes), not the actual payload length. For any packet with `payload.size < DATA_PAYLOAD_LEN` — which is the common case — this reads past the end of the valid bytes into adjacent memory in the protobuf decode scratch buffer.

Those extra bytes are later rebroadcast verbatim when S&F replays the packet to a recipient.

## Fix

```cpp
memcpy(..., p.payload.bytes, p.payload.size);
```

One character change (`meshtastic_Constants_DATA_PAYLOAD_LEN` → `p.payload.size`).

## Classification

Bounded out-of-bounds **read** into decode scratch memory. Destination buffer is the same capacity so not directly exploitable for RCE, but:

- Leaks adjacent memory contents into replayed packets (info disclosure potential)
- Silently changes payload content between what sender sent and what S&F replays
- A latent correctness bug independent of the read

## Risk

Minimal. One-token change. `p.payload.size` is already used two lines above to set `payload_size` on the history entry. Matches the bounds that other decoders use.

## Testing

In local fleet build for weeks, no regressions. S&F continues to work; replayed packet payloads now match what the sender transmitted (previously had trailing garbage).